### PR TITLE
fix(di): break Autofac cycles, make container actually start (#38)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,15 +66,19 @@ RUN dotnet publish IntelliTrader/IntelliTrader.csproj \
 ########################
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-alpine AS runtime
 
-# Only wget is installed at runtime — it is needed by HEALTHCHECK to probe
-# /api/health. Two intentional omissions to keep the final image under
-# 200 MB:
-#   * icu-libs: we run with invariant globalization (see ENV) because the
-#     bot only parses JSON numbers, not localized strings.
-#   * tzdata: the codebase has no TimeZoneInfo / FindSystemTimeZoneById
-#     calls; the only timezone setting is a numeric TimezoneOffset in
-#     core.json, which does not require IANA zone data.
-RUN apk add --no-cache wget \
+# Runtime packages:
+#   * wget — needed by HEALTHCHECK to probe /api/health.
+#   * tzdata — required at runtime by the ExchangeSharp library, whose
+#     static initializer in CryptoUtility..cctor calls
+#     `TimeZoneInfo.FindSystemTimeZoneById("Asia/Shanghai")`. The
+#     IntelliTrader code itself does not use TimeZoneInfo (only a
+#     numeric TimezoneOffset in core.json), but the transitive
+#     dependency does, and the type initializer throws on import
+#     without IANA zone data.
+# icu-libs is intentionally NOT installed: we run with invariant
+# globalization (see ENV below) to keep the image small. The bot only
+# parses JSON numbers, not localized strings.
+RUN apk add --no-cache wget tzdata \
  && adduser -S -u ${APP_UID:-1654} -G root intellitrader || true
 
 WORKDIR /app
@@ -95,7 +99,8 @@ RUN mkdir -p /app/data /app/log \
 ENV ASPNETCORE_ENVIRONMENT=Production \
     ASPNETCORE_URLS=http://+:7000 \
     DOTNET_RUNNING_IN_CONTAINER=true \
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
+    INTELLITRADER_HEADLESS=true
 
 EXPOSE 7000
 
@@ -104,11 +109,16 @@ EXPOSE 7000
 VOLUME ["/app/config", "/app/data", "/app/log"]
 
 # Anonymous liveness endpoint defined in
-# IntelliTrader.Web/MinimalApiEndpoints.cs — returns 200 OK as long as the
-# web host is running. Kept outside of the authenticated /api group on
-# purpose so container orchestrators can reach it without credentials.
+# IntelliTrader.Web/MinimalApiEndpoints.cs — returns 200 OK as long as
+# the web host is running. Kept outside of the authenticated /api group
+# on purpose so container orchestrators can reach it without credentials.
+#
+# We deliberately do NOT use `wget --spider`: the BusyBox build of wget
+# shipped with Alpine returns exit code 8 ("server issued an error
+# response") on perfectly valid 200 responses when in spider mode. The
+# `-O /dev/null` form is portable and matches GNU wget semantics.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://127.0.0.1:7000/api/health || exit 1
+    CMD wget --quiet --tries=1 -O /dev/null http://127.0.0.1:7000/api/health || exit 1
 
 USER ${APP_UID}
 

--- a/IntelliTrader.Backtesting/Services/BacktestingService.cs
+++ b/IntelliTrader.Backtesting/Services/BacktestingService.cs
@@ -7,12 +7,18 @@ using System.Threading;
 
 namespace IntelliTrader.Backtesting
 {
+    // Both ICoreService and ITradingService are injected as Lazy<T> on
+    // purpose: CoreService depends on IBacktestingService and
+    // TradingService depends on IBacktestingService, so direct injection
+    // would create cycles at container build time. Every use of these
+    // services happens at Start()/Stop()/Complete()/runtime methods,
+    // never inside the constructor body.
     internal class BacktestingService(
         ILoggingService loggingService,
         IHealthCheckService healthCheckService,
-        ICoreService coreService,
+        Lazy<ICoreService> coreService,
         ISignalsService signalsService,
-        ITradingService tradingService,
+        Lazy<ITradingService> tradingService,
         IConfigProvider configProvider) : ConfigrableServiceBase<BacktestingConfig>(configProvider), IBacktestingService
     {
         public const string SNAPSHOT_FILE_EXTENSION = "bin";
@@ -34,23 +40,23 @@ namespace IntelliTrader.Backtesting
 
             if (Config.Replay)
             {
-                backtestingLoadSnapshotsTimedTask = new BacktestingLoadSnapshotsTimedTask(loggingService, healthCheckService, tradingService, this);
+                backtestingLoadSnapshotsTimedTask = new BacktestingLoadSnapshotsTimedTask(loggingService, healthCheckService, tradingService.Value, this);
                 backtestingLoadSnapshotsTimedTask.RunInterval = (float)(Config.SnapshotsInterval / Config.ReplaySpeed * 1000);
                 backtestingLoadSnapshotsTimedTask.StartDelay = Constants.TimedTasks.StandardDelay / Config.ReplaySpeed;
-                coreService.AddTask(nameof(BacktestingLoadSnapshotsTimedTask), backtestingLoadSnapshotsTimedTask);
+                coreService.Value.AddTask(nameof(BacktestingLoadSnapshotsTimedTask), backtestingLoadSnapshotsTimedTask);
             }
 
-            backtestingSaveSnapshotsTimedTask = new BacktestingSaveSnapshotsTimedTask(loggingService, healthCheckService, tradingService, signalsService, this);
+            backtestingSaveSnapshotsTimedTask = new BacktestingSaveSnapshotsTimedTask(loggingService, healthCheckService, tradingService.Value, signalsService, this);
             backtestingSaveSnapshotsTimedTask.RunInterval = Config.SnapshotsInterval * 1000;
             backtestingSaveSnapshotsTimedTask.StartDelay = Constants.TimedTasks.StandardDelay / Config.ReplaySpeed;
-            coreService.AddTask(nameof(BacktestingSaveSnapshotsTimedTask), backtestingSaveSnapshotsTimedTask);
+            coreService.Value.AddTask(nameof(BacktestingSaveSnapshotsTimedTask), backtestingSaveSnapshotsTimedTask);
 
             if (Config.DeleteLogs)
             {
                 loggingService.DeleteAllLogs();
             }
 
-            string virtualAccountPath = Path.Combine(Directory.GetCurrentDirectory(), tradingService.Config.VirtualAccountFilePath);
+            string virtualAccountPath = Path.Combine(Directory.GetCurrentDirectory(), tradingService.Value.Config.VirtualAccountFilePath);
             if (File.Exists(virtualAccountPath) && (Config.DeleteAccountData || !String.IsNullOrWhiteSpace(Config.CopyAccountDataPath)))
             {
                 File.Delete(virtualAccountPath);
@@ -70,12 +76,12 @@ namespace IntelliTrader.Backtesting
 
             if (Config.Replay)
             {
-                coreService.StopTask(nameof(BacktestingLoadSnapshotsTimedTask));
-                coreService.RemoveTask(nameof(BacktestingLoadSnapshotsTimedTask));
+                coreService.Value.StopTask(nameof(BacktestingLoadSnapshotsTimedTask));
+                coreService.Value.RemoveTask(nameof(BacktestingLoadSnapshotsTimedTask));
             }
 
-            coreService.StopTask(nameof(BacktestingSaveSnapshotsTimedTask));
-            coreService.RemoveTask(nameof(BacktestingSaveSnapshotsTimedTask));
+            coreService.Value.StopTask(nameof(BacktestingSaveSnapshotsTimedTask));
+            coreService.Value.RemoveTask(nameof(BacktestingSaveSnapshotsTimedTask));
 
             healthCheckService.RemoveHealthCheck(Constants.HealthChecks.BacktestingSignalsSnapshotTaken);
             healthCheckService.RemoveHealthCheck(Constants.HealthChecks.BacktestingTickersSnapshotTaken);
@@ -90,7 +96,7 @@ namespace IntelliTrader.Backtesting
             loggingService.Info("Backtesting results:");
 
             double lagAmount = 0;
-            foreach (var t in coreService.GetAllTasks().OrderBy(t => t.Key))
+            foreach (var t in coreService.Value.GetAllTasks().OrderBy(t => t.Key))
             {
                 string taskName = t.Key;
                 HighResolutionTimedTask task = t.Value;
@@ -104,7 +110,7 @@ namespace IntelliTrader.Backtesting
             loggingService.Info($"Skipped signal snapshots: {skippedSignalSnapshots}");
             loggingService.Info($"Skipped ticker snapshots: {skippedTickerSnapshots}");
 
-            tradingService.SuspendTrading(forced: true);
+            tradingService.Value.SuspendTrading(forced: true);
             signalsService.ClearTrailing();
             signalsService.Stop();
         }

--- a/IntelliTrader.Backtesting/Services/BacktestingSignalsService.cs
+++ b/IntelliTrader.Backtesting/Services/BacktestingSignalsService.cs
@@ -7,13 +7,16 @@ using System.Linq;
 
 namespace IntelliTrader.Backtesting
 {
+    // coreService was previously injected here but is never referenced
+    // inside the class. Removed to break the
+    //   CoreService -> ... -> BacktestingSignalsService -> CoreService
+    // back-edge consistently with the SignalsService refactor.
     public class BacktestingSignalsService(
         ILoggingService loggingService,
         IHealthCheckService healthCheckService,
         ITradingService tradingService,
         IRulesService rulesService,
         IBacktestingService backtestingService,
-        ICoreService coreService,
         IConfigProvider configProvider) : ConfigrableServiceBase<SignalsConfig>(configProvider), ISignalsService
     {
         public override string ServiceName => Constants.ServiceNames.SignalsService;

--- a/IntelliTrader.Core/Services/HealthCheckService.cs
+++ b/IntelliTrader.Core/Services/HealthCheckService.cs
@@ -4,11 +4,17 @@ using System.Collections.Generic;
 
 namespace IntelliTrader.Core
 {
+    // Both ICoreService and ITradingService are injected as Lazy<T> on
+    // purpose: CoreService depends on IHealthCheckService and
+    // TradingService depends on IHealthCheckService, so direct injection
+    // would create cycles at container build time. Every use of these
+    // services happens at Start()/Stop()/runtime methods, never inside
+    // the constructor body, so deferring resolution via Lazy<T> is safe.
     internal class HealthCheckService(
         ILoggingService loggingService,
         INotificationService notificationService,
-        ICoreService coreService,
-        ITradingService tradingService,
+        Lazy<ICoreService> coreService,
+        Lazy<ITradingService> tradingService,
         IApplicationContext applicationContext) : IHealthCheckService
     {
         private readonly IApplicationContext _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
@@ -19,10 +25,11 @@ namespace IntelliTrader.Core
         {
             loggingService.Info($"Start Health Check service...");
 
-            healthCheckTimedTask = new HealthCheckTimedTask(loggingService, notificationService, this, coreService, tradingService);
-            healthCheckTimedTask.RunInterval = (float)(coreService.Config.HealthCheckInterval * 1000 / _applicationContext.Speed);
+            var core = coreService.Value;
+            healthCheckTimedTask = new HealthCheckTimedTask(loggingService, notificationService, this, core, tradingService.Value);
+            healthCheckTimedTask.RunInterval = (float)(core.Config.HealthCheckInterval * 1000 / _applicationContext.Speed);
             healthCheckTimedTask.StartDelay = Constants.TimedTasks.StandardDelay / _applicationContext.Speed;
-            coreService.AddTask(nameof(HealthCheckTimedTask), healthCheckTimedTask);
+            core.AddTask(nameof(HealthCheckTimedTask), healthCheckTimedTask);
 
             loggingService.Info("Health Check service started");
         }
@@ -31,8 +38,9 @@ namespace IntelliTrader.Core
         {
             loggingService.Info($"Stop Health Check service...");
 
-            coreService.StopTask(nameof(HealthCheckTimedTask));
-            coreService.RemoveTask(nameof(HealthCheckTimedTask));
+            var core = coreService.Value;
+            core.StopTask(nameof(HealthCheckTimedTask));
+            core.RemoveTask(nameof(HealthCheckTimedTask));
 
             loggingService.Info("Health Check service stopped");
         }

--- a/IntelliTrader.Core/Services/NotificationService.cs
+++ b/IntelliTrader.Core/Services/NotificationService.cs
@@ -8,9 +8,14 @@ using Telegram.Bot.Types.Enums;
 
 namespace IntelliTrader.Core
 {
+    // ICoreService is injected as Lazy<T> on purpose: CoreService depends
+    // on INotificationService, so a direct injection would create a cycle
+    // at container build time. The lazy wrapper defers resolution until
+    // NotifyAsync runs, by which point both services are constructed.
+    // Autofac supports Lazy<T> natively (no extra registration needed).
     internal class NotificationService(
         ILoggingService loggingService,
-        ICoreService coreService,
+        Lazy<ICoreService> coreService,
         IConfigProvider configProvider) : ConfigrableServiceBase<NotificationConfig>(configProvider), INotificationService
     {
         public override string ServiceName => Constants.ServiceNames.NotificationService;
@@ -62,7 +67,7 @@ namespace IntelliTrader.Core
                 {
                     try
                     {
-                        var instanceName = coreService.Config.InstanceName;
+                        var instanceName = coreService.Value.Config.InstanceName;
                         await telegramBotClient.SendTextMessageAsync(
                             chatId: telegramChatId,
                             text: $"({instanceName}) {message}",

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -7,6 +7,7 @@ using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Infrastructure.Adapters.Legacy;
 using IntelliTrader.Infrastructure.Dispatching;
 using IntelliTrader.Infrastructure.Events;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IntelliTrader.Infrastructure;
 
@@ -33,11 +34,43 @@ public class AppModule : Module
 
     private static void RegisterDomainEventDispatcher(ContainerBuilder builder)
     {
-        // Register the domain event dispatcher as a singleton
-        // The dispatcher resolves handlers from the container at dispatch time
-        builder.RegisterType<InMemoryDomainEventDispatcher>()
+        // InMemoryDomainEventDispatcher's constructor expects Microsoft DI
+        // primitives (System.IServiceProvider, ILogger<T>) that are not
+        // part of the Autofac root container. We adapt them manually here:
+        //   * IServiceProvider is satisfied by a tiny adapter wrapping the
+        //     active Autofac lifetime scope (no extra package required).
+        //   * ILogger<InMemoryDomainEventDispatcher> falls back to
+        //     NullLogger because IntelliTrader uses its own ILoggingService
+        //     and does not configure Microsoft.Extensions.Logging.
+        builder.Register(c =>
+            {
+                var scope = c.Resolve<ILifetimeScope>();
+                return new InMemoryDomainEventDispatcher(
+                    new AutofacServiceProviderAdapter(scope),
+                    NullLogger<InMemoryDomainEventDispatcher>.Instance);
+            })
             .As<IDomainEventDispatcher>()
             .SingleInstance();
+    }
+
+    /// <summary>
+    /// Minimal IServiceProvider adapter over an Autofac lifetime scope.
+    /// Used to bridge classes (like InMemoryDomainEventDispatcher) that
+    /// take a Microsoft DI IServiceProvider into the Autofac container
+    /// without pulling in the Autofac.Extensions.DependencyInjection
+    /// package just for one type.
+    /// </summary>
+    private sealed class AutofacServiceProviderAdapter : IServiceProvider
+    {
+        private readonly ILifetimeScope _scope;
+
+        public AutofacServiceProviderAdapter(ILifetimeScope scope)
+        {
+            _scope = scope ?? throw new ArgumentNullException(nameof(scope));
+        }
+
+        public object? GetService(Type serviceType)
+            => _scope.TryResolve(serviceType, out var instance) ? instance : null;
     }
 
     private static void RegisterDispatchers(ContainerBuilder builder)

--- a/IntelliTrader.Signals.Base/Services/SignalsService.cs
+++ b/IntelliTrader.Signals.Base/Services/SignalsService.cs
@@ -8,35 +8,36 @@ using System.Threading;
 
 namespace IntelliTrader.Signals.Base
 {
+    // DI cycle notes:
+    //  * coreService and tradingService were previously injected here
+    //    but neither is referenced inside the class. They have been
+    //    removed entirely to break the
+    //      CoreService -> TradingService -> SignalsService -> CoreService
+    //    and
+    //      TradingService -> SignalsService -> TradingService
+    //    cycles. Existing test fixtures (SignalsServiceTests) have been
+    //    updated to match the new signature.
     public class SignalsService(
-        ICoreService coreService,
         ILoggingService loggingService,
         IHealthCheckService healthCheckService,
-        ITradingService tradingService,
         IRulesService rulesService,
         Func<string, string, IConfigurationSection, ISignalReceiver> signalReceiverFactory,
         IConfigProvider configProvider) : ConfigrableServiceBase<SignalsConfig>(configProvider), ISignalsService
     {
         private readonly bool _dependenciesValidated = ValidateDependencies(
-            coreService,
             loggingService,
             healthCheckService,
-            tradingService,
             rulesService,
             signalReceiverFactory);
 
         private static bool ValidateDependencies(
-            ICoreService coreService,
             ILoggingService loggingService,
             IHealthCheckService healthCheckService,
-            ITradingService tradingService,
             IRulesService rulesService,
             Func<string, string, IConfigurationSection, ISignalReceiver> signalReceiverFactory)
         {
-            ArgumentNullException.ThrowIfNull(coreService);
             ArgumentNullException.ThrowIfNull(loggingService);
             ArgumentNullException.ThrowIfNull(healthCheckService);
-            ArgumentNullException.ThrowIfNull(tradingService);
             ArgumentNullException.ThrowIfNull(rulesService);
             ArgumentNullException.ThrowIfNull(signalReceiverFactory);
             return true;

--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -20,14 +20,24 @@ namespace IntelliTrader.Trading
     /// Facade service that coordinates trading operations through specialized orchestrators.
     /// Maintains backward compatibility while delegating to single-responsibility components.
     /// </summary>
+    // DI cycle notes:
+    //  * coreService was previously injected here but never used inside
+    //    the class. It has been removed entirely to break the
+    //    CoreService -> TradingService -> CoreService cycle.
+    //  * backtestingService and signalsService are injected as Lazy<T>
+    //    because TradingService is itself a constructor dependency of
+    //    BacktestingService and SignalsService. The lazy wrapper defers
+    //    resolution until the first runtime access (Start/Stop/order
+    //    execution paths), by which point the container is fully built.
+    //    See `IsReplayingSnapshots` below for the one place where this
+    //    used to live in a field initializer.
     internal class TradingService(
-        ICoreService coreService,
         ILoggingService loggingService,
         INotificationService notificationService,
         IHealthCheckService healthCheckService,
         IRulesService rulesService,
-        IBacktestingService backtestingService,
-        ISignalsService signalsService,
+        Lazy<IBacktestingService> backtestingService,
+        Lazy<ISignalsService> signalsService,
         Func<string, IExchangeService> exchangeServiceFactory,
         IApplicationContext applicationContext,
         IConfigProvider configProvider,
@@ -68,7 +78,17 @@ namespace IntelliTrader.Trading
         // - OrderExecutionService
         // - SignalRuleProcessorService
 
-        private readonly bool isReplayingSnapshots = backtestingService?.Config.Enabled == true && backtestingService.Config.Replay;
+        // Computed at first access (not in a field initializer) so we
+        // do not force-resolve the lazy IBacktestingService at construct
+        // time, which would re-introduce the DI cycle.
+        private bool IsReplayingSnapshots
+        {
+            get
+            {
+                var backtesting = backtestingService?.Value;
+                return backtesting?.Config.Enabled == true && backtesting.Config.Replay;
+            }
+        }
         private bool tradingForcefullySuspended;
 
         // Orchestrators for single-responsibility operations (lazily initialized)
@@ -151,7 +171,7 @@ namespace IntelliTrader.Trading
             ArgumentNullException.ThrowIfNull(exchangeServiceFactory);
             ArgumentNullException.ThrowIfNull(backtestingService);
 
-            var serviceName = isReplayingSnapshots
+            var serviceName = IsReplayingSnapshots
                 ? Constants.ServiceNames.BacktestingExchangeService
                 : Config.Exchange;
 
@@ -207,19 +227,19 @@ namespace IntelliTrader.Trading
 
             if (!Config.VirtualTrading)
             {
-                Account = new ExchangeAccount(loggingService, notificationService, healthCheckService, signalsService, this);
+                Account = new ExchangeAccount(loggingService, notificationService, healthCheckService, signalsService.Value, this);
             }
             else
             {
-                Account = new VirtualAccount(loggingService, notificationService, healthCheckService, signalsService, this);
+                Account = new VirtualAccount(loggingService, notificationService, healthCheckService, signalsService.Value, this);
             }
 
             // Initial account refresh
             Account.Refresh();
 
-            if (signalsService.Config.Enabled)
+            if (signalsService.Value.Config.Enabled)
             {
-                signalsService.Start();
+                signalsService.Value.Start();
             }
 
             // Note: Trading rules and order execution are now handled by BackgroundServices
@@ -236,9 +256,9 @@ namespace IntelliTrader.Trading
 
             exchangeService.Stop();
 
-            if (signalsService.Config.Enabled)
+            if (signalsService.Value.Config.Enabled)
             {
-                signalsService.Stop();
+                signalsService.Value.Stop();
             }
 
             // Note: BackgroundServices are stopped by the host when the application shuts down
@@ -391,7 +411,7 @@ namespace IntelliTrader.Trading
         {
             lock (SyncRoot)
             {
-                IRule rule = signalsService.Rules.Entries.FirstOrDefault(r => r.Name == options.Metadata.SignalRule);
+                IRule rule = signalsService.Value.Rules.Entries.FirstOrDefault(r => r.Name == options.Metadata.SignalRule);
 
                 ITradingPair swappedPair = Account.GetTradingPairs().OrderBy(p => p.CurrentMargin).FirstOrDefault(tradingPair =>
                 {
@@ -517,7 +537,7 @@ namespace IntelliTrader.Trading
         // Async trading methods (preferred for new code)
         public async Task BuyAsync(BuyOptions options, CancellationToken cancellationToken = default)
         {
-            IRule rule = signalsService.Rules.Entries.FirstOrDefault(r => r.Name == options.Metadata.SignalRule);
+            IRule rule = signalsService.Value.Rules.Entries.FirstOrDefault(r => r.Name == options.Metadata.SignalRule);
 
             ITradingPair swappedPair = Account.GetTradingPairs().OrderBy(p => p.CurrentMargin).FirstOrDefault(tradingPair =>
             {

--- a/IntelliTrader.Web/Services/WebService.cs
+++ b/IntelliTrader.Web/Services/WebService.cs
@@ -31,13 +31,33 @@ namespace IntelliTrader.Web
                 // Set the container for Startup to use when registering services
                 Startup.Container = container;
 
-                var contentRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "..", "IntelliTrader.Web"));
-#if RELEASE
-                if (!System.Diagnostics.Debugger.IsAttached)
+                // Resolve the ASP.NET content root.
+                //
+                // The legacy logic computed `cwd/../IntelliTrader.Web` for
+                // dev runs and `cwd/bin` for Release builds. Both
+                // assumptions break inside a published container, where
+                // the executable, views and wwwroot all live next to each
+                // other under /app — there is no parent IntelliTrader.Web
+                // folder and no `bin` subdirectory.
+                //
+                // Use AppContext.BaseDirectory (the directory of the
+                // running assembly) which is correct in every environment:
+                // dev runs from bin/Debug/..., Release publishes flat,
+                // and containers have /app as the base directory.
+                var contentRoot = AppContext.BaseDirectory;
+                if (!Directory.Exists(Path.Combine(contentRoot, "Views")) &&
+                    !Directory.Exists(Path.Combine(contentRoot, "wwwroot")))
                 {
-                    contentRoot = Path.Combine(Directory.GetCurrentDirectory(), "bin");
+                    // Legacy dev fallback: Visual Studio runs from
+                    // IntelliTrader/bin/Debug/net9.0 and the static
+                    // content lives two levels up under IntelliTrader.Web.
+                    var devFallback = Path.GetFullPath(
+                        Path.Combine(Directory.GetCurrentDirectory(), "..", "IntelliTrader.Web"));
+                    if (Directory.Exists(devFallback))
+                    {
+                        contentRoot = devFallback;
+                    }
                 }
-#endif
 
                 var webHostBuilder = new WebHostBuilder()
                     .UseContentRoot(contentRoot)

--- a/IntelliTrader/Program.cs
+++ b/IntelliTrader/Program.cs
@@ -52,8 +52,41 @@ namespace IntelliTrader
         {
             var coreService = Container.Resolve<ICoreService>();
             coreService.Start();
-            Console.ReadLine();
+
+            if (IsHeadless())
+            {
+                // Container / detached / pipe-launched mode: stdin is
+                // not a TTY, so the legacy Console.ReadLine() returned
+                // immediately on EOF and the process exited right after
+                // startup. Block until SIGINT (Ctrl+C) or SIGTERM
+                // (`docker stop`) instead so the bot keeps running.
+                var shutdown = new System.Threading.ManualResetEventSlim(false);
+                Console.CancelKeyPress += (_, e) =>
+                {
+                    e.Cancel = true;
+                    shutdown.Set();
+                };
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown.Set();
+                shutdown.Wait();
+            }
+            else
+            {
+                Console.ReadLine();
+            }
+
             coreService.Stop();
+        }
+
+        private static bool IsHeadless()
+        {
+            if (Console.IsInputRedirected)
+            {
+                return true;
+            }
+
+            var envOverride = Environment.GetEnvironmentVariable("INTELLITRADER_HEADLESS");
+            return string.Equals(envOverride, "true", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(envOverride, "1", StringComparison.Ordinal);
         }
 
         private static void PrintWelcomeMessage()

--- a/tests/IntelliTrader.Signals.Tests/SignalsServiceTests.cs
+++ b/tests/IntelliTrader.Signals.Tests/SignalsServiceTests.cs
@@ -9,10 +9,8 @@ namespace IntelliTrader.Signals.Tests;
 
 public class SignalsServiceTests
 {
-    private readonly Mock<ICoreService> _coreServiceMock;
     private readonly Mock<ILoggingService> _loggingServiceMock;
     private readonly Mock<IHealthCheckService> _healthCheckServiceMock;
-    private readonly Mock<ITradingService> _tradingServiceMock;
     private readonly Mock<IRulesService> _rulesServiceMock;
     private readonly Mock<IModuleRules> _moduleRulesMock;
     private readonly Mock<IConfigProvider> _configProviderMock;
@@ -22,10 +20,8 @@ public class SignalsServiceTests
 
     public SignalsServiceTests()
     {
-        _coreServiceMock = new Mock<ICoreService>();
         _loggingServiceMock = new Mock<ILoggingService>();
         _healthCheckServiceMock = new Mock<IHealthCheckService>();
-        _tradingServiceMock = new Mock<ITradingService>();
         _rulesServiceMock = new Mock<IRulesService>();
         _moduleRulesMock = new Mock<IModuleRules>();
         _configProviderMock = new Mock<IConfigProvider>();
@@ -49,10 +45,8 @@ public class SignalsServiceTests
             };
 
         _sut = new SignalsService(
-            _coreServiceMock.Object,
             _loggingServiceMock.Object,
             _healthCheckServiceMock.Object,
-            _tradingServiceMock.Object,
             _rulesServiceMock.Object,
             signalReceiverFactory,
             _configProviderMock.Object);
@@ -921,33 +915,19 @@ public class SignalsServiceTests
 
     #region Constructor Validation Tests
 
-    [Fact]
-    public void Constructor_WithNullCoreService_ThrowsArgumentNullException()
-    {
-        // Arrange & Act
-        Action act = () => new SignalsService(
-            null!,
-            _loggingServiceMock.Object,
-            _healthCheckServiceMock.Object,
-            _tradingServiceMock.Object,
-            _rulesServiceMock.Object,
-            (r, n, c) => null!,
-            _configProviderMock.Object);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("coreService");
-    }
+    // NOTE: the SignalsService constructor no longer accepts ICoreService
+    // or ITradingService — both were dead parameters that contributed to
+    // a DI cycle (see #38). The corresponding null-guard tests have been
+    // removed accordingly. The remaining four tests still cover every
+    // current dependency that the constructor validates.
 
     [Fact]
     public void Constructor_WithNullLoggingService_ThrowsArgumentNullException()
     {
         // Arrange & Act
         Action act = () => new SignalsService(
-            _coreServiceMock.Object,
             null!,
             _healthCheckServiceMock.Object,
-            _tradingServiceMock.Object,
             _rulesServiceMock.Object,
             (r, n, c) => null!,
             _configProviderMock.Object);
@@ -962,10 +942,8 @@ public class SignalsServiceTests
     {
         // Arrange & Act
         Action act = () => new SignalsService(
-            _coreServiceMock.Object,
             _loggingServiceMock.Object,
             null!,
-            _tradingServiceMock.Object,
             _rulesServiceMock.Object,
             (r, n, c) => null!,
             _configProviderMock.Object);
@@ -976,32 +954,12 @@ public class SignalsServiceTests
     }
 
     [Fact]
-    public void Constructor_WithNullTradingService_ThrowsArgumentNullException()
-    {
-        // Arrange & Act
-        Action act = () => new SignalsService(
-            _coreServiceMock.Object,
-            _loggingServiceMock.Object,
-            _healthCheckServiceMock.Object,
-            null!,
-            _rulesServiceMock.Object,
-            (r, n, c) => null!,
-            _configProviderMock.Object);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("tradingService");
-    }
-
-    [Fact]
     public void Constructor_WithNullRulesService_ThrowsArgumentNullException()
     {
         // Arrange & Act
         Action act = () => new SignalsService(
-            _coreServiceMock.Object,
             _loggingServiceMock.Object,
             _healthCheckServiceMock.Object,
-            _tradingServiceMock.Object,
             null!,
             (r, n, c) => null!,
             _configProviderMock.Object);
@@ -1016,10 +974,8 @@ public class SignalsServiceTests
     {
         // Arrange & Act
         Action act = () => new SignalsService(
-            _coreServiceMock.Object,
             _loggingServiceMock.Object,
             _healthCheckServiceMock.Object,
-            _tradingServiceMock.Object,
             _rulesServiceMock.Object,
             null!,
             _configProviderMock.Object);

--- a/tests/IntelliTrader.Trading.Tests/TradingServiceTests.cs
+++ b/tests/IntelliTrader.Trading.Tests/TradingServiceTests.cs
@@ -57,13 +57,12 @@ public class TradingServiceTests
         Func<string, IExchangeService> exchangeServiceFactory = (name) => _exchangeServiceMock.Object;
 
         _sut = new TradingService(
-            _coreServiceMock.Object,
             _loggingServiceMock.Object,
             _notificationServiceMock.Object,
             _healthCheckServiceMock.Object,
             _rulesServiceMock.Object,
-            _backtestingServiceMock.Object,
-            _signalsServiceMock.Object,
+            new Lazy<IBacktestingService>(() => _backtestingServiceMock.Object),
+            new Lazy<ISignalsService>(() => _signalsServiceMock.Object),
             exchangeServiceFactory,
             _applicationContextMock.Object,
             _configProviderMock.Object);
@@ -2091,13 +2090,12 @@ public class TradingServiceTests
         Func<string, IExchangeService> exchangeServiceFactory = (name) => exchangeServiceMock.Object;
 
         var sut = new TradingService(
-            coreServiceMock.Object,
             loggingServiceMock.Object,
             notificationServiceMock.Object,
             healthCheckServiceMock.Object,
             rulesServiceMock.Object,
-            backtestingServiceMock.Object,
-            signalsServiceMock.Object,
+            new Lazy<IBacktestingService>(() => backtestingServiceMock.Object),
+            new Lazy<ISignalsService>(() => signalsServiceMock.Object),
             exchangeServiceFactory,
             applicationContextMock.Object,
             configProviderMock.Object);
@@ -2143,13 +2141,12 @@ public class TradingServiceTests
         Func<string, IExchangeService> exchangeServiceFactory = (name) => exchangeServiceMock.Object;
 
         var sut = new TradingService(
-            coreServiceMock.Object,
             loggingServiceMock.Object,
             notificationServiceMock.Object,
             healthCheckServiceMock.Object,
             rulesServiceMock.Object,
-            backtestingServiceMock.Object,
-            signalsServiceMock.Object,
+            new Lazy<IBacktestingService>(() => backtestingServiceMock.Object),
+            new Lazy<ISignalsService>(() => signalsServiceMock.Object),
             exchangeServiceFactory,
             applicationContextMock.Object,
             configProviderMock.Object);
@@ -2203,13 +2200,12 @@ public class TradingServiceTests
         Func<string, IExchangeService> exchangeServiceFactory = (name) => exchangeServiceMock.Object;
 
         var sut = new TradingService(
-            coreServiceMock.Object,
             loggingServiceMock.Object,
             notificationServiceMock.Object,
             healthCheckServiceMock.Object,
             rulesServiceMock.Object,
-            backtestingServiceMock.Object,
-            signalsServiceMock.Object,
+            new Lazy<IBacktestingService>(() => backtestingServiceMock.Object),
+            new Lazy<ISignalsService>(() => signalsServiceMock.Object),
             exchangeServiceFactory,
             applicationContextMock.Object,
             configProviderMock.Object);
@@ -2275,13 +2271,12 @@ public class TradingServiceTests
         Func<string, IExchangeService> exchangeServiceFactory = (name) => exchangeServiceMock.Object;
 
         var sut = new TradingService(
-            coreServiceMock.Object,
             loggingServiceMock.Object,
             notificationServiceMock.Object,
             healthCheckServiceMock.Object,
             rulesServiceMock.Object,
-            backtestingServiceMock.Object,
-            signalsServiceMock.Object,
+            new Lazy<IBacktestingService>(() => backtestingServiceMock.Object),
+            new Lazy<ISignalsService>(() => signalsServiceMock.Object),
             exchangeServiceFactory,
             applicationContextMock.Object,
             configProviderMock.Object);


### PR DESCRIPTION
## Summary

Walks the full Autofac DI graph and breaks every cycle introduced by the
service-locator → constructor-injection refactor (commit `5f44984`) in a
single coherent pass instead of whack-a-mole. While at it, fixes the
three other pre-existing crashes that were sitting on the same startup
path so the container actually reaches a healthy state end-to-end.

Closes #38 and unblocks the e2e validation of #2 and #3.

## DI cycle resolution

| Service | Change | Type |
|---|---|---|
| `TradingService` | drop `ICoreService` | dead param |
| `SignalsService` | drop `ICoreService`, `ITradingService` | dead params |
| `BacktestingSignalsService` | drop `ICoreService` | dead param |
| `NotificationService` | `coreService` → `Lazy<>` | wrap |
| `HealthCheckService` | `coreService`, `tradingService` → `Lazy<>` | wrap |
| `TradingService` | `backtestingService`, `signalsService` → `Lazy<>` | wrap |
| `BacktestingService` | `coreService`, `tradingService` → `Lazy<>` | wrap |

Autofac supports `Lazy<T>` natively (no extra registration). The previous
field initializer in `TradingService` that read `backtestingService.Config.Replay`
at construct time is moved behind the new `IsReplayingSnapshots` computed
property so the lazy is not force-resolved at the wrong moment.

## Other startup blockers fixed (same root cause: nobody had ever run the app post-refactor)

1. **`InMemoryDomainEventDispatcher` constructor mismatch** — expected
   Microsoft DI primitives (`System.IServiceProvider`, `ILogger<T>`) that
   the Autofac root container does not provide. `Infrastructure/AppModule.cs`
   now registers it via a factory backed by a tiny inline
   `IServiceProvider` adapter over `ILifetimeScope` plus a `NullLogger`.
   No new package dependency.

2. **`ExchangeSharp.CryptoUtility..cctor` needs IANA tzdata** — calls
   `TimeZoneInfo.FindSystemTimeZoneById("Asia/Shanghai")` from a static
   initializer. The image in #2 had `tzdata` removed because grep against
   IntelliTrader sources turned up no `TimeZoneInfo` usage; the
   dependency is transitive. Restored in the Dockerfile (~1 MB) with a
   linking comment.

3. **`WebService` content root resolution** — computed `cwd/bin` for
   Release and `cwd/../IntelliTrader.Web` for dev. Neither path exists
   inside a published container. Resolved via `AppContext.BaseDirectory`
   with the legacy dev layout kept as a fallback for VS runs.

4. **`Program.Main` blocked on `Console.ReadLine()`** — under detached
   stdin (every container ever) `ReadLine` returned immediately on EOF
   and the process exited cleanly right after a successful startup.
   Added headless detection (`Console.IsInputRedirected` plus an
   `INTELLITRADER_HEADLESS` env var override that the Dockerfile sets)
   that waits on SIGINT/SIGTERM instead.

5. **HEALTHCHECK never went healthy** — Alpine BusyBox `wget --spider`
   returns exit 8 on valid 200 responses. Switched to `wget -O /dev/null`
   which is portable and matches GNU semantics.

## End-to-end smoke test

```bash
$ docker build -t intellitrader:test .
$ docker run -d --name it -p 7099:7000 intellitrader:test
$ docker logs it | head
22:51:02 [INF] Trading service started
22:51:02 [INF] Start Web service (Port: 7000)...
22:51:02 [INF] Web service started
22:51:02 [INF] Core service started
$ curl -s http://localhost:7099/api/health
{"status":"ok"}
$ docker inspect it --format '{{.State.Health.Status}}'
healthy
```

Status reaches `healthy` after the first probe past `start_period` (~60s).

## Test impact

- `IntelliTrader.Signals.Tests.SignalsServiceTests` — the two null-guard
  tests for the dropped parameters were removed, the SUT factory updated.
  Compiles and runs in CI.
- `IntelliTrader.Trading.Tests.TradingServiceTests` — five
  `new TradingService(...)` calls updated to pass
  `new Lazy<...>(() => mock.Object)` for the wrapped dependencies, and
  the dropped `coreServiceMock.Object` argument removed. The project is
  still excluded from CI under #36 (pre-existing failures unrelated to
  this change), but compiles cleanly.
- `IntelliTrader.Backtesting.Tests.BacktestingSignalsServiceTests` lives
  in an orphan project (#37) not referenced by the solution; no CI
  impact, will need updating when #37 lands.

## Test plan

- [x] All 5 currently-built test projects compile
- [x] CI Build & Test workflow stays green (no behavioral changes)
- [x] `docker build` succeeds
- [x] `docker run` reaches `Welcome to IntelliTrader` AND continues past it
- [x] All core services log "started"
- [x] `curl http://127.0.0.1:7000/api/health` returns `200 {"status":"ok"}` from inside the container
- [x] `curl http://localhost:<host>/api/health` returns `200` from the host
- [x] `docker inspect --format '{{.State.Health.Status}}'` reaches `healthy`
- [x] SIGTERM (`docker stop`) triggers graceful shutdown via the new headless wait

## Related

- Closes #38
- Unblocks the "(blocked by #38)" line items in #2 and #3 PR descriptions
- Surfaces follow-up: the `Stop()` of `WebService` still throws an unrelated
  `NullReferenceException` when `webHost` was never assigned (e.g. when
  Start failed). Trivial guard fix, can land in a separate small PR if
  desired — left here intentionally for scope hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless mode support enabling operation in containerized or non-interactive environments via environment variable or stdin detection.

* **Chores**
  * Improved Docker configuration with timezone package support and enhanced health check mechanism.
  * Refactored internal service architecture for better modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->