### PR TITLE
feat(web): /health/live and /health/ready for Kubernetes (#4)

### DIFF
--- a/IntelliTrader.Core/Interfaces/Services/ICoreService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ICoreService.cs
@@ -8,6 +8,12 @@ namespace IntelliTrader.Core
     {
         ICoreConfig Config { get; }
         string Version { get; }
+        /// <summary>
+        /// True once <see cref="Start"/> has completed and all timed
+        /// tasks are active. Used by Kubernetes readiness probes to
+        /// decide whether the bot is ready to serve traffic.
+        /// </summary>
+        bool Running { get; }
         void Start();
         void Stop();
         void Restart();

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -82,12 +82,14 @@ namespace IntelliTrader.Core
                 StartAllTasks();
             });
 
+            Running = true;
             loggingService.Info("Core service started");
             _ = notificationService.NotifyAsync("IntelliTrader started");
         }
 
         public void Stop()
         {
+            Running = false;
             _ = notificationService.NotifyAsync("IntelliTrader stopped");
             loggingService.Info("Stop Core service...");
             if (tradingService.Config.Enabled)

--- a/IntelliTrader.Web/MinimalApiEndpoints.cs
+++ b/IntelliTrader.Web/MinimalApiEndpoints.cs
@@ -26,6 +26,65 @@ namespace IntelliTrader.Web
                 .WithName("HealthCheck")
                 .WithDescription("Liveness probe returning 200 OK whenever the web host is running");
 
+            // GET /health/live - Kubernetes-style liveness probe.
+            // Returns 200 whenever the web host is running. This is a
+            // pure process-aliveness signal: if Kestrel can answer, the
+            // container is alive and the kubelet should not kill it.
+            endpoints.MapGet("/health/live", () => Results.Ok(new
+                {
+                    status = "alive",
+                    timestamp = DateTimeOffset.UtcNow
+                }))
+                .AllowAnonymous()
+                .WithName("LivenessProbe")
+                .WithDescription("Kubernetes liveness probe — 200 OK while the process is running");
+
+            // GET /health/ready - Kubernetes-style readiness probe.
+            // Returns 200 only when the bot is fully initialized AND
+            // actively trading. Returns 503 when:
+            //   * CoreService has not finished Start() yet, or
+            //   * trading has been suspended (manual or by health rules), or
+            //   * any IHealthCheck registered on IHealthCheckService is failing.
+            // The payload always includes the per-component breakdown so
+            // operators can see exactly which check flipped the probe.
+            endpoints.MapGet("/health/ready", (
+                ICoreService coreService,
+                ITradingService tradingService,
+                IHealthCheckService healthCheckService) =>
+                {
+                    var checks = healthCheckService.GetHealthChecks()
+                        .OrderBy(c => c.Name)
+                        .ToList();
+
+                    var failingChecks = checks.Where(c => c.Failed).ToList();
+                    var isRunning = coreService.Running;
+                    var isSuspended = tradingService.IsTradingSuspended;
+                    var isReady = isRunning && !isSuspended && failingChecks.Count == 0;
+
+                    var payload = new
+                    {
+                        status = isReady ? "ready" : "not_ready",
+                        timestamp = DateTimeOffset.UtcNow,
+                        coreRunning = isRunning,
+                        tradingSuspended = isSuspended,
+                        failingCheckCount = failingChecks.Count,
+                        checks = checks.Select(c => new
+                        {
+                            name = c.Name,
+                            failed = c.Failed,
+                            message = c.Message,
+                            lastUpdated = c.LastUpdated
+                        })
+                    };
+
+                    return isReady
+                        ? Results.Ok(payload)
+                        : Results.Json(payload, statusCode: StatusCodes.Status503ServiceUnavailable);
+                })
+                .AllowAnonymous()
+                .WithName("ReadinessProbe")
+                .WithDescription("Kubernetes readiness probe — 200 when bot is ready, 503 otherwise");
+
             var apiGroup = endpoints.MapGroup("/api")
                 .RequireAuthorization();
 


### PR DESCRIPTION
## Summary
- Add `GET /health/live` — Kubernetes liveness probe. Anonymous, returns 200 whenever Kestrel can answer.
- Add `GET /health/ready` — Kubernetes readiness probe. Anonymous, returns 200 when the bot is fully initialized AND not suspended AND no registered health check is failing; 503 otherwise. The JSON payload always includes the full per-component breakdown.
- Expose `ICoreService.Running` on the interface (the property already existed on the concrete class but was not part of the contract).
- Fix a latent bug: `CoreService.Running` was declared but never assigned — `Start()` now sets it to `true`, `Stop()` clears it. Surfaced while wiring the readiness probe.

Closes #4

## Acceptance criteria coverage

| Criterion | Status | Notes |
|---|---|---|
| `/health/live` returns 200 when process is running | ✅ | Confirmed end-to-end on the built image |
| `/health/ready` returns 200 when all services initialized | ✅ | `coreRunning && !suspended && 0 failing checks` |
| `/health/ready` returns 503 when trading is suspended | ✅ | Same aggregate logic; 503 path also covers startup and failing checks |
| Endpoints are unauthenticated (probe-accessible) | ✅ | Mounted **outside** the `/api` `RequireAuthorization()` group, same pattern as `/api/health` |
| Returns JSON with component status details | ✅ | `status`, `timestamp`, `coreRunning`, `tradingSuspended`, `failingCheckCount`, plus `checks[]` with name/failed/message/lastUpdated |
| Integrates with existing `IHealthCheckService` | ✅ | Reads `GetHealthChecks()` directly, no Microsoft.Extensions.Diagnostics.HealthChecks dependency introduced |

## Design notes

- **No new NuGet package**. I considered `Microsoft.Extensions.Diagnostics.HealthChecks` + `MapHealthChecks` but that would re-introduce the same Microsoft-DI-vs-Autofac friction that bit #38. The existing minimal-API pattern ships the same functionality with zero new dependencies.
- **JSON shape is consistent** between the 200 and 503 responses so operators never have to branch on status code to parse the payload.
- **Liveness ≠ Readiness**. `/health/live` intentionally ignores every domain signal. If Kestrel can answer, the container is alive and kubelet must not kill it — restarting a process that is mid-startup is exactly what readiness probes are for.
- **`/api/health` is kept unchanged** so the Dockerfile `HEALTHCHECK` from #2 keeps working. A Kubernetes deployment would point `livenessProbe` at `/health/live` instead.

## Smoke test on the built image

```bash
$ docker run -d --name it -p 7099:7000 intellitrader:test
$ sleep 20  # wait for CoreService.Start() to flip Running=true

$ curl -s http://localhost:7099/health/live
{"status":"alive","timestamp":"2026-04-11T23:22:27..."}
# HTTP 200

$ curl -s http://localhost:7099/health/ready
{"status":"ready","timestamp":"...","coreRunning":true,
 "tradingSuspended":false,"failingCheckCount":0,
 "checks":[{"name":"Account refreshed","failed":false,...},
           {"name":"TV Signals received [TV-15mins]","failed":false,...},
           ...]}
# HTTP 200
```

Earlier during startup, before `Running` flips, the **same** endpoint returned `HTTP 503` with `"status":"not_ready"` and `"coreRunning":false` — the 503 path is real and observed.

## Test plan
- [x] Image builds
- [x] Container reaches `healthy` on existing Dockerfile HEALTHCHECK
- [x] `GET /health/live` → 200 with `{status: "alive", timestamp: ...}`
- [x] `GET /health/ready` during Start → 503 with full breakdown
- [x] `GET /health/ready` after Start → 200 with full breakdown
- [x] Both endpoints reachable without authentication
- [x] Existing `/api/health` still works
- [ ] (Out of scope, follow-up) End-to-end Kubernetes probe verification against a real kubelet — blocked by #5 (Helm chart)

## Follow-ups

- Issue #5 (Helm chart) can now wire `livenessProbe.httpGet.path: /health/live` and `readinessProbe.httpGet.path: /health/ready` directly.
- Optional: update the Dockerfile HEALTHCHECK to probe `/health/live` instead of `/api/health` for semantic consistency. Not done here to keep the blast radius of this PR narrow — would be a trivial one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoints for monitoring application status: `/health/live` reports the service is active with a timestamp; `/health/ready` indicates whether the service is fully operational based on trading suspension state and system health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->