### PR TITLE
feat(helm): Kubernetes Helm chart (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,35 @@ docker compose -f docker-compose.yml up -d
 
 **Live trading inside compose** — drop an encrypted `keys.bin` next to `docker-compose.yml` and uncomment the corresponding bind mount in the file. The same encryption command shown above for plain Docker applies.
 
+### Deploying to Kubernetes with Helm
+
+A Helm chart is provided under `deploy/helm/intellitrader/`.
+
+```bash
+# Install (virtual trading, default values)
+helm install intellitrader deploy/helm/intellitrader
+
+# Install with custom config overrides
+helm install intellitrader deploy/helm/intellitrader \
+  --set image.repository=ghcr.io/blackms/intellitrader \
+  --set image.tag=v1.0.0 \
+  --set-file config.files.trading\\.json=./my-trading.json
+
+# Check the deployment
+kubectl get pods -l app.kubernetes.io/name=intellitrader
+kubectl logs -f deployment/intellitrader
+
+# Upgrade
+helm upgrade intellitrader deploy/helm/intellitrader --reuse-values
+
+# Uninstall
+helm uninstall intellitrader
+```
+
+The chart includes Deployment, Service, ConfigMap, Secret, PVC, Ingress (optional), HPA (optional), and ServiceAccount templates. Liveness and readiness probes point at `/health/live` and `/health/ready` respectively. See `deploy/helm/intellitrader/values.yaml` for the full set of configurable parameters.
+
+> **Note**: IntelliTrader is a stateful singleton — the HPA defaults to `maxReplicas: 1`. Do not scale beyond 1 without external state coordination.
+
 <br />
 
 ## 🔌 API Overview

--- a/deploy/helm/intellitrader/Chart.yaml
+++ b/deploy/helm/intellitrader/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: intellitrader
+description: A Helm chart for deploying IntelliTrader cryptocurrency trading bot to Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - trading
+  - cryptocurrency
+  - binance
+maintainers:
+  - name: Alessio Rocchi
+    url: https://github.com/blackms
+home: https://github.com/blackms/IntelliTrader
+sources:
+  - https://github.com/blackms/IntelliTrader

--- a/deploy/helm/intellitrader/templates/NOTES.txt
+++ b/deploy/helm/intellitrader/templates/NOTES.txt
@@ -1,0 +1,28 @@
+IntelliTrader has been deployed!
+
+1. Get the dashboard URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "intellitrader.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "intellitrader.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "intellitrader.fullname" . }} 7000:{{ .Values.service.port }}
+  echo "Dashboard: http://localhost:7000"
+{{- end }}
+
+2. Check readiness:
+  curl http://localhost:7000/health/ready
+
+3. View logs:
+  kubectl logs -f deployment/{{ include "intellitrader.fullname" . }} --namespace {{ .Release.Namespace }}
+
+NOTE: IntelliTrader is a singleton by design. Do not scale replicas
+above 1 without external state coordination — doing so would cause
+duplicate trades and split position state.

--- a/deploy/helm/intellitrader/templates/_helpers.tpl
+++ b/deploy/helm/intellitrader/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "intellitrader.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "intellitrader.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "intellitrader.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "intellitrader.labels" -}}
+helm.sh/chart: {{ include "intellitrader.chart" . }}
+{{ include "intellitrader.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "intellitrader.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "intellitrader.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "intellitrader.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "intellitrader.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/configmap.yaml
+++ b/deploy/helm/intellitrader/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.config.existingConfigMap }}
+{{- if .Values.config.files }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "intellitrader.fullname" . }}-config
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config.files }}
+  {{ $key }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/deployment.yaml
+++ b/deploy/helm/intellitrader/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "intellitrader.fullname" . }}
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  # IntelliTrader is a stateful singleton. Rolling updates must drain
+  # the old pod before starting the new one to prevent duplicate
+  # WebSocket connections and split position state.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "intellitrader.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Force a rollout when the ConfigMap changes so the bot
+        # picks up new trading rules / signal definitions.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "intellitrader.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "intellitrader.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      # Give the trading loop time to flush positions on shutdown.
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 7000
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production
+            - name: ASPNETCORE_URLS
+              value: "http://+:7000"
+            - name: DOTNET_RUNNING_IN_CONTAINER
+              value: "true"
+            - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+              value: "true"
+            - name: INTELLITRADER_HEADLESS
+              value: "true"
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if or .Values.config.files .Values.config.existingConfigMap }}
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app/data
+            {{- end }}
+            {{- if or .Values.secret.files .Values.secret.existingSecret }}
+            - name: secret
+              mountPath: /app/keys.bin
+              subPath: keys.bin
+              readOnly: true
+            {{- end }}
+      volumes:
+        {{- if or .Values.config.files .Values.config.existingConfigMap }}
+        - name: config
+          configMap:
+            name: {{ .Values.config.existingConfigMap | default (printf "%s-config" (include "intellitrader.fullname" .)) }}
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "intellitrader.fullname" . }}-data
+        {{- end }}
+        {{- if or .Values.secret.files .Values.secret.existingSecret }}
+        - name: secret
+          secret:
+            secretName: {{ .Values.secret.existingSecret | default (printf "%s-secret" (include "intellitrader.fullname" .)) }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/intellitrader/templates/hpa.yaml
+++ b/deploy/helm/intellitrader/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "intellitrader.fullname" . }}
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "intellitrader.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/ingress.yaml
+++ b/deploy/helm/intellitrader/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "intellitrader.fullname" . }}
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "intellitrader.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/pvc.yaml
+++ b/deploy/helm/intellitrader/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "intellitrader.fullname" . }}-data
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/secret.yaml
+++ b/deploy/helm/intellitrader/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.secret.existingSecret }}
+{{- if .Values.secret.files }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "intellitrader.fullname" . }}-secret
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secret.files }}
+  {{ $key }}: {{ $value }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/intellitrader/templates/service.yaml
+++ b/deploy/helm/intellitrader/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "intellitrader.fullname" . }}
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "intellitrader.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/intellitrader/templates/serviceaccount.yaml
+++ b/deploy/helm/intellitrader/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "intellitrader.serviceAccountName" . }}
+  labels:
+    {{- include "intellitrader.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/helm/intellitrader/values.yaml
+++ b/deploy/helm/intellitrader/values.yaml
@@ -1,0 +1,144 @@
+# Default values for intellitrader.
+
+replicaCount: 1
+
+image:
+  repository: intellitrader
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1654
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1654
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 7000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: intellitrader.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: intellitrader-tls
+  #    hosts:
+  #      - intellitrader.local
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# Liveness and readiness probes pointing at the endpoints from issue #4.
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Horizontal Pod Autoscaler.
+# IMPORTANT: IntelliTrader is a stateful singleton by design — it holds
+# in-memory positions, trailing orders, and a persistent WebSocket
+# connection to Binance. Running multiple replicas WITHOUT coordination
+# would cause duplicate trades and split state. maxReplicas defaults to
+# 1 to prevent accidental scale-out. Increase only if you implement
+# external state coordination (e.g. Redis-backed position locking).
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# IntelliTrader configuration. The chart creates a ConfigMap from
+# these values and mounts it at /app/config inside the container.
+# Each key maps to a JSON config file. Override individual files
+# here or supply your own ConfigMap via existingConfigMap.
+config:
+  # Use an existing ConfigMap instead of generating one.
+  existingConfigMap: ""
+  # Inline configuration overrides. Defaults are read from the
+  # image at /app/config; only override what you need.
+  files: {}
+  #   core.json: |
+  #     {
+  #       "Core": {
+  #         "DebugMode": false,
+  #         "InstanceName": "K8s-Main"
+  #       }
+  #     }
+  #   trading.json: |
+  #     {
+  #       "Trading": {
+  #         "VirtualTrading": true
+  #       }
+  #     }
+
+# Secret for sensitive files (API keys). The chart creates a Secret
+# and mounts it at /app inside the container. For live trading, add
+# your encrypted keys.bin here.
+secret:
+  # Use an existing Secret instead of generating one.
+  existingSecret: ""
+  # Base64-encoded files to include in the generated Secret.
+  files: {}
+  #   keys.bin: <base64-encoded-content>
+
+# Persistent volume for runtime data (positions, snapshots).
+persistence:
+  enabled: true
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}


### PR DESCRIPTION
## Summary
Add a production-ready Helm chart under `deploy/helm/intellitrader/` with 8 resource templates, sensible defaults, and README documentation.

Closes #5 — completes the DevOps & Infrastructure epic (#1, #2, #3, #4, #5).

## Templates

| Resource | Conditional | Notes |
|---|---|---|
| Deployment | always | Recreate strategy, probes from #4, configmap checksum rollout |
| Service | always | ClusterIP:7000 |
| ServiceAccount | `serviceAccount.create` | default: true |
| PVC | `persistence.enabled` | 1Gi RWO, default: true |
| ConfigMap | `config.files` or `config.existingConfigMap` | Per-file JSON overrides |
| Secret | `secret.files` or `secret.existingSecret` | For encrypted keys.bin |
| HPA | `autoscaling.enabled` | default: false, maxReplicas: 1 |
| Ingress | `ingress.enabled` | default: false, networking.k8s.io/v1 |

## Acceptance criteria

| Criterion | Status |
|---|---|
| Deployment, Service, ConfigMap, Secret templates | ✅ |
| values.yaml with sensible defaults | ✅ (non-root, resource limits, probes) |
| HPA support | ✅ (disabled by default, maxReplicas: 1 singleton caveat) |
| Liveness and readiness probes | ✅ (`/health/live` and `/health/ready` from #4) |
| Ingress template (optional) | ✅ (disabled by default, TLS support) |
| Documents installation in README | ✅ (install/upgrade/uninstall) |
| Passes `helm lint` | ✅ (1 info: icon recommended) |

## Design notes

- **Recreate strategy** instead of RollingUpdate: IntelliTrader holds WebSocket connections and in-memory positions. Two pods running concurrently would cause duplicate trades.
- **ConfigMap checksum annotation** on the pod template forces a rollout when config JSON changes, so the bot picks up new rules without manual restarts.
- **maxReplicas: 1** with a prominent comment in values.yaml explaining the singleton constraint.
- **PVC for /app/data** (positions, snapshots) persists across pod restarts.
- **Secret mount** uses `subPath: keys.bin` so only the single file appears at `/app/keys.bin`.

## Validation

```
$ helm lint deploy/helm/intellitrader
==> Linting deploy/helm/intellitrader
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template test deploy/helm/intellitrader --set ingress.enabled=true \
    --set autoscaling.enabled=true ...
# Renders all 8 resource types correctly
```

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders ServiceAccount, PVC, Service, Deployment with defaults
- [x] `helm template` renders ConfigMap, Secret, HPA, Ingress when enabled
- [x] Probes point at `/health/live` and `/health/ready`
- [x] README documents install/upgrade/uninstall
- [ ] (Out of scope) Deploy to a real cluster — would need an image in a registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Kubernetes deployment guide covering Helm installation, configuration options, upgrades, health verification, and log monitoring.

* **New Features**
  * Released Helm chart enabling Kubernetes deployment with support for persistent storage, ingress routing, horizontal auto-scaling, service accounts, and configurable runtime resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->