### PR TITLE
docs(adr): add architecture decision records

### DIFF
--- a/docs/ADRs/ADR-0010-lazy-di-cycle-breaking.md
+++ b/docs/ADRs/ADR-0010-lazy-di-cycle-breaking.md
@@ -1,0 +1,51 @@
+# ADR-0010: Lazy<T> for Dependency Injection Cycle Breaking
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+IntelliTrader's service graph contains circular dependencies where services need references to each other (e.g., TradingService depends on ExchangeService which depends on TradingService for order callbacks). Autofac detects these cycles at resolution time and throws a `DependencyResolutionException`, preventing the application from starting.
+
+Common solutions include restructuring the dependency graph, introducing mediator services, or using lazy resolution to defer one side of the cycle.
+
+## Decision
+We use `Lazy<T>` wrappers on back-edges of the service dependency graph to break circular references. The service that initiates the cycle injects `Lazy<T>` instead of `T` directly, deferring resolution until first access. Autofac natively supports `Lazy<T>` without additional registration.
+
+Example:
+```csharp
+public class TradingService : ITradingService
+{
+    private readonly Lazy<IExchangeService> _exchangeService;
+
+    public TradingService(Lazy<IExchangeService> exchangeService)
+    {
+        _exchangeService = exchangeService;
+    }
+
+    private IExchangeService Exchange => _exchangeService.Value;
+}
+```
+
+The convention is: the service that is "logically secondary" in the relationship receives the `Lazy<T>` wrapper, keeping the primary dependency path eager.
+
+## Consequences
+
+### Positive
+- Breaks circular dependencies without restructuring the service graph
+- Zero overhead until `.Value` is accessed; no unnecessary early resolution
+- Native Autofac support; no custom registrations or interceptors needed
+- Minimal code change: only the constructor parameter type changes
+
+### Negative
+- Hides architectural coupling; cycles remain in the logical graph
+- Runtime failure risk: if `.Value` is accessed during construction of another lazy-resolved service, the cycle reappears
+- Developers must understand which edges are lazy and why
+
+### Neutral
+- All services are singletons (see [ADR-0001](ADR-0001-dependency-injection.md)), so `Lazy<T>.Value` is resolved at most once per application lifetime
+
+## References
+- [ADR-0001: Autofac Dependency Injection](ADR-0001-dependency-injection.md) - Parent DI architecture decision

--- a/docs/ADRs/ADR-0011-alpine-docker-image.md
+++ b/docs/ADRs/ADR-0011-alpine-docker-image.md
@@ -1,0 +1,39 @@
+# ADR-0011: Alpine-Based Docker Image for Production
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+IntelliTrader needs a production container image that balances size, security, and compatibility. The application targets .NET 9 and runs as a long-lived process on Kubernetes. Smaller images reduce pull times, storage costs, and the attack surface from unused OS packages.
+
+The main candidates are Debian-based (`aspnet:9.0`), Ubuntu Chiseled (`aspnet:9.0-noble-chiseled`), and Alpine-based (`aspnet:9.0-alpine`) base images.
+
+## Decision
+We use `mcr.microsoft.com/dotnet/aspnet:9.0-alpine` as the production runtime base image and `mcr.microsoft.com/dotnet/sdk:9.0-alpine` for the build stage. Alpine uses musl libc instead of glibc, producing images roughly 5x smaller than Debian equivalents (~50MB vs ~250MB).
+
+Key configuration choices:
+- `RUN apk add --no-cache icu-libs` to enable globalization (currency formatting, date parsing)
+- `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false` to ensure correct locale behavior for financial data
+- Multi-stage build: SDK stage compiles, runtime stage only contains the published output
+
+## Consequences
+
+### Positive
+- Image size reduced from ~250MB to ~50MB, improving pull and startup times
+- Smaller attack surface: Alpine ships with fewer packages and a minimal shell
+- Faster CI builds due to smaller layer caching footprint
+- Consistent with 12-factor app practices for immutable deployments
+
+### Negative
+- musl libc differences may cause subtle runtime behavior differences vs glibc
+- Some native NuGet packages may not ship musl-compatible binaries
+- Debugging in production is harder due to missing tools (no bash, limited coreutils)
+
+### Neutral
+- Alpine images require explicit timezone data (`tzdata` package) if local time formatting is needed
+
+## References
+- [ADR-0012: Helm Chart with Recreate Strategy](ADR-0012-helm-chart-recreate-strategy.md) - Deployment strategy for the containerized application

--- a/docs/ADRs/ADR-0012-helm-chart-recreate-strategy.md
+++ b/docs/ADRs/ADR-0012-helm-chart-recreate-strategy.md
@@ -1,0 +1,49 @@
+# ADR-0012: Helm Chart with Recreate Deployment Strategy
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+IntelliTrader is deployed to Kubernetes via a Helm chart. The application maintains in-memory state (open positions, trailing orders, signal ratings) and holds a single WebSocket connection to the Binance exchange. Running multiple replicas simultaneously would cause:
+
+1. Duplicate order execution (both replicas acting on the same signal)
+2. Conflicting exchange state (two WebSocket streams with divergent order books)
+3. Data corruption in the shared trading account
+
+A rolling update strategy (`RollingUpdate`) briefly runs old and new pods concurrently, which is unsafe for this singleton trading bot.
+
+## Decision
+We use the `Recreate` deployment strategy in the Helm chart. This terminates the existing pod completely before starting the new one, guaranteeing that at most one instance is active at any time.
+
+```yaml
+strategy:
+  type: Recreate
+```
+
+Combined with `replicas: 1`, this ensures single-instance operation. The brief downtime during restarts (typically 10-30 seconds) is acceptable because:
+- Trading signals are cached and re-fetched on startup
+- Open positions are tracked on the exchange, not only in-memory
+- Missed signals during restart represent negligible risk
+
+## Consequences
+
+### Positive
+- Eliminates risk of duplicate order execution during deployments
+- Simple to reason about: exactly one instance running at all times
+- No need for distributed locking or leader election
+- Safe for stateful, singleton workloads
+
+### Negative
+- Brief downtime during every deployment (pod termination + startup)
+- No zero-downtime deployments; maintenance windows may be needed for critical market periods
+- Cannot horizontally scale without architectural changes (distributed state, leader election)
+
+### Neutral
+- Health probes (liveness and readiness) control when the new pod receives traffic after restart
+
+## References
+- [ADR-0011: Alpine Docker Image](ADR-0011-alpine-docker-image.md) - Container image used by this deployment
+- [ADR-0013: Anonymous Health Endpoints](ADR-0013-anonymous-health-endpoints.md) - Health checks used by Kubernetes probes

--- a/docs/ADRs/ADR-0013-anonymous-health-endpoints.md
+++ b/docs/ADRs/ADR-0013-anonymous-health-endpoints.md
@@ -1,0 +1,52 @@
+# ADR-0013: Anonymous Health Endpoints
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+IntelliTrader runs on Kubernetes, which requires HTTP health endpoints for liveness and readiness probes. The web dashboard uses cookie-based authentication to protect trading operations. Kubernetes probes cannot authenticate, so health endpoints must be accessible without credentials.
+
+Two endpoints are needed:
+- **Liveness** (`/health/live`): Is the process running and not deadlocked?
+- **Readiness** (`/health/ready`): Is the application connected to the exchange and able to trade?
+
+## Decision
+We expose `/health/live` and `/health/ready` as anonymous endpoints outside the authentication middleware group. All other endpoints (dashboard, trading APIs, SignalR hub) remain behind authentication.
+
+The readiness probe checks critical service health: exchange WebSocket connectivity, signal service availability, and trading service initialization. The liveness probe returns 200 if the process is responsive.
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    // Anonymous health endpoints - outside auth group
+    endpoints.MapGet("/health/live", () => Results.Ok("alive"));
+    endpoints.MapGet("/health/ready", (IHealthCheckService healthCheck) =>
+        healthCheck.IsReady() ? Results.Ok("ready") : Results.StatusCode(503));
+
+    // Authenticated endpoints
+    endpoints.MapControllerRoute(...);
+    endpoints.MapHub<TradingHub>("/trading-hub");
+});
+```
+
+## Consequences
+
+### Positive
+- Kubernetes can probe health without credentials or service account tokens
+- Clear separation: health endpoints are operational, not business-facing
+- Readiness probe prevents traffic routing before exchange connection is established
+- Liveness probe enables automatic pod restart on deadlock
+
+### Negative
+- Health endpoints leak minimal information (alive/ready status) to unauthenticated callers
+- Must be careful not to expose sensitive data (balances, positions) through health responses
+
+### Neutral
+- Standard Kubernetes practice; aligns with industry conventions for health checking
+
+## References
+- [ADR-0012: Helm Chart with Recreate Strategy](ADR-0012-helm-chart-recreate-strategy.md) - Deployment using these health probes
+- [ADR-0009: Web Dashboard](ADR-0009-web-dashboard.md) - Authentication setup for the dashboard

--- a/docs/ADRs/ADR-0014-virtual-trading-mode.md
+++ b/docs/ADRs/ADR-0014-virtual-trading-mode.md
@@ -1,0 +1,50 @@
+# ADR-0014: Virtual Trading Mode
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+Testing trading strategies with real funds is expensive and risky. Developers and traders need a way to validate signal configurations, rule parameters, and DCA settings against live market data without executing real orders on the exchange.
+
+A paper trading mode must use real-time prices from Binance but simulate order fills, balance tracking, and position management entirely in memory.
+
+## Decision
+We implement a virtual trading mode controlled by a single configuration toggle in `trading.json`:
+
+```json
+{
+  "VirtualTrading": true
+}
+```
+
+When enabled:
+- **Prices are real**: The exchange service fetches live ticker data from Binance via WebSocket
+- **Orders are simulated**: Buy/sell operations update an in-memory virtual account instead of calling the exchange API
+- **Positions are tracked**: Virtual positions maintain entry price, quantity, DCA levels, and trailing state
+- **Rules execute normally**: Signal and trading rules evaluate identically in both modes
+
+The trading service checks `Config.VirtualTrading` before routing orders to the exchange. This keeps the trading logic unified; only the execution layer differs.
+
+## Consequences
+
+### Positive
+- Risk-free strategy validation against live market conditions
+- No code branching in rules, signals, or DCA logic; the same pipeline runs in both modes
+- Fast iteration: change config, restart, observe behavior
+- New users can familiarize themselves with the system before committing funds
+
+### Negative
+- Virtual fills assume instant execution at current price; real markets have slippage and partial fills
+- No exchange-side validation (minimum order size, balance checks) in virtual mode
+- Virtual and live performance may diverge in volatile markets
+
+### Neutral
+- Virtual trading state is lost on restart (positions are in-memory only)
+- The web dashboard displays virtual positions identically to real ones, distinguished only by a config indicator
+
+## References
+- [ADR-0001: Autofac Dependency Injection](ADR-0001-dependency-injection.md) - Service resolution for trading mode
+- [ADR-0005: Rule Engine](ADR-0005-rule-engine.md) - Rules execute identically in both modes


### PR DESCRIPTION
## Summary
- Add 5 new Architecture Decision Records (ADR-0010 through ADR-0014) documenting key architectural choices
- Covers: Lazy<T> DI cycle breaking, Alpine Docker image, Helm Recreate strategy, anonymous health endpoints, and virtual trading mode
- Each ADR follows the established template with Context, Decision, and Consequences sections, and cross-references related ADRs

## Test plan
- [ ] Verify all 5 ADR files are present in `docs/ADRs/`
- [ ] Confirm sequential numbering continues from existing ADR-0009
- [ ] Check cross-references between ADRs resolve correctly

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)