### PR TITLE
refactor(core): rename ConfigrableServiceBase to ConfigurableServiceBase

### DIFF
--- a/IntelliTrader.Backtesting/Services/BacktestingExchangeService.cs
+++ b/IntelliTrader.Backtesting/Services/BacktestingExchangeService.cs
@@ -11,7 +11,7 @@ namespace IntelliTrader.Backtesting
         ILoggingService loggingService,
         IHealthCheckService healthCheckService,
         IBacktestingService backtestingService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<ExchangeConfig>(configProvider), IExchangeService
+        IConfigProvider configProvider) : ConfigurableServiceBase<ExchangeConfig>(configProvider), IExchangeService
     {
         public override string ServiceName => Constants.ServiceNames.ExchangeService;
 

--- a/IntelliTrader.Backtesting/Services/BacktestingService.cs
+++ b/IntelliTrader.Backtesting/Services/BacktestingService.cs
@@ -19,7 +19,7 @@ namespace IntelliTrader.Backtesting
         Lazy<ICoreService> coreService,
         ISignalsService signalsService,
         Lazy<ITradingService> tradingService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<BacktestingConfig>(configProvider), IBacktestingService
+        IConfigProvider configProvider) : ConfigurableServiceBase<BacktestingConfig>(configProvider), IBacktestingService
     {
         public const string SNAPSHOT_FILE_EXTENSION = "bin";
 

--- a/IntelliTrader.Backtesting/Services/BacktestingSignalsService.cs
+++ b/IntelliTrader.Backtesting/Services/BacktestingSignalsService.cs
@@ -17,7 +17,7 @@ namespace IntelliTrader.Backtesting
         ITradingService tradingService,
         IRulesService rulesService,
         IBacktestingService backtestingService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<SignalsConfig>(configProvider), ISignalsService
+        IConfigProvider configProvider) : ConfigurableServiceBase<SignalsConfig>(configProvider), ISignalsService
     {
         public override string ServiceName => Constants.ServiceNames.SignalsService;
 

--- a/IntelliTrader.Core/Services/CachingService.cs
+++ b/IntelliTrader.Core/Services/CachingService.cs
@@ -13,7 +13,7 @@ namespace IntelliTrader.Core
 {
     internal class CachingService(
         ILoggingService loggingService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<CachingConfig>(configProvider), ICachingService
+        IConfigProvider configProvider) : ConfigurableServiceBase<CachingConfig>(configProvider), ICachingService
     {
         public override string ServiceName => Constants.ServiceNames.CachingService;
 

--- a/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
+++ b/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
-    public abstract class ConfigrableServiceBase<TConfig> : IConfigurableService
+    public abstract class ConfigurableServiceBase<TConfig> : IConfigurableService
         where TConfig : class
     {
         private const double DELAY_BETWEEN_CONFIG_RELOADS_MILLISECONDS = 500;
@@ -33,7 +33,7 @@ namespace IntelliTrader.Core
         /// Default constructor for backward compatibility.
         /// Services should migrate to use the constructor that accepts IConfigProvider.
         /// </summary>
-        protected ConfigrableServiceBase()
+        protected ConfigurableServiceBase()
         {
             _configProvider = null;
         }
@@ -43,7 +43,7 @@ namespace IntelliTrader.Core
         /// Preferred constructor for proper DI usage.
         /// </summary>
         /// <param name="configProvider">The configuration provider</param>
-        protected ConfigrableServiceBase(IConfigProvider configProvider)
+        protected ConfigurableServiceBase(IConfigProvider configProvider)
         {
             _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
         }

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -17,7 +17,7 @@ namespace IntelliTrader.Core
         IWebService webService,
         IBacktestingService backtestingService,
         IApplicationContext applicationContext,
-        IConfigProvider configProvider) : ConfigrableServiceBase<CoreConfig>(configProvider), ICoreService
+        IConfigProvider configProvider) : ConfigurableServiceBase<CoreConfig>(configProvider), ICoreService
     {
         private readonly IApplicationContext _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
         public override string ServiceName => Constants.ServiceNames.CoreService;

--- a/IntelliTrader.Core/Services/LoggingService.cs
+++ b/IntelliTrader.Core/Services/LoggingService.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
-    internal class LoggingService : ConfigrableServiceBase<LoggingConfig>, ILoggingService
+    internal class LoggingService : ConfigurableServiceBase<LoggingConfig>, ILoggingService
     {
         private int LOG_ENTRIES_MAX_LENGTH = 50000;
 

--- a/IntelliTrader.Core/Services/NotificationService.cs
+++ b/IntelliTrader.Core/Services/NotificationService.cs
@@ -16,7 +16,7 @@ namespace IntelliTrader.Core
     internal class NotificationService(
         ILoggingService loggingService,
         Lazy<ICoreService> coreService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<NotificationConfig>(configProvider), INotificationService
+        IConfigProvider configProvider) : ConfigurableServiceBase<NotificationConfig>(configProvider), INotificationService
     {
         public override string ServiceName => Constants.ServiceNames.NotificationService;
 

--- a/IntelliTrader.Exchange.Base/Services/ExchangeService.cs
+++ b/IntelliTrader.Exchange.Base/Services/ExchangeService.cs
@@ -11,7 +11,7 @@ namespace IntelliTrader.Exchange.Base
         ILoggingService loggingService,
         IHealthCheckService healthCheckService,
         ICoreService coreService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<ExchangeConfig>(configProvider), IExchangeService
+        IConfigProvider configProvider) : ConfigurableServiceBase<ExchangeConfig>(configProvider), IExchangeService
     {
         public override string ServiceName => Constants.ServiceNames.ExchangeService;
 

--- a/IntelliTrader.Integration.Base/Services/IntegrationService.cs
+++ b/IntelliTrader.Integration.Base/Services/IntegrationService.cs
@@ -7,7 +7,7 @@ namespace IntelliTrader.Integration.Core
 {
     internal class IntegrationService(
         ILoggingService loggingService,
-        IConfigProvider configProvider) : ConfigrableServiceBase<IntegrationConfig>(configProvider), IIntegrationService
+        IConfigProvider configProvider) : ConfigurableServiceBase<IntegrationConfig>(configProvider), IIntegrationService
     {
         public override string ServiceName => Constants.ServiceNames.IntegrationService;
 

--- a/IntelliTrader.Rules/Services/RulesService.cs
+++ b/IntelliTrader.Rules/Services/RulesService.cs
@@ -9,7 +9,7 @@ namespace IntelliTrader.Rules
     internal class RulesService(
         ILoggingService loggingService,
         IApplicationContext applicationContext,
-        IConfigProvider configProvider) : ConfigrableServiceBase<RulesConfig>(configProvider), IRulesService
+        IConfigProvider configProvider) : ConfigurableServiceBase<RulesConfig>(configProvider), IRulesService
     {
         private readonly IApplicationContext _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
 

--- a/IntelliTrader.Signals.Base/Services/SignalsService.cs
+++ b/IntelliTrader.Signals.Base/Services/SignalsService.cs
@@ -22,7 +22,7 @@ namespace IntelliTrader.Signals.Base
         IHealthCheckService healthCheckService,
         IRulesService rulesService,
         Func<string, string, IConfigurationSection, ISignalReceiver> signalReceiverFactory,
-        IConfigProvider configProvider) : ConfigrableServiceBase<SignalsConfig>(configProvider), ISignalsService
+        IConfigProvider configProvider) : ConfigurableServiceBase<SignalsConfig>(configProvider), ISignalsService
     {
         private readonly bool _dependenciesValidated = ValidateDependencies(
             loggingService,

--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -43,7 +43,7 @@ namespace IntelliTrader.Trading
         IConfigProvider configProvider,
         IPortfolioRiskManager portfolioRiskManager = null,
         IPositionSizerFactory positionSizerFactory = null,
-        IDomainEventDispatcher domainEventDispatcher = null) : ConfigrableServiceBase<TradingConfig>(configProvider), ITradingService
+        IDomainEventDispatcher domainEventDispatcher = null) : ConfigurableServiceBase<TradingConfig>(configProvider), ITradingService
     {
         private readonly IApplicationContext _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
         private readonly IDomainEventDispatcher _domainEventDispatcher = domainEventDispatcher;

--- a/IntelliTrader.Web/Services/WebService.cs
+++ b/IntelliTrader.Web/Services/WebService.cs
@@ -12,7 +12,7 @@ namespace IntelliTrader.Web
     internal class WebService(
         ILoggingService loggingService,
         ILifetimeScope container,
-        IConfigProvider configProvider) : ConfigrableServiceBase<WebConfig>(configProvider), IWebService
+        IConfigProvider configProvider) : ConfigurableServiceBase<WebConfig>(configProvider), IWebService
     {
         public override string ServiceName => Constants.ServiceNames.WebService;
 

--- a/docs/ADRs/ADR-0002-configuration-system.md
+++ b/docs/ADRs/ADR-0002-configuration-system.md
@@ -37,7 +37,7 @@ private IConfigurationRoot GetConfig(string configPath, Action<IConfigurationRoo
 }
 ```
 
-Service configuration callback pattern from `ConfigrableServiceBase<T>`:
+Service configuration callback pattern from `ConfigurableServiceBase<T>`:
 ```csharp
 public T GetSection<T>(string sectionName, Action<T> onChange = null) where T : class
 {

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -252,7 +252,7 @@ public interface ITradingService : IConfigurableService
 
 **Configurable services implement `IConfigurableService`**:
 ```csharp
-internal class TradingService : ConfigrableServiceBase<TradingConfig>, ITradingService
+internal class TradingService : ConfigurableServiceBase<TradingConfig>, ITradingService
 {
     public override string ServiceName => Constants.ServiceNames.TradingService;
     protected override ILoggingService LoggingService => _loggingService;

--- a/tests/IntelliTrader.Signals.Tests/SignalsServiceTests.cs
+++ b/tests/IntelliTrader.Signals.Tests/SignalsServiceTests.cs
@@ -82,7 +82,7 @@ public class SignalsServiceTests
             GlobalRatingSignals = globalRatingSignals ?? new List<string>()
         };
 
-        // Use reflection to set the config since ConfigrableServiceBase manages it
+        // Use reflection to set the config since ConfigurableServiceBase manages it
         var configField = typeof(SignalsService)
             .BaseType!
             .GetField("config", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);

--- a/tests/IntelliTrader.Trading.Tests/TradingServiceTests.cs
+++ b/tests/IntelliTrader.Trading.Tests/TradingServiceTests.cs
@@ -1652,7 +1652,7 @@ public class TradingServiceTests
     private void SetupTradingConfig(Action<TradingConfig> configureAction)
     {
         // Get current config through reflection and modify it
-        var configField = typeof(ConfigrableServiceBase<TradingConfig>)
+        var configField = typeof(ConfigurableServiceBase<TradingConfig>)
             .GetField("config", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
         var config = configField?.GetValue(_sut) as TradingConfig ?? new TradingConfig


### PR DESCRIPTION
## Summary
- Fix typo in abstract base class name: `ConfigrableServiceBase` → `ConfigurableServiceBase` (missing "u" in "Configurable")
- Updated all 14 inheriting service classes across the solution
- Updated 2 test files and 2 documentation files

Closes #23

## Test plan
- [ ] CI build passes — this is a pure rename, no logic changes
- [ ] Verify no remaining occurrences of `ConfigrableServiceBase` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)