### PR TITLE
feat(security): add AES-256 encryption for config files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,5 +84,10 @@ ASPNETCORE_ENVIRONMENT=Production
 # --- Notification settings (notification.json) ---
 #INTELLITRADER_Notification__Enabled=false
 
+# --- Config encryption (standalone env var, not a config override) ---
+# Required at runtime when config files have been encrypted with --encrypt-config.
+# Generate encrypted configs:  dotnet IntelliTrader.dll --encrypt-config --password=<master>
+#INTELLITRADER_MASTER_PASSWORD=
+
 # --- Headless mode (not a config override, standalone env var) ---
 #INTELLITRADER_HEADLESS=true

--- a/IntelliTrader.Core/Models/Config/ConfigProvider.cs
+++ b/IntelliTrader.Core/Models/Config/ConfigProvider.cs
@@ -1,8 +1,10 @@
 using IntelliTrader.Core.Exceptions;
+using IntelliTrader.Core.Security;
 using IntelliTrader.Core.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 
 namespace IntelliTrader.Core
@@ -23,6 +25,11 @@ namespace IntelliTrader.Core
 
         // Flag to enable/disable validation (can be toggled for testing or specific scenarios)
         private bool _validationEnabled = true;
+
+        // Tracks which config files were originally encrypted so we re-encrypt on save
+        private readonly ConcurrentDictionary<string, bool> _encryptedFiles = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        private const string MasterPasswordEnvVar = "INTELLITRADER_MASTER_PASSWORD";
 
         public ConfigProvider() : this(new ConfigValidationService())
         {
@@ -91,7 +98,8 @@ namespace IntelliTrader.Core
                 }
 
                 fullConfigPath = Path.Combine(Directory.GetCurrentDirectory(), ROOT_CONFIG_DIR, configPath);
-                return File.ReadAllText(fullConfigPath);
+                string content = File.ReadAllText(fullConfigPath);
+                return DecryptIfNeeded(content, fullConfigPath);
             }
             catch (FileNotFoundException ex)
             {
@@ -130,7 +138,8 @@ namespace IntelliTrader.Core
                 }
 
                 fullConfigPath = Path.Combine(Directory.GetCurrentDirectory(), ROOT_CONFIG_DIR, configPath);
-                File.WriteAllText(fullConfigPath, definition);
+                string contentToWrite = EncryptIfNeeded(definition, fullConfigPath);
+                File.WriteAllText(fullConfigPath, contentToWrite);
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -199,16 +208,108 @@ namespace IntelliTrader.Core
 
         private IConfigurationRoot GetConfig(string configPath, Action<IConfigurationRoot> onChange)
         {
-            var fullConfigPath = Path.Combine(Directory.GetCurrentDirectory(), ROOT_CONFIG_DIR);
+            var fullConfigDir = Path.Combine(Directory.GetCurrentDirectory(), ROOT_CONFIG_DIR);
+            var fullFilePath = Path.Combine(fullConfigDir, configPath);
+
+            // Check if the file is encrypted; if so, decrypt to a temp file
+            // so the JSON configuration provider can parse it.
+            string effectivePath = configPath;
+            string effectiveBaseDir = fullConfigDir;
+
+            if (File.Exists(fullFilePath))
+            {
+                string raw = File.ReadAllText(fullFilePath);
+                if (ConfigEncryption.IsEncrypted(raw))
+                {
+                    _encryptedFiles[fullFilePath] = true;
+                    string masterPassword = Environment.GetEnvironmentVariable(MasterPasswordEnvVar);
+                    if (string.IsNullOrEmpty(masterPassword))
+                    {
+                        LogError($"Config file '{configPath}' is encrypted but {MasterPasswordEnvVar} is not set. Cannot decrypt.");
+                    }
+                    else
+                    {
+                        try
+                        {
+                            string decrypted = ConfigEncryption.Decrypt(raw, masterPassword);
+                            // Write a decrypted temporary file that the JSON provider can read.
+                            // Place it in the system temp directory so we don't pollute the config folder.
+                            string tempFile = Path.Combine(Path.GetTempPath(), $"intellitrader_cfg_{Path.GetFileName(configPath)}");
+                            File.WriteAllText(tempFile, decrypted);
+                            effectivePath = Path.GetFileName(tempFile);
+                            effectiveBaseDir = Path.GetDirectoryName(tempFile);
+                        }
+                        catch (Exception ex)
+                        {
+                            LogError($"Failed to decrypt config file '{configPath}'.", ex);
+                        }
+                    }
+                }
+            }
 
             var configBuilder = new ConfigurationBuilder()
-                 .SetBasePath(fullConfigPath)
-                 .AddJsonFile(configPath, optional: false, reloadOnChange: true)
+                 .SetBasePath(effectiveBaseDir)
+                 .AddJsonFile(effectivePath, optional: false, reloadOnChange: true)
                  .AddEnvironmentVariables(prefix: "INTELLITRADER_");
 
             var configRoot = configBuilder.Build();
             ChangeToken.OnChange(configRoot.GetReloadToken, () => onChange(configRoot));
             return configRoot;
+        }
+
+        /// <summary>
+        /// Decrypts content if it starts with the ENC: prefix.
+        /// Returns plaintext JSON on success, or the original content on failure / if not encrypted.
+        /// </summary>
+        private string DecryptIfNeeded(string content, string filePath)
+        {
+            if (!ConfigEncryption.IsEncrypted(content))
+                return content;
+
+            _encryptedFiles[filePath] = true;
+
+            string masterPassword = Environment.GetEnvironmentVariable(MasterPasswordEnvVar);
+            if (string.IsNullOrEmpty(masterPassword))
+            {
+                LogError($"Config file '{filePath}' is encrypted but {MasterPasswordEnvVar} is not set. Cannot decrypt.");
+                return null;
+            }
+
+            try
+            {
+                return ConfigEncryption.Decrypt(content, masterPassword);
+            }
+            catch (Exception ex)
+            {
+                LogError($"Failed to decrypt config file '{filePath}'.", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Re-encrypts content if the file was originally loaded as encrypted.
+        /// </summary>
+        private string EncryptIfNeeded(string content, string filePath)
+        {
+            if (!_encryptedFiles.TryGetValue(filePath, out bool wasEncrypted) || !wasEncrypted)
+                return content;
+
+            string masterPassword = Environment.GetEnvironmentVariable(MasterPasswordEnvVar);
+            if (string.IsNullOrEmpty(masterPassword))
+            {
+                LogError($"Cannot re-encrypt config file '{filePath}': {MasterPasswordEnvVar} is not set. Saving as plaintext.");
+                return content;
+            }
+
+            try
+            {
+                return ConfigEncryption.Encrypt(content, masterPassword);
+            }
+            catch (Exception ex)
+            {
+                LogError($"Failed to re-encrypt config file '{filePath}'. Saving as plaintext.", ex);
+                return content;
+            }
         }
     }
 }

--- a/IntelliTrader.Core/Security/ConfigEncryption.cs
+++ b/IntelliTrader.Core/Security/ConfigEncryption.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace IntelliTrader.Core.Security
+{
+    /// <summary>
+    /// Provides AES-256-CBC encryption and decryption for configuration files.
+    /// Uses PBKDF2 with SHA256 for key derivation from a master password.
+    /// Encrypted content is prefixed with "ENC:" followed by base64-encoded data.
+    /// The binary layout is: [16-byte salt][16-byte IV][ciphertext].
+    /// </summary>
+    public static class ConfigEncryption
+    {
+        private const string EncryptedPrefix = "ENC:";
+        private const int KeySizeBytes = 32;   // AES-256
+        private const int SaltSizeBytes = 16;
+        private const int IvSizeBytes = 16;    // AES block size
+        private const int Pbkdf2Iterations = 100_000;
+
+        /// <summary>
+        /// Checks whether the given content is an encrypted config blob.
+        /// </summary>
+        public static bool IsEncrypted(string content)
+        {
+            return !string.IsNullOrEmpty(content) &&
+                   content.StartsWith(EncryptedPrefix, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Encrypts plaintext JSON using AES-256-CBC with a key derived from
+        /// <paramref name="masterPassword"/> via PBKDF2 (100 000 iterations, SHA256).
+        /// Returns a string in the form "ENC:&lt;base64&gt;".
+        /// </summary>
+        public static string Encrypt(string plaintext, string masterPassword)
+        {
+            if (plaintext == null) throw new ArgumentNullException(nameof(plaintext));
+            if (string.IsNullOrEmpty(masterPassword)) throw new ArgumentException("Master password must not be empty.", nameof(masterPassword));
+
+            byte[] salt = new byte[SaltSizeBytes];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(salt);
+            }
+
+            byte[] key = DeriveKey(masterPassword, salt);
+
+            using (var aes = Aes.Create())
+            {
+                aes.KeySize = 256;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                aes.Key = key;
+                aes.GenerateIV();
+
+                byte[] iv = aes.IV;
+
+                using (var encryptor = aes.CreateEncryptor())
+                {
+                    byte[] plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
+                    byte[] ciphertext = encryptor.TransformFinalBlock(plaintextBytes, 0, plaintextBytes.Length);
+
+                    // Layout: salt + IV + ciphertext
+                    byte[] blob = new byte[SaltSizeBytes + IvSizeBytes + ciphertext.Length];
+                    Buffer.BlockCopy(salt, 0, blob, 0, SaltSizeBytes);
+                    Buffer.BlockCopy(iv, 0, blob, SaltSizeBytes, IvSizeBytes);
+                    Buffer.BlockCopy(ciphertext, 0, blob, SaltSizeBytes + IvSizeBytes, ciphertext.Length);
+
+                    return EncryptedPrefix + Convert.ToBase64String(blob);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decrypts a string previously produced by <see cref="Encrypt"/>.
+        /// The input must start with the "ENC:" prefix.
+        /// </summary>
+        public static string Decrypt(string ciphertext, string masterPassword)
+        {
+            if (ciphertext == null) throw new ArgumentNullException(nameof(ciphertext));
+            if (string.IsNullOrEmpty(masterPassword)) throw new ArgumentException("Master password must not be empty.", nameof(masterPassword));
+
+            if (!IsEncrypted(ciphertext))
+            {
+                throw new ArgumentException("Content does not appear to be encrypted (missing ENC: prefix).", nameof(ciphertext));
+            }
+
+            string base64 = ciphertext.Substring(EncryptedPrefix.Length);
+            byte[] blob = Convert.FromBase64String(base64);
+
+            if (blob.Length < SaltSizeBytes + IvSizeBytes + 1)
+            {
+                throw new CryptographicException("Encrypted blob is too short to be valid.");
+            }
+
+            byte[] salt = new byte[SaltSizeBytes];
+            byte[] iv = new byte[IvSizeBytes];
+            byte[] encrypted = new byte[blob.Length - SaltSizeBytes - IvSizeBytes];
+
+            Buffer.BlockCopy(blob, 0, salt, 0, SaltSizeBytes);
+            Buffer.BlockCopy(blob, SaltSizeBytes, iv, 0, IvSizeBytes);
+            Buffer.BlockCopy(blob, SaltSizeBytes + IvSizeBytes, encrypted, 0, encrypted.Length);
+
+            byte[] key = DeriveKey(masterPassword, salt);
+
+            using (var aes = Aes.Create())
+            {
+                aes.KeySize = 256;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                aes.Key = key;
+                aes.IV = iv;
+
+                using (var decryptor = aes.CreateDecryptor())
+                {
+                    byte[] plaintextBytes = decryptor.TransformFinalBlock(encrypted, 0, encrypted.Length);
+                    return Encoding.UTF8.GetString(plaintextBytes);
+                }
+            }
+        }
+
+        private static byte[] DeriveKey(string password, byte[] salt)
+        {
+            using (var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Pbkdf2Iterations, HashAlgorithmName.SHA256))
+            {
+                return pbkdf2.GetBytes(KeySizeBytes);
+            }
+        }
+    }
+}

--- a/IntelliTrader/Program.cs
+++ b/IntelliTrader/Program.cs
@@ -1,8 +1,10 @@
 using Autofac;
 using ExchangeSharp;
 using IntelliTrader.Core;
+using IntelliTrader.Core.Security;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace IntelliTrader
 {
@@ -25,6 +27,14 @@ namespace IntelliTrader
                     parsedArgs.ContainsKey("publickey") && parsedArgs.ContainsKey("privatekey"))
                 {
                     EncryptKeys(parsedArgs);
+                }
+                else if (parsedArgs.ContainsKey("encrypt-config") && parsedArgs.ContainsKey("password"))
+                {
+                    EncryptConfigFiles(parsedArgs["password"]);
+                }
+                else if (parsedArgs.ContainsKey("decrypt-config") && parsedArgs.ContainsKey("password"))
+                {
+                    DecryptConfigFiles(parsedArgs["password"]);
                 }
                 else
                 {
@@ -109,14 +119,83 @@ namespace IntelliTrader
             Console.ReadKey();
         }
 
+        private static void EncryptConfigFiles(string password)
+        {
+            var configDir = Path.Combine(Directory.GetCurrentDirectory(), "config");
+            if (!Directory.Exists(configDir))
+            {
+                Console.WriteLine($"Config directory not found: {configDir}");
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(configDir, "*.json"))
+            {
+                string content = File.ReadAllText(file);
+                if (ConfigEncryption.IsEncrypted(content))
+                {
+                    Console.WriteLine($"  Skipped (already encrypted): {Path.GetFileName(file)}");
+                    continue;
+                }
+
+                string encrypted = ConfigEncryption.Encrypt(content, password);
+                File.WriteAllText(file, encrypted);
+                Console.WriteLine($"  Encrypted: {Path.GetFileName(file)}");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("All config files encrypted. Set INTELLITRADER_MASTER_PASSWORD to the same password at runtime.");
+        }
+
+        private static void DecryptConfigFiles(string password)
+        {
+            var configDir = Path.Combine(Directory.GetCurrentDirectory(), "config");
+            if (!Directory.Exists(configDir))
+            {
+                Console.WriteLine($"Config directory not found: {configDir}");
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(configDir, "*.json"))
+            {
+                string content = File.ReadAllText(file);
+                if (!ConfigEncryption.IsEncrypted(content))
+                {
+                    Console.WriteLine($"  Skipped (not encrypted): {Path.GetFileName(file)}");
+                    continue;
+                }
+
+                try
+                {
+                    string decrypted = ConfigEncryption.Decrypt(content, password);
+                    File.WriteAllText(file, decrypted);
+                    Console.WriteLine($"  Decrypted: {Path.GetFileName(file)}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"  FAILED to decrypt {Path.GetFileName(file)}: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Config files decrypted.");
+        }
+
         private static void PrintUsage()
         {
             Console.WriteLine();
-            Console.WriteLine("Usage: dotnet IntelliTrader.dll --encrypt --path=<output_path> --publickey=<public_key> --privatekey=<private_key>");
-            Console.WriteLine("The encrypted file is only valid for the current user and only on the computer it is created on.");
+            Console.WriteLine("Usage:");
             Console.WriteLine();
-            Console.WriteLine("Press any key to exit...");
-            Console.ReadKey();
+            Console.WriteLine("  Encrypt API keys:");
+            Console.WriteLine("    dotnet IntelliTrader.dll --encrypt --path=<output_path> --publickey=<key> --privatekey=<secret>");
+            Console.WriteLine();
+            Console.WriteLine("  Encrypt config files:");
+            Console.WriteLine("    dotnet IntelliTrader.dll --encrypt-config --password=<master_password>");
+            Console.WriteLine();
+            Console.WriteLine("  Decrypt config files:");
+            Console.WriteLine("    dotnet IntelliTrader.dll --decrypt-config --password=<master_password>");
+            Console.WriteLine();
+            Console.WriteLine("  At runtime, set INTELLITRADER_MASTER_PASSWORD env var to auto-decrypt encrypted configs.");
+            Console.WriteLine();
         }
 
         private static Dictionary<string, string> ParseCommandLineArgs(string[] args)


### PR DESCRIPTION
## Summary

- Add `ConfigEncryption` utility (`IntelliTrader.Core/Security/ConfigEncryption.cs`) with AES-256-CBC encryption, PBKDF2 key derivation (100k iterations, SHA256), random salt + IV per encryption
- Modify `ConfigProvider` to transparently decrypt encrypted configs on load and re-encrypt on save, using `INTELLITRADER_MASTER_PASSWORD` env var
- Add `--encrypt-config` and `--decrypt-config` CLI commands in `Program.cs` for migrating existing plaintext configs
- Backward compatible: plaintext config files continue to work unchanged with no env var needed

Closes #8

## Test plan

- [ ] Build succeeds with no new warnings
- [ ] Run `--encrypt-config --password=test123` and verify all config/*.json files get `ENC:` prefix
- [ ] Run `--decrypt-config --password=test123` and verify files are restored to valid JSON
- [ ] Set `INTELLITRADER_MASTER_PASSWORD=test123`, encrypt configs, then start the app normally -- configs load correctly
- [ ] Start app with encrypted configs but without `INTELLITRADER_MASTER_PASSWORD` set -- error is logged, app does not crash
- [ ] Start app with plaintext configs (no env var) -- everything works as before
- [ ] Hot-reload: modify a config via the web dashboard while encrypted -- file is re-encrypted on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)