### PR TITLE
feat(auth): implement role-based access control

### DIFF
--- a/IntelliTrader.Web/Controllers/HomeController.cs
+++ b/IntelliTrader.Web/Controllers/HomeController.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Web.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = AuthPolicies.ViewerOrAbove)]
     public class HomeController : Controller
     {
         private readonly ICoreService _coreService;
@@ -29,6 +29,7 @@ namespace IntelliTrader.Web.Controllers
         private readonly IConfigProvider _configProvider;
         private readonly IEnumerable<IConfigurableService> _configurableServices;
         private readonly IPortfolioRiskManager _portfolioRiskManager;
+        private readonly UsersConfig _usersConfig;
 
         public HomeController(
             ICoreService coreService,
@@ -39,6 +40,7 @@ namespace IntelliTrader.Web.Controllers
             IPasswordService passwordService,
             IConfigProvider configProvider,
             IEnumerable<IConfigurableService> configurableServices,
+            UsersConfig usersConfig,
             IPortfolioRiskManager portfolioRiskManager = null)
         {
             _coreService = coreService ?? throw new ArgumentNullException(nameof(coreService));
@@ -49,25 +51,33 @@ namespace IntelliTrader.Web.Controllers
             _passwordService = passwordService ?? throw new ArgumentNullException(nameof(passwordService));
             _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
             _configurableServices = configurableServices ?? throw new ArgumentNullException(nameof(configurableServices));
+            _usersConfig = usersConfig ?? throw new ArgumentNullException(nameof(usersConfig));
             _portfolioRiskManager = portfolioRiskManager; // Optional - may be null if not registered
         }
+
+        /// <summary>
+        /// Whether RBAC mode is active (users.json has users defined).
+        /// When false, falls back to legacy single-password mode from core.json.
+        /// </summary>
+        private bool IsRbacEnabled => _usersConfig.Users != null && _usersConfig.Users.Count > 0;
 
         #region Authentication
 
         [AllowAnonymous]
         public async Task<IActionResult> Login()
         {
-            if (_coreService.Config.PasswordProtected)
+            if (_coreService.Config.PasswordProtected || IsRbacEnabled)
             {
                 var model = new LoginViewModel
                 {
-                    RememberMe = true
+                    RememberMe = true,
+                    UsesRbac = IsRbacEnabled
                 };
                 return View(model);
             }
             else
             {
-                return await PerformLogin(true);
+                return await PerformLogin("user", UserRoles.Admin, true);
             }
         }
 
@@ -77,23 +87,48 @@ namespace IntelliTrader.Web.Controllers
         {
             if (ModelState.IsValid)
             {
-                var isValid = !_coreService.Config.PasswordProtected ||
-                    _passwordService.VerifyPassword(model.Password, _coreService.Config.Password);
-                if (!isValid)
+                if (IsRbacEnabled)
                 {
-                    ModelState.AddModelError("Password", "Invalid Password");
-                    return View(model);
+                    // RBAC mode: validate username + password against users.json
+                    if (string.IsNullOrWhiteSpace(model.Username))
+                    {
+                        ModelState.AddModelError("Username", "Username is required");
+                        return View(model);
+                    }
+
+                    var user = _usersConfig.Users.Find(u =>
+                        string.Equals(u.Username, model.Username, StringComparison.OrdinalIgnoreCase));
+
+                    if (user == null || !_passwordService.VerifyPassword(model.Password, user.PasswordHash))
+                    {
+                        ModelState.AddModelError("Password", "Invalid username or password");
+                        return View(model);
+                    }
+
+                    return await PerformLogin(user.Username, user.Role, model.RememberMe);
                 }
                 else
                 {
-                    // Log warning if using legacy MD5 hash - admin should migrate to BCrypt
-                    if (_passwordService.IsLegacyHash(_coreService.Config.Password))
+                    // Legacy single-password mode: validate against core.json Password
+                    var isValid = !_coreService.Config.PasswordProtected ||
+                        _passwordService.VerifyPassword(model.Password, _coreService.Config.Password);
+                    if (!isValid)
                     {
-                        _loggingService.Warning(
-                            "SECURITY WARNING: Password is using legacy MD5 hash. " +
-                            "Please generate a new BCrypt hash using /GeneratePasswordHash endpoint and update core.json");
+                        ModelState.AddModelError("Password", "Invalid Password");
+                        return View(model);
                     }
-                    return await PerformLogin(model.RememberMe);
+                    else
+                    {
+                        // Log warning if using legacy MD5 hash - admin should migrate to BCrypt
+                        if (_passwordService.IsLegacyHash(_coreService.Config.Password))
+                        {
+                            _loggingService.Warning(
+                                "SECURITY WARNING: Password is using legacy MD5 hash. " +
+                                "Please generate a new BCrypt hash using /GeneratePasswordHash endpoint and update core.json");
+                        }
+                        // Legacy mode: all authenticated users get Admin role for backward compatibility
+                        return await PerformLogin("user", UserRoles.Admin, model.RememberMe);
+                    }
                 }
             }
             else
@@ -109,12 +144,12 @@ namespace IntelliTrader.Web.Controllers
             return RedirectToAction(nameof(Login));
         }
 
-        private async Task<IActionResult> PerformLogin(bool persistent)
+        private async Task<IActionResult> PerformLogin(string username, string role, bool persistent)
         {
             var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme, ClaimTypes.Name, ClaimTypes.Role);
-            var name = "user";
-            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, name));
-            identity.AddClaim(new Claim(ClaimTypes.Name, name));
+            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, username));
+            identity.AddClaim(new Claim(ClaimTypes.Name, username));
+            identity.AddClaim(new Claim(ClaimTypes.Role, role));
             var principal = new ClaimsPrincipal(identity);
             await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal, new AuthenticationProperties { IsPersistent = persistent });
 
@@ -130,18 +165,18 @@ namespace IntelliTrader.Web.Controllers
 
         /// <summary>
         /// Generates a secure BCrypt hash for a password.
-        /// Use this endpoint to create a hash for core.json configuration.
+        /// Use this endpoint to create a hash for users.json or core.json configuration.
         ///
-        /// SECURITY NOTE: This endpoint requires authentication. Only authenticated
-        /// administrators can generate password hashes.
+        /// SECURITY NOTE: This endpoint requires Admin role.
         ///
         /// USAGE:
         /// 1. POST /GeneratePasswordHash with {"password": "your-new-password"}
-        /// 2. Copy the returned hash to core.json Password field
+        /// 2. Copy the returned hash to users.json PasswordHash field (or core.json Password for legacy mode)
         /// 3. Restart the service
         /// </summary>
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult GeneratePasswordHash([FromForm] string password)
         {
             if (string.IsNullOrEmpty(password))
@@ -168,6 +203,7 @@ namespace IntelliTrader.Web.Controllers
         /// Returns information about the current password hash type.
         /// Useful for administrators to check if migration to BCrypt is needed.
         /// </summary>
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult PasswordStatus()
         {
             var currentHash = _coreService.Config.Password;
@@ -282,6 +318,7 @@ namespace IntelliTrader.Web.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult Settings()
         {
             var model = new SettingsViewModel()
@@ -468,6 +505,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("config")]
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult Settings(SettingsViewModel model)
         {
             _coreService.Config.HealthCheckEnabled = model.HealthCheckEnabled;
@@ -489,6 +527,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("config")]
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult SaveConfig([FromForm] ConfigUpdateModel model)
         {
             if (!ModelState.IsValid)
@@ -509,6 +548,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("trading")]
+        [Authorize(Policy = AuthPolicies.TraderOrAbove)]
         public IActionResult Sell([FromForm] SellInputModel model)
         {
             if (!ModelState.IsValid)
@@ -527,6 +567,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("trading")]
+        [Authorize(Policy = AuthPolicies.TraderOrAbove)]
         public IActionResult Buy([FromForm] BuyInputModel model)
         {
             if (!ModelState.IsValid)
@@ -546,6 +587,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("trading")]
+        [Authorize(Policy = AuthPolicies.TraderOrAbove)]
         public IActionResult BuyDefault([FromForm] BuyDefaultInputModel model)
         {
             if (!ModelState.IsValid)
@@ -569,6 +611,7 @@ namespace IntelliTrader.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [EnableRateLimiting("trading")]
+        [Authorize(Policy = AuthPolicies.TraderOrAbove)]
         public IActionResult Swap([FromForm] SwapInputModel model)
         {
             if (!ModelState.IsValid)
@@ -583,12 +626,14 @@ namespace IntelliTrader.Web.Controllers
             return Ok();
         }
 
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult RefreshAccount()
         {
             _tradingService.Account.Refresh();
             return new OkResult();
         }
 
+        [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult RestartServices()
         {
             _coreService.Restart();

--- a/IntelliTrader.Web/MinimalApiEndpoints.cs
+++ b/IntelliTrader.Web/MinimalApiEndpoints.cs
@@ -1,4 +1,5 @@
 using IntelliTrader.Core;
+using IntelliTrader.Web.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
@@ -98,7 +99,7 @@ namespace IntelliTrader.Web
                 .Produces(StatusCodes.Status503ServiceUnavailable);
 
             var apiGroup = endpoints.MapGroup("/api")
-                .RequireAuthorization()
+                .RequireAuthorization(AuthPolicies.ViewerOrAbove)
                 .RequireRateLimiting("status");
 
             // GET /api/status - Get current trading status

--- a/IntelliTrader.Web/Models/LoginViewModel.cs
+++ b/IntelliTrader.Web/Models/LoginViewModel.cs
@@ -4,9 +4,20 @@ namespace IntelliTrader.Web.Models
 {
     public class LoginViewModel : BaseViewModel
     {
+        /// <summary>
+        /// Username for RBAC login. Optional for legacy single-password mode.
+        /// </summary>
+        public string Username { get; set; }
+
         [Required, DataType(DataType.Password)]
         public string Password { get; set; }
 
         public bool RememberMe { get; set; }
+
+        /// <summary>
+        /// Indicates whether the system uses RBAC (users.json) or legacy single-password mode.
+        /// Set by the controller to control view rendering.
+        /// </summary>
+        public bool UsesRbac { get; set; }
     }
 }

--- a/IntelliTrader.Web/Models/UserConfig.cs
+++ b/IntelliTrader.Web/Models/UserConfig.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace IntelliTrader.Web.Models
+{
+    /// <summary>
+    /// Represents a user with role-based access control.
+    /// Users are defined in config/users.json.
+    /// </summary>
+    public class UserConfig
+    {
+        /// <summary>
+        /// Unique username for authentication.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// BCrypt-hashed password. Generate using POST /GeneratePasswordHash.
+        /// </summary>
+        public string PasswordHash { get; set; }
+
+        /// <summary>
+        /// Role determining access level: Admin, Trader, or Viewer.
+        /// </summary>
+        public string Role { get; set; }
+    }
+
+    /// <summary>
+    /// Root configuration object for users.json.
+    /// </summary>
+    public class UsersConfig
+    {
+        public List<UserConfig> Users { get; set; } = new List<UserConfig>();
+    }
+
+    /// <summary>
+    /// Defines the available roles for RBAC.
+    /// </summary>
+    public static class UserRoles
+    {
+        public const string Admin = "Admin";
+        public const string Trader = "Trader";
+        public const string Viewer = "Viewer";
+
+        /// <summary>
+        /// All valid role names.
+        /// </summary>
+        public static readonly string[] All = { Admin, Trader, Viewer };
+    }
+
+    /// <summary>
+    /// Defines authorization policy names used throughout the application.
+    /// </summary>
+    public static class AuthPolicies
+    {
+        public const string AdminOnly = "AdminOnly";
+        public const string TraderOrAbove = "TraderOrAbove";
+        public const string ViewerOrAbove = "ViewerOrAbove";
+    }
+}

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -4,6 +4,7 @@ using IntelliTrader.Infrastructure.Telemetry;
 using IntelliTrader.Web.BackgroundServices;
 using IntelliTrader.Web.Hubs;
 using IntelliTrader.Web.Middleware;
+using IntelliTrader.Web.Models;
 using IntelliTrader.Web.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
@@ -18,6 +19,7 @@ using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Threading.RateLimiting;
 
 namespace IntelliTrader.Web
@@ -70,6 +72,35 @@ namespace IntelliTrader.Web
             {
                 options.LoginPath = "/Login";
                 options.Cookie.Name = $"{nameof(IntelliTrader)}_{coreService.Config.InstanceName}";
+            });
+
+            // Load users.json for RBAC if it exists, otherwise fall back to legacy single-password mode
+            var usersConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config", "users.json");
+            UsersConfig usersConfig = null;
+            if (File.Exists(usersConfigPath))
+            {
+                try
+                {
+                    var usersJson = File.ReadAllText(usersConfigPath);
+                    usersConfig = JsonSerializer.Deserialize<UsersConfig>(usersJson, new JsonSerializerOptions
+                    {
+                        PropertyNameCaseInsensitive = true
+                    });
+                }
+                catch
+                {
+                    // If users.json is malformed, fall back to legacy mode
+                    usersConfig = null;
+                }
+            }
+            services.AddSingleton(usersConfig ?? new UsersConfig());
+
+            // Configure role-based authorization policies
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy(AuthPolicies.AdminOnly, p => p.RequireRole(UserRoles.Admin));
+                options.AddPolicy(AuthPolicies.TraderOrAbove, p => p.RequireRole(UserRoles.Admin, UserRoles.Trader));
+                options.AddPolicy(AuthPolicies.ViewerOrAbove, p => p.RequireRole(UserRoles.Admin, UserRoles.Trader, UserRoles.Viewer));
             });
 
             services.AddControllersWithViews()

--- a/IntelliTrader.Web/Views/Home/Login.cshtml
+++ b/IntelliTrader.Web/Views/Home/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@model LoginViewModel
+@model LoginViewModel
 @{
     ViewData["Title"] = "Login";
 }
@@ -6,6 +6,13 @@
 <div style="clear: both; width: 300px;">
     <form method="post">
         <div asp-validation-summary="All" class="text-danger"></div>
+        @if (Model.UsesRbac)
+        {
+            <div class="form-group">
+                <label for="Username">Username </label>
+                @Html.TextBoxFor(m => m.Username, new { @class = "form-control", autocomplete = "username" })
+            </div>
+        }
         <div class="form-group">
             <label for="Password">Password </label>
             @Html.PasswordFor(m => m.Password, new { @class = "form-control" })
@@ -16,6 +23,7 @@
                 Remember Me
              </label>
         </div>
+        @Html.HiddenFor(m => m.UsesRbac)
         <br />
         <button type="submit" class="btn btn-primary">Login</button>
         @Html.AntiForgeryToken()

--- a/IntelliTrader/config/users.json
+++ b/IntelliTrader/config/users.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Role-Based Access Control configuration. Roles: Admin (full access), Trader (trading operations), Viewer (read-only dashboard). Generate password hashes using POST /GeneratePasswordHash after logging in as Admin.",
+  "Users": [
+    {
+      "Username": "admin",
+      "PasswordHash": "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/X4/jJrZk.oB8C6.Hy",
+      "Role": "Admin"
+    }
+  ]
+}

--- a/tests/IntelliTrader.Web.Tests/HomeControllerTests.cs
+++ b/tests/IntelliTrader.Web.Tests/HomeControllerTests.cs
@@ -90,7 +90,8 @@ public class HomeControllerTests
             _healthCheckServiceMock.Object,
             _passwordServiceMock.Object,
             _configProviderMock.Object,
-            _configurableServices);
+            _configurableServices,
+            new UsersConfig());
 
         // Setup HttpContext for controller
         var httpContext = new DefaultHttpContext();
@@ -114,7 +115,8 @@ public class HomeControllerTests
             _healthCheckServiceMock.Object,
             _passwordServiceMock.Object,
             _configProviderMock.Object,
-            _configurableServices);
+            _configurableServices,
+            new UsersConfig());
 
         // Assert
         act.Should().Throw<ArgumentNullException>().WithParameterName("coreService");
@@ -132,7 +134,8 @@ public class HomeControllerTests
             _healthCheckServiceMock.Object,
             _passwordServiceMock.Object,
             _configProviderMock.Object,
-            _configurableServices);
+            _configurableServices,
+            new UsersConfig());
 
         // Assert
         act.Should().Throw<ArgumentNullException>().WithParameterName("tradingService");
@@ -150,7 +153,8 @@ public class HomeControllerTests
             _healthCheckServiceMock.Object,
             null!,
             _configProviderMock.Object,
-            _configurableServices);
+            _configurableServices,
+            new UsersConfig());
 
         // Assert
         act.Should().Throw<ArgumentNullException>().WithParameterName("passwordService");


### PR DESCRIPTION
## Summary
- Implement RBAC with three roles: **Admin** (full access), **Trader** (trading operations), **Viewer** (read-only dashboard)
- Users defined in `config/users.json` with BCrypt-hashed passwords and role assignment
- Full backward compatibility: if `users.json` is absent or empty, falls back to legacy single-password mode from `core.json` (all authenticated users get Admin role)

## Changes
- **Created** `IntelliTrader.Web/Models/UserConfig.cs` — user model, roles constants, policy names
- **Created** `IntelliTrader/config/users.json` — default admin user config
- **Modified** `IntelliTrader.Web/Startup.cs` — loads `users.json`, registers authorization policies (AdminOnly, TraderOrAbove, ViewerOrAbove)
- **Modified** `IntelliTrader.Web/Controllers/HomeController.cs` — RBAC login flow with username, policy attributes on all actions
- **Modified** `IntelliTrader.Web/MinimalApiEndpoints.cs` — API group uses `ViewerOrAbove` policy
- **Modified** `IntelliTrader.Web/Models/LoginViewModel.cs` — added Username and UsesRbac fields
- **Modified** `IntelliTrader.Web/Views/Home/Login.cshtml` — conditional username field for RBAC mode

## Policy Mapping
| Action | Policy |
|--------|--------|
| Dashboard, Market, Stats, Trades, Log, Help, Status, API endpoints | ViewerOrAbove |
| Buy, Sell, Swap, BuyDefault | TraderOrAbove |
| Settings, SaveConfig, RestartServices, RefreshAccount, GeneratePasswordHash, PasswordStatus | AdminOnly |
| Login, Logout, Health endpoints | Anonymous |

## Test plan
- [ ] Verify existing setups without `users.json` still work (legacy mode, Admin role assigned)
- [ ] Verify login with username/password when `users.json` is present
- [ ] Verify Viewer role can access dashboard but cannot trade or change settings
- [ ] Verify Trader role can trade but cannot access settings/restart
- [ ] Verify Admin role has full access
- [ ] Verify health endpoints remain anonymous
- [ ] Verify malformed `users.json` gracefully falls back to legacy mode

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)