### PR TITLE
feat(config): add environment variable overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,45 @@ ASPNETCORE_ENVIRONMENT=Production
 #
 # Then uncomment the corresponding bind mount in docker-compose.yml. The
 # file MUST live next to docker-compose.yml on the host. Never commit it.
+
+# ---------------------------------------------------------------------------
+# Configuration overrides (12-factor app)
+# ---------------------------------------------------------------------------
+#
+# All JSON configuration settings can be overridden via environment variables
+# using the prefix INTELLITRADER_ and __ (double underscore) as the hierarchy
+# separator. The env var takes precedence over the JSON file value.
+#
+# Naming convention:
+#   INTELLITRADER_{Section}__{Key}
+#   INTELLITRADER_{Section}__{NestedObject}__{Key}
+#
+# Examples:
+
+# --- Core settings (core.json) ---
+#INTELLITRADER_Core__DebugMode=false
+#INTELLITRADER_Core__InstanceName=Main
+#INTELLITRADER_Core__HealthCheckEnabled=true
+#INTELLITRADER_Core__HealthCheckInterval=180
+
+# --- Trading settings (trading.json) ---
+#INTELLITRADER_Trading__Enabled=true
+#INTELLITRADER_Trading__Market=BTC
+#INTELLITRADER_Trading__Exchange=Binance
+#INTELLITRADER_Trading__MaxPairs=10
+#INTELLITRADER_Trading__BuyEnabled=true
+#INTELLITRADER_Trading__SellEnabled=true
+#INTELLITRADER_Trading__VirtualTrading=true
+#INTELLITRADER_Trading__VirtualAccountInitialBalance=0.12
+
+# --- Exchange settings (exchange.json) ---
+#INTELLITRADER_Exchange__KeysPath=keys.bin
+
+# --- Web settings (web.json) ---
+#INTELLITRADER_Web__Port=7000
+
+# --- Notification settings (notification.json) ---
+#INTELLITRADER_Notification__Enabled=false
+
+# --- Headless mode (not a config override, standalone env var) ---
+#INTELLITRADER_HEADLESS=true

--- a/IntelliTrader.Core/Models/Config/ConfigProvider.cs
+++ b/IntelliTrader.Core/Models/Config/ConfigProvider.cs
@@ -204,7 +204,7 @@ namespace IntelliTrader.Core
             var configBuilder = new ConfigurationBuilder()
                  .SetBasePath(fullConfigPath)
                  .AddJsonFile(configPath, optional: false, reloadOnChange: true)
-                 .AddEnvironmentVariables();
+                 .AddEnvironmentVariables(prefix: "INTELLITRADER_");
 
             var configRoot = configBuilder.Build();
             ChangeToken.OnChange(configRoot.GetReloadToken, () => onChange(configRoot));

--- a/README.md
+++ b/README.md
@@ -550,6 +550,32 @@ The chart includes Deployment, Service, ConfigMap, Secret, PVC, Ingress (optiona
 
 > **Note**: IntelliTrader is a stateful singleton — the HPA defaults to `maxReplicas: 1`. Do not scale beyond 1 without external state coordination.
 
+### Environment Variable Configuration
+
+All JSON configuration settings can be overridden via environment variables, following [12-factor app](https://12factor.net/config) principles. Environment variables **take precedence** over values in JSON config files.
+
+**Naming convention:**
+
+```
+INTELLITRADER_{Section}__{Key}
+INTELLITRADER_{Section}__{NestedObject}__{Key}
+```
+
+The prefix `INTELLITRADER_` is stripped automatically. Double underscores (`__`) map to the `:` hierarchy separator used by .NET Configuration (this is standard `Microsoft.Extensions.Configuration` behavior).
+
+**Examples:**
+
+| JSON path | Environment variable |
+|---|---|
+| `core.json` > `Core.DebugMode` | `INTELLITRADER_Core__DebugMode=false` |
+| `core.json` > `Core.InstanceName` | `INTELLITRADER_Core__InstanceName=Prod` |
+| `trading.json` > `Trading.Enabled` | `INTELLITRADER_Trading__Enabled=true` |
+| `trading.json` > `Trading.VirtualTrading` | `INTELLITRADER_Trading__VirtualTrading=false` |
+| `trading.json` > `Trading.Market` | `INTELLITRADER_Trading__Market=USDT` |
+| `exchange.json` > `Exchange.KeysPath` | `INTELLITRADER_Exchange__KeysPath=/secrets/keys.bin` |
+
+This works with `docker run -e`, `docker compose` environment blocks, Kubernetes `env` specs, and `.env` files. See `.env.example` for a full list of documented overrides.
+
 <br />
 
 ## 🔌 API Overview


### PR DESCRIPTION
## Summary
- Add `INTELLITRADER_` prefix to `AddEnvironmentVariables()` in `ConfigProvider.GetConfig()` so all JSON config settings are overridable via environment variables (e.g., `INTELLITRADER_Core__DebugMode=false`)
- Extend `.env.example` with documented examples for core, trading, exchange, web, and notification overrides
- Add "Environment Variable Configuration" section to README with naming convention and examples table

## Details

The config provider already called `.AddEnvironmentVariables()` but without a prefix, which meant every system environment variable was loaded into the configuration. Adding `prefix: "INTELLITRADER_"` scopes it properly and establishes a clear naming convention following 12-factor app principles.

Environment variables take precedence over JSON file values (standard `Microsoft.Extensions.Configuration` layering). The `__` double-underscore separator maps to `:` in the config hierarchy.

Closes #6

## Test plan
- [ ] Verify `INTELLITRADER_Core__DebugMode=false` overrides `core.json` value
- [ ] Verify `INTELLITRADER_Trading__VirtualTrading=false` overrides `trading.json` value
- [ ] Verify unset env vars fall back to JSON file values
- [ ] Verify nested config works (e.g., `INTELLITRADER_Trading__PositionSizing__Enabled=true`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)