### PR TITLE
feat(web): add API rate limiting per endpoint category

### DIFF
--- a/IntelliTrader.Web/Controllers/HomeController.cs
+++ b/IntelliTrader.Web/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -466,6 +467,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("config")]
         public IActionResult Settings(SettingsViewModel model)
         {
             _coreService.Config.HealthCheckEnabled = model.HealthCheckEnabled;
@@ -486,6 +488,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("config")]
         public IActionResult SaveConfig([FromForm] ConfigUpdateModel model)
         {
             if (!ModelState.IsValid)
@@ -505,6 +508,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("trading")]
         public IActionResult Sell([FromForm] SellInputModel model)
         {
             if (!ModelState.IsValid)
@@ -522,6 +526,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("trading")]
         public IActionResult Buy([FromForm] BuyInputModel model)
         {
             if (!ModelState.IsValid)
@@ -540,6 +545,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("trading")]
         public IActionResult BuyDefault([FromForm] BuyDefaultInputModel model)
         {
             if (!ModelState.IsValid)
@@ -562,6 +568,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [EnableRateLimiting("trading")]
         public IActionResult Swap([FromForm] SwapInputModel model)
         {
             if (!ModelState.IsValid)

--- a/IntelliTrader.Web/MinimalApiEndpoints.cs
+++ b/IntelliTrader.Web/MinimalApiEndpoints.cs
@@ -1,6 +1,7 @@
 using IntelliTrader.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Routing;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,8 +22,10 @@ namespace IntelliTrader.Web
             // GET /api/health - Anonymous liveness probe used by Docker
             // HEALTHCHECK and Kubernetes probes. Must stay outside of the
             // authenticated /api group so it can be reached without a session.
+            // Health endpoints are exempt from rate limiting so probes always succeed.
             endpoints.MapGet("/api/health", () => Results.Ok(new { status = "ok" }))
                 .AllowAnonymous()
+                .DisableRateLimiting()
                 .WithName("HealthCheck")
                 .WithDescription("Liveness probe returning 200 OK whenever the web host is running");
 
@@ -36,6 +39,7 @@ namespace IntelliTrader.Web
                     timestamp = DateTimeOffset.UtcNow
                 }))
                 .AllowAnonymous()
+                .DisableRateLimiting()
                 .WithName("LivenessProbe")
                 .WithDescription("Kubernetes liveness probe — 200 OK while the process is running");
 
@@ -82,11 +86,13 @@ namespace IntelliTrader.Web
                         : Results.Json(payload, statusCode: StatusCodes.Status503ServiceUnavailable);
                 })
                 .AllowAnonymous()
+                .DisableRateLimiting()
                 .WithName("ReadinessProbe")
                 .WithDescription("Kubernetes readiness probe — 200 when bot is ready, 503 otherwise");
 
             var apiGroup = endpoints.MapGroup("/api")
-                .RequireAuthorization();
+                .RequireAuthorization()
+                .RequireRateLimiting("status");
 
             // GET /api/status - Get current trading status
             apiGroup.MapGet("/status", (

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -7,6 +7,8 @@ using IntelliTrader.Web.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -14,6 +16,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.RateLimiting;
 
 namespace IntelliTrader.Web
 {
@@ -85,6 +88,50 @@ namespace IntelliTrader.Web
             // Includes tracing, metrics for trading operations, ASP.NET Core, HTTP, and runtime
             var enableConsoleExporter = Environment.IsDevelopment();
             services.AddIntelliTraderTelemetry(enableConsoleExporter);
+
+            // Configure API rate limiting per endpoint category to prevent abuse.
+            // Limits are configurable via web.json RateLimiting section.
+            var rateLimitSection = Configuration.GetSection("Web:RateLimiting");
+            var tradingLimit = rateLimitSection.GetValue<int?>("TradingPermitLimit") ?? 10;
+            var statusLimit = rateLimitSection.GetValue<int?>("StatusPermitLimit") ?? 60;
+            var configLimit = rateLimitSection.GetValue<int?>("ConfigPermitLimit") ?? 5;
+            var windowSeconds = rateLimitSection.GetValue<int?>("WindowSeconds") ?? 60;
+
+            services.AddRateLimiter(options =>
+            {
+                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+                options.AddFixedWindowLimiter("trading", opt =>
+                {
+                    opt.PermitLimit = tradingLimit;
+                    opt.Window = TimeSpan.FromSeconds(windowSeconds);
+                    opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                    opt.QueueLimit = 0;
+                });
+
+                options.AddFixedWindowLimiter("status", opt =>
+                {
+                    opt.PermitLimit = statusLimit;
+                    opt.Window = TimeSpan.FromSeconds(windowSeconds);
+                    opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                    opt.QueueLimit = 0;
+                });
+
+                options.AddFixedWindowLimiter("config", opt =>
+                {
+                    opt.PermitLimit = configLimit;
+                    opt.Window = TimeSpan.FromSeconds(windowSeconds);
+                    opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                    opt.QueueLimit = 0;
+                });
+
+                options.OnRejected = async (context, cancellationToken) =>
+                {
+                    context.HttpContext.Response.Headers.RetryAfter =
+                        windowSeconds.ToString();
+                    await Task.CompletedTask;
+                };
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -109,6 +156,8 @@ namespace IntelliTrader.Web
 
             app.UseAuthentication();
             app.UseAuthorization();
+
+            app.UseRateLimiter();
 
             app.UseEndpoints(endpoints =>
             {

--- a/IntelliTrader/config/web.json
+++ b/IntelliTrader/config/web.json
@@ -2,6 +2,12 @@
   "Web": {
     "Enabled": true,
     "DebugMode": true,
-    "Port": 7000
+    "Port": 7000,
+    "RateLimiting": {
+      "TradingPermitLimit": 10,
+      "StatusPermitLimit": 60,
+      "ConfigPermitLimit": 5,
+      "WindowSeconds": 60
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add fixed-window rate limiting to all API endpoints using .NET built-in `Microsoft.AspNetCore.RateLimiting` middleware
- Three policy categories: **trading** (10 req/min), **status** (60 req/min), **config** (5 req/min)
- Returns `429 Too Many Requests` with `Retry-After` header when limits are exceeded
- Health probe endpoints (`/api/health`, `/health/live`, `/health/ready`) are explicitly excluded from rate limiting
- All limits are configurable via `web.json` `RateLimiting` section with sensible defaults

## Files changed
- `IntelliTrader.Web/Startup.cs` -- rate limiter service registration and middleware
- `IntelliTrader.Web/MinimalApiEndpoints.cs` -- status policy on API group, health endpoints exempt
- `IntelliTrader.Web/Controllers/HomeController.cs` -- trading/config policies on MVC actions
- `IntelliTrader/config/web.json` -- default rate limit configuration values

## Test plan
- [ ] Verify build succeeds with zero new errors
- [ ] Confirm trading endpoints (Buy/Sell/Swap) return 429 after 10 requests/minute
- [ ] Confirm status endpoints return 429 after 60 requests/minute
- [ ] Confirm config endpoints (Settings POST, SaveConfig) return 429 after 5 requests/minute
- [ ] Confirm health endpoints never return 429 regardless of request volume
- [ ] Confirm Retry-After header is present on 429 responses
- [ ] Confirm custom limits in web.json override defaults

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)