### PR TITLE
feat(web): add security response headers

### DIFF
--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -89,6 +89,24 @@ namespace IntelliTrader.Web
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            // Security response headers middleware - placed early so all responses get headers
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                context.Response.Headers["X-Frame-Options"] = "DENY";
+                context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+                context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+                context.Response.Headers["Content-Security-Policy"] =
+                    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws: wss:";
+
+                if (context.Request.IsHttps)
+                {
+                    context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+                }
+
+                await next();
+            });
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
## Summary
- Add inline middleware in `Startup.Configure` to set security headers on all HTTP responses
- Headers: `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Content-Security-Policy`
- `Strict-Transport-Security` is conditionally added only for HTTPS requests
- CSP allows `'unsafe-inline'` for scripts/styles (Razor views), `ws:/wss:` for SignalR, and `data:` for images

Closes #13

## Test plan
- [ ] Verify security headers appear on HTML page responses
- [ ] Verify security headers appear on API responses (`/api/health`)
- [ ] Verify security headers appear on static file responses
- [ ] Verify `Strict-Transport-Security` only appears on HTTPS requests
- [ ] Verify SignalR WebSocket connections still work (CSP `connect-src` includes `ws: wss:`)
- [ ] Verify inline scripts/styles in Razor views still function (CSP allows `'unsafe-inline'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Security**
- Enhanced HTTP security headers are now automatically included with all responses to provide improved protection against common web vulnerabilities.
- Strict transport security enforcement has been added for HTTPS connections to ensure secure communication protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->