### PR TITLE
feat(compose): docker compose with dev override (#3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# Sample environment file for docker compose.
+# Copy to `.env` and adjust to your needs:
+#
+#   cp .env.example .env
+#
+# Compose loads `.env` automatically; values here are interpolated into
+# docker-compose.yml via ${VAR:-default} substitutions.
+
+# ---------------------------------------------------------------------------
+# Image / build
+# ---------------------------------------------------------------------------
+
+# Image name and tag pushed/pulled. Override when consuming a registry copy.
+INTELLITRADER_IMAGE=intellitrader
+INTELLITRADER_TAG=latest
+
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+
+# Host port that maps to the container's 7000 (the dashboard). Change if
+# 7000 is already in use on your machine.
+INTELLITRADER_HOST_PORT=7000
+
+# ---------------------------------------------------------------------------
+# Runtime configuration
+# ---------------------------------------------------------------------------
+
+# ASP.NET Core environment. The dev override hard-codes Development; this
+# is only used when running with `-f docker-compose.yml` (no override).
+ASPNETCORE_ENVIRONMENT=Production
+
+# ---------------------------------------------------------------------------
+# Live trading (optional, sensitive)
+# ---------------------------------------------------------------------------
+#
+# IntelliTrader expects an encrypted `keys.bin` next to the executable
+# when live trading is enabled in trading.json. Generate it with:
+#
+#   dotnet run --project IntelliTrader -- \
+#     --encrypt --path keys.bin \
+#     --publickey YOUR_API_KEY \
+#     --privatekey YOUR_API_SECRET
+#
+# Then uncomment the corresponding bind mount in docker-compose.yml. The
+# file MUST live next to docker-compose.yml on the host. Never commit it.

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ packages/
 logs/
 *.log
 node_modules
+
+# Local environment overrides for docker compose (may contain secrets)
+.env
+!.env.example

--- a/README.md
+++ b/README.md
@@ -486,6 +486,41 @@ docker run -d \
 
 **Healthcheck** — the container exposes a Docker `HEALTHCHECK` that polls `GET /api/health` every 30 seconds. The endpoint is anonymous and returns `200 OK` whenever the web host is running, so `docker inspect` / orchestrators can reliably detect liveness.
 
+### Running with docker compose
+
+A `docker-compose.yml` is provided alongside a `docker-compose.override.yml` for local development. Compose merges them automatically.
+
+```bash
+# 1. Copy the sample env file and tweak host port / image tag if needed
+cp .env.example .env
+
+# 2. Build (first run only) and start in the background
+docker compose up -d
+
+# 3. Tail logs
+docker compose logs -f
+
+# 4. Stop and remove containers (volumes persist)
+docker compose down
+```
+
+**Production-like vs development**
+
+| | `docker-compose.yml` (base) | `+ docker-compose.override.yml` (default) |
+|---|---|---|
+| `ASPNETCORE_ENVIRONMENT` | `Production` | `Development` |
+| Config bind mount | read-only | read-write |
+| Log directory | named volume `intellitrader-log` | bind to `./IntelliTrader/log` |
+| Healthcheck | every 30s | every 10s |
+
+To run with the production-like base only (skipping the dev override):
+
+```bash
+docker compose -f docker-compose.yml up -d
+```
+
+**Live trading inside compose** — drop an encrypted `keys.bin` next to `docker-compose.yml` and uncomment the corresponding bind mount in the file. The same encryption command shown above for plain Docker applies.
+
 <br />
 
 ## 🔌 API Overview

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,29 @@
+# Local development overrides for docker-compose.yml.
+#
+# Compose merges this file on top of docker-compose.yml automatically
+# when you run `docker compose up`. To skip the overrides (e.g. to
+# reproduce production locally) use:
+#
+#   docker compose -f docker-compose.yml up
+#
+# What this file changes versus the production-like base:
+#   * ASPNETCORE_ENVIRONMENT=Development (enables developer exception page)
+#   * Tighter healthcheck cadence so failures are visible sooner
+#   * Config bind mount switched to read-write so editing JSON files
+#     on the host can hot-reload settings inside the container
+#   * Log directory bind-mounted to ./IntelliTrader/log so tailing logs
+#     from your editor / IDE just works
+
+services:
+  intellitrader:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Logging__LogLevel__Default: Debug
+    volumes:
+      - ./IntelliTrader/config:/app/config:rw
+      - ./IntelliTrader/log:/app/log:rw
+    healthcheck:
+      interval: 10s
+      timeout: 3s
+      start_period: 30s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+# Production-like Compose definition for IntelliTrader.
+#
+# Usage:
+#   cp .env.example .env        # tweak host port, image tag, etc. as needed
+#   docker compose up -d        # build (if needed) and start in background
+#   docker compose logs -f      # tail logs
+#   docker compose down         # stop and remove containers
+#
+# This file is intentionally kept production-like:
+#   * restart: unless-stopped
+#   * read-only config bind mount
+#   * no source code mounted
+#   * Production ASP.NET environment
+#
+# Local development overrides live in `docker-compose.override.yml`,
+# which Compose merges automatically. To run *only* this base file (i.e.
+# without dev overrides) use `docker compose -f docker-compose.yml ...`.
+#
+# NOTE: A pre-existing systemic Autofac DI bug (tracked in #38) currently
+# prevents the application from starting end-to-end. The container will
+# build and reach `Welcome to IntelliTrader`, then crash on bootstrap.
+# This compose file is correct and will work as soon as #38 is fixed.
+
+services:
+  intellitrader:
+    image: ${INTELLITRADER_IMAGE:-intellitrader}:${INTELLITRADER_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: intellitrader
+    restart: unless-stopped
+    ports:
+      # Host port is configurable via INTELLITRADER_HOST_PORT (defaults
+      # to 7000). Container always listens on 7000 — see ASPNETCORE_URLS
+      # baked into the Dockerfile.
+      - "${INTELLITRADER_HOST_PORT:-7000}:7000"
+    environment:
+      # Production by default. The dev override flips this to Development.
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Production}
+      # Free-form additional environment overrides for the host operator,
+      # picked up by .NET via the standard configuration providers.
+      DOTNET_RUNNING_IN_CONTAINER: "true"
+    volumes:
+      # Configuration is bind-mounted read-only so operators edit JSON
+      # files directly on the host. The image ships sensible defaults at
+      # /app/config; this mount overrides them.
+      - ./IntelliTrader/config:/app/config:ro
+      # Persistent runtime state (positions, snapshots).
+      - intellitrader-data:/app/data
+      # Serilog output. Bind to ./log on the host if you prefer to tail
+      # files directly; using a named volume by default keeps the
+      # repository clean.
+      - intellitrader-log:/app/log
+      # Live trading: drop an encrypted keys.bin next to this compose
+      # file and uncomment the line below. Never bake secrets into the
+      # image.
+      # - ./keys.bin:/app/keys.bin:ro
+    # The Dockerfile already declares a HEALTHCHECK against /api/health.
+    # Compose inherits it; no override needed here.
+    stop_grace_period: 30s
+
+volumes:
+  intellitrader-data:
+  intellitrader-log:


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` (production-like base) building on the Dockerfile from #2.
- Add `docker-compose.override.yml` (auto-merged dev defaults).
- Add `.env.example` documenting every interpolated variable, plus a `.gitignore` rule that excludes `.env` while keeping `.env.example` tracked.
- Update `README.md` with a "Running with docker compose" subsection.

Closes #3

## Acceptance criteria coverage

| Criterion | Status | Notes |
|---|---|---|
| Defines `intellitrader` service with `build:` context | ✅ | `build: { context: ., dockerfile: Dockerfile }` |
| Mounts config directory as volume | ✅ | `./IntelliTrader/config:/app/config:ro` (base), `:rw` in dev override |
| Mounts data directory as volume (persistence) | ✅ | Named volume `intellitrader-data` |
| Exposes port 7000 | ✅ | `${INTELLITRADER_HOST_PORT:-7000}:7000` |
| Environment variable overrides | ✅ | All knobs parameterized via `.env` (`INTELLITRADER_IMAGE`, `INTELLITRADER_TAG`, `INTELLITRADER_HOST_PORT`, `ASPNETCORE_ENVIRONMENT`) |
| `docker-compose.override.yml` for dev | ✅ | Auto-merged; flips to `Development`, raises log verbosity, makes config bind RW, log dir bind, faster healthcheck |
| Documented in README | ✅ | New subsection with up/down/logs and prod-vs-dev table |

## Design notes

- **`docker-compose.yml` filename** (rather than the modern `compose.yaml`) intentionally matches the criterion text in #3 verbatim. Compose Spec accepts both.
- **Bind mount for config, named volume for data** — the rationale is that operators expect to edit JSON config from the host (bind), while runtime state (positions, snapshots) should be opaque and survive `down` (named volume).
- **Healthcheck inherited from the image** — the Dockerfile already declares it; the override just tightens cadence for dev (10s vs 30s).
- **`keys.bin` left commented out** in the base file. Live trading instructions in the README explain how to enable it.
- **`stop_grace_period: 30s`** so the trading loop has time to flush snapshots before SIGKILL.
- **Network**: default bridge created by Compose, no manual network needed yet (helm chart in #5 will add real topology).

## Validation

```bash
$ docker compose config        # base + override merged
# → ASPNETCORE_ENVIRONMENT=Development, healthcheck 10s, config :rw, log bind ✅

$ docker compose -f docker-compose.yml config   # base only
# → ASPNETCORE_ENVIRONMENT=Production, healthcheck inherited, config :ro ✅
```

Both forms parse and merge correctly.

## ⚠️ Same caveat as #2

`docker compose up` will build the image and reach `Welcome to IntelliTrader` on startup, then crash on Autofac DI bootstrap due to the systemic bug tracked in #38. **This is not a compose bug.** The compose template is correct and will work end-to-end as soon as #38 is resolved. The healthcheck will report `unhealthy` until then.

## Test plan
- [x] `docker compose config` validates the merged base + override
- [x] `docker compose -f docker-compose.yml config` validates the base-only form
- [x] `.env.example` covers every variable interpolated by the compose files
- [x] `.gitignore` excludes `.env` and keeps `.env.example`
- [ ] (Blocked by #38) `docker compose up -d && curl http://localhost:7000/api/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker Compose support for containerized application deployment with production-like configuration
  * Local development environment overrides with automatic configuration merging

* **Documentation**
  * Added Docker Compose setup and usage guide with step-by-step commands

* **Chores**
  * Created environment variable template for configuration management
  * Updated gitignore to manage environment files securely

<!-- end of auto-generated comment: release notes by coderabbit.ai -->