### PR TITLE
feat(web): add OpenAPI documentation with Swagger UI

### DIFF
--- a/IntelliTrader.Web/IntelliTrader.Web.csproj
+++ b/IntelliTrader.Web/IntelliTrader.Web.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <!-- OpenTelemetry packages for observability -->
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/IntelliTrader.Web/MinimalApiEndpoints.cs
+++ b/IntelliTrader.Web/MinimalApiEndpoints.cs
@@ -24,7 +24,9 @@ namespace IntelliTrader.Web
             endpoints.MapGet("/api/health", () => Results.Ok(new { status = "ok" }))
                 .AllowAnonymous()
                 .WithName("HealthCheck")
-                .WithDescription("Liveness probe returning 200 OK whenever the web host is running");
+                .WithDescription("Liveness probe returning 200 OK whenever the web host is running")
+                .WithTags("Health")
+                .Produces(StatusCodes.Status200OK);
 
             // GET /health/live - Kubernetes-style liveness probe.
             // Returns 200 whenever the web host is running. This is a
@@ -37,7 +39,9 @@ namespace IntelliTrader.Web
                 }))
                 .AllowAnonymous()
                 .WithName("LivenessProbe")
-                .WithDescription("Kubernetes liveness probe — 200 OK while the process is running");
+                .WithDescription("Kubernetes liveness probe — 200 OK while the process is running")
+                .WithTags("Health")
+                .Produces(StatusCodes.Status200OK);
 
             // GET /health/ready - Kubernetes-style readiness probe.
             // Returns 200 only when the bot is fully initialized AND
@@ -83,7 +87,10 @@ namespace IntelliTrader.Web
                 })
                 .AllowAnonymous()
                 .WithName("ReadinessProbe")
-                .WithDescription("Kubernetes readiness probe — 200 when bot is ready, 503 otherwise");
+                .WithDescription("Kubernetes readiness probe — 200 when bot is ready, 503 otherwise")
+                .WithTags("Health")
+                .Produces(StatusCodes.Status200OK)
+                .Produces(StatusCodes.Status503ServiceUnavailable);
 
             var apiGroup = endpoints.MapGroup("/api")
                 .RequireAuthorization();
@@ -109,7 +116,10 @@ namespace IntelliTrader.Web
                 return Results.Json(status);
             })
             .WithName("GetStatus")
-            .WithDescription("Get current trading status including balance, ratings, and health checks");
+            .WithDescription("Get current trading status including balance, ratings, and health checks")
+            .WithTags("Trading")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
             // POST /api/trading-pairs - Get all trading pairs with their details
             apiGroup.MapPost("/trading-pairs", (
@@ -148,7 +158,10 @@ namespace IntelliTrader.Web
                 return Results.Json(tradingPairs);
             })
             .WithName("GetTradingPairs")
-            .WithDescription("Get all active trading pairs with their current status and configuration");
+            .WithDescription("Get all active trading pairs with their current status and configuration")
+            .WithTags("Trading")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
             // POST /api/market-pairs - Get all market pairs with signals
             apiGroup.MapPost("/market-pairs", (
@@ -196,7 +209,10 @@ namespace IntelliTrader.Web
                 }
             })
             .WithName("GetMarketPairs")
-            .WithDescription("Get all market pairs with their signal data and configuration");
+            .WithDescription("Get all market pairs with their signal data and configuration")
+            .WithTags("Signals")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
             // POST /api/market-pairs/filtered - Get market pairs with signals filter in body
             apiGroup.MapPost("/market-pairs/filtered", async (
@@ -253,7 +269,11 @@ namespace IntelliTrader.Web
                 }
             })
             .WithName("GetMarketPairsFiltered")
-            .WithDescription("Get market pairs filtered by specific signal names");
+            .WithDescription("Get market pairs filtered by specific signal names")
+            .WithTags("Signals")
+            .Accepts<List<string>>("application/json")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
             // GET /api/signal-names - Get all available signal names
             apiGroup.MapGet("/signal-names", (ISignalsService signalsService) =>
@@ -261,7 +281,10 @@ namespace IntelliTrader.Web
                 return Results.Json(signalsService.GetSignalNames());
             })
             .WithName("GetSignalNames")
-            .WithDescription("Get all available signal names");
+            .WithDescription("Get all available signal names")
+            .WithTags("Signals")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
             return endpoints;
         }

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -126,13 +126,19 @@ namespace IntelliTrader.Web
                 RequestPath = "/Static"
             });
 
-            // Serve OpenAPI spec and Swagger UI (before auth so it's publicly accessible)
-            app.UseSwagger();
-            app.UseSwaggerUI(c =>
+            // Serve OpenAPI spec and Swagger UI (before auth so it's publicly accessible).
+            // Only enabled in Development or when explicitly opted-in via config to avoid
+            // leaking API surface details in production.
+            var enableSwagger = env.IsDevelopment() || Configuration.GetValue<bool>("Swagger:Enabled");
+            if (enableSwagger)
             {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "IntelliTrader API v1");
-                c.RoutePrefix = "swagger";
-            });
+                app.UseSwagger();
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "IntelliTrader API v1");
+                    c.RoutePrefix = "swagger";
+                });
+            }
 
             app.UseRouting();
 

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -85,6 +86,26 @@ namespace IntelliTrader.Web
             // Includes tracing, metrics for trading operations, ASP.NET Core, HTTP, and runtime
             var enableConsoleExporter = Environment.IsDevelopment();
             services.AddIntelliTraderTelemetry(enableConsoleExporter);
+
+            // Configure OpenAPI/Swagger documentation
+            services.AddEndpointsApiExplorer();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo
+                {
+                    Title = "IntelliTrader API",
+                    Version = "v1",
+                    Description = "Cryptocurrency trading bot REST API for managing trades, monitoring signals, and checking system health.",
+                    Contact = new OpenApiContact
+                    {
+                        Name = "IntelliTrader",
+                        Url = new Uri("https://github.com/nicamedic/IntelliTrader")
+                    }
+                });
+
+                // Include MVC controller actions in Swagger docs
+                c.DocInclusionPredicate((docName, apiDesc) => true);
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -103,6 +124,14 @@ namespace IntelliTrader.Web
                 FileProvider = new PhysicalFileProvider(
                 Path.Combine(env.ContentRootPath, "Static")),
                 RequestPath = "/Static"
+            });
+
+            // Serve OpenAPI spec and Swagger UI (before auth so it's publicly accessible)
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "IntelliTrader API v1");
+                c.RoutePrefix = "swagger";
             });
 
             app.UseRouting();


### PR DESCRIPTION
## Summary
- Add `Swashbuckle.AspNetCore` 6.9.0 package to `IntelliTrader.Web`
- Configure Swagger middleware in `Startup.cs` with OpenAPI v1 doc (title, description, contact)
- Swagger UI served at `/swagger`, OpenAPI JSON spec at `/swagger/v1/swagger.json`
- Middleware placed before `UseAuthentication` so docs are accessible without login
- All minimal API endpoints annotated with `WithTags` (Health, Trading, Signals), `Produces` status codes, and `WithDescription` for rich documentation
- Readiness probe documents both 200 and 503 responses; filtered market-pairs endpoint documents accepted request body type

## Test plan
- [ ] Verify `dotnet build IntelliTrader.sln` succeeds
- [ ] Start the web host and navigate to `/swagger` -- Swagger UI should render
- [ ] Verify `/swagger/v1/swagger.json` returns a valid OpenAPI 3.0 spec
- [ ] Confirm endpoints are grouped under Health, Trading, and Signals tags
- [ ] Confirm Swagger UI is accessible without authentication

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive, interactive API documentation providing details on all available endpoints, request parameters, response schemas, and HTTP status codes. The documentation is publicly accessible at the `/swagger` endpoint, enabling easy exploration and understanding of the API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->