### PR TITLE
refactor(core): remove service locator pattern

### DIFF
--- a/IntelliTrader.Backtesting/AppModule.cs
+++ b/IntelliTrader.Backtesting/AppModule.cs
@@ -1,6 +1,5 @@
 using Autofac;
 using IntelliTrader.Core;
-using System;
 
 namespace IntelliTrader.Backtesting
 {
@@ -14,12 +13,10 @@ namespace IntelliTrader.Backtesting
                 .Named<IConfigurableService>(Constants.ServiceNames.BacktestingService)
                 .SingleInstance();
 
-            // Access config through the static facade during module registration.
-            // The facade is initialized by ApplicationBootstrapper before module loading,
-            // ensuring the same IConfigProvider instance is used throughout the application.
-#pragma warning disable CS0618 // Suppress obsolete warning - this is a known transitional usage
-            var backtestingConfig = Application.ConfigProvider.GetSection<BacktestingConfig>(Constants.ServiceNames.BacktestingService);
-#pragma warning restore CS0618
+            // Access config through builder properties set by ApplicationBootstrapper,
+            // avoiding the static Application facade (service locator pattern).
+            var configProvider = (IConfigProvider)builder.Properties[nameof(IConfigProvider)];
+            var backtestingConfig = configProvider.GetSection<BacktestingConfig>(Constants.ServiceNames.BacktestingService);
 
             if (backtestingConfig.Enabled && backtestingConfig.Replay)
             {

--- a/IntelliTrader.Core/Application.cs
+++ b/IntelliTrader.Core/Application.cs
@@ -1,90 +1,12 @@
-using Autofac;
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-
 namespace IntelliTrader.Core
 {
     /// <summary>
-    /// Static application facade providing backward compatibility during the transition to DI.
-    ///
-    /// MIGRATION GUIDE:
-    /// - Use IApplicationBootstrapper for building containers (inject or use ApplicationBootstrapper directly)
-    /// - Use IConfigProvider injected via constructor instead of Application.ConfigProvider
-    /// - Use IApplicationContext injected via constructor instead of Application.Speed
-    ///
-    /// The static members are marked as [Obsolete] to encourage migration to the DI-based approach.
+    /// Retained as a marker class for the IntelliTrader.Core assembly.
+    /// All service-locator members (Resolve, ConfigProvider, Speed, BuildContainer)
+    /// have been removed. Use constructor injection and IApplicationBootstrapper instead.
+    /// See ADR-0015 for details.
     /// </summary>
-    public class Application
+    public static class Application
     {
-        // Backing instances - initialized during bootstrapping
-        private static IConfigProvider _configProvider;
-        private static IApplicationContext _applicationContext;
-
-        /// <summary>
-        /// Gets the configuration provider.
-        /// Prefer using IConfigProvider via dependency injection instead.
-        /// </summary>
-        [Obsolete("Use IConfigProvider via dependency injection instead. This static accessor will be removed in a future version.")]
-        public static IConfigProvider ConfigProvider
-        {
-            get
-            {
-                // Lazy initialization for backward compatibility during bootstrap
-                if (_configProvider == null)
-                {
-                    _configProvider = new ConfigProvider();
-                }
-                return _configProvider;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the speed multiplier.
-        /// Prefer using IApplicationContext via dependency injection instead.
-        /// </summary>
-        [Obsolete("Use IApplicationContext.Speed via dependency injection instead. This static accessor will be removed in a future version.")]
-        public static double Speed
-        {
-            get => _applicationContext?.Speed ?? 1;
-            set
-            {
-                if (_applicationContext != null)
-                {
-                    _applicationContext.Speed = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Initializes the static facade with the DI-resolved instances.
-        /// Called by ApplicationBootstrapper after building the container.
-        /// </summary>
-        /// <param name="configProvider">The config provider instance</param>
-        /// <param name="applicationContext">The application context instance</param>
-        internal static void Initialize(IConfigProvider configProvider, IApplicationContext applicationContext)
-        {
-            _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
-            _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
-        }
-
-        /// <summary>
-        /// Builds and returns the DI container. Call this once at application startup.
-        /// Prefer using IApplicationBootstrapper instead.
-        /// </summary>
-        /// <returns>The built Autofac container</returns>
-        [Obsolete("Use IApplicationBootstrapper.BuildContainer() instead. This static method will be removed in a future version.")]
-        public static IContainer BuildContainer()
-        {
-            var bootstrapper = new ApplicationBootstrapper();
-            var container = bootstrapper.BuildContainer();
-
-            // Initialize the static facade with the bootstrapper's instances
-            Initialize(bootstrapper.ConfigProvider, bootstrapper.ApplicationContext);
-
-            return container;
-        }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IApplicationBootstrapper.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IApplicationBootstrapper.cs
@@ -4,7 +4,6 @@ namespace IntelliTrader.Core
 {
     /// <summary>
     /// Interface for building and configuring the DI container.
-    /// Replaces the static Application.BuildContainer() method.
     /// </summary>
     public interface IApplicationBootstrapper
     {

--- a/IntelliTrader.Core/Interfaces/Services/IApplicationContext.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IApplicationContext.cs
@@ -2,7 +2,6 @@ namespace IntelliTrader.Core
 {
     /// <summary>
     /// Provides application-wide runtime context such as speed multiplier for backtesting.
-    /// Replaces the static Application.Speed property.
     /// </summary>
     public interface IApplicationContext
     {

--- a/IntelliTrader.Core/Services/ApplicationBootstrapper.cs
+++ b/IntelliTrader.Core/Services/ApplicationBootstrapper.cs
@@ -9,7 +9,6 @@ namespace IntelliTrader.Core
 {
     /// <summary>
     /// Builds and configures the Autofac DI container.
-    /// Replaces the static Application.BuildContainer() method.
     /// </summary>
     public class ApplicationBootstrapper : IApplicationBootstrapper
     {
@@ -54,15 +53,15 @@ namespace IntelliTrader.Core
         /// <inheritdoc/>
         public IContainer BuildContainer(Action<ContainerBuilder> configureBuilder)
         {
-            // Initialize the static Application facade before module registration
-            // This ensures modules can access config during registration (backward compatibility)
-            Application.Initialize(_configProvider, _applicationContext);
-
             var builder = new ContainerBuilder();
 
             // Register the singleton instances created during bootstrapping
             builder.RegisterInstance(_configProvider).As<IConfigProvider>().SingleInstance();
             builder.RegisterInstance(_applicationContext).As<IApplicationContext>().SingleInstance();
+
+            // Expose the config provider via builder properties so modules can access
+            // configuration at registration time without using the static Application facade.
+            builder.Properties[nameof(IConfigProvider)] = _configProvider;
 
             // Discover and register all IntelliTrader modules
             var assemblyPattern = new Regex($"{nameof(IntelliTrader)}.*.dll");

--- a/IntelliTrader.Core/Services/ApplicationContext.cs
+++ b/IntelliTrader.Core/Services/ApplicationContext.cs
@@ -2,7 +2,6 @@ namespace IntelliTrader.Core
 {
     /// <summary>
     /// Provides application-wide runtime context.
-    /// Replaces the static Application.Speed property.
     /// </summary>
     public class ApplicationContext : IApplicationContext
     {

--- a/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
+++ b/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
@@ -1,8 +1,5 @@
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace IntelliTrader.Core
 {
@@ -22,25 +19,12 @@ namespace IntelliTrader.Core
         protected virtual ILoggingService LoggingService => null;
 
         /// <summary>
-        /// Gets the config provider. Derived classes should override this to provide
-        /// the injected config provider. Returns the static fallback by default for backward compatibility.
+        /// Gets the config provider injected via constructor.
         /// </summary>
-#pragma warning disable CS0618 // Suppress obsolete warning - this is intentional backward compatibility
-        protected virtual IConfigProvider ConfigProvider => _configProvider ?? Application.ConfigProvider;
-#pragma warning restore CS0618
-
-        /// <summary>
-        /// Default constructor for backward compatibility.
-        /// Services should migrate to use the constructor that accepts IConfigProvider.
-        /// </summary>
-        protected ConfigurableServiceBase()
-        {
-            _configProvider = null;
-        }
+        protected IConfigProvider ConfigProvider => _configProvider;
 
         /// <summary>
         /// Constructor that accepts an injected IConfigProvider.
-        /// Preferred constructor for proper DI usage.
         /// </summary>
         /// <param name="configProvider">The configuration provider</param>
         protected ConfigurableServiceBase(IConfigProvider configProvider)

--- a/IntelliTrader.Rules/Specifications/ConditionContext.cs
+++ b/IntelliTrader.Rules/Specifications/ConditionContext.cs
@@ -32,7 +32,7 @@ namespace IntelliTrader.Rules.Specifications
         public ITradingPair? TradingPair { get; }
 
         /// <summary>
-        /// The speed multiplier from Application.Speed for age calculations.
+        /// The speed multiplier for age calculations.
         /// </summary>
         public double Speed { get; }
 

--- a/docs/ADRs/ADR-0015-remove-service-locator-pattern.md
+++ b/docs/ADRs/ADR-0015-remove-service-locator-pattern.md
@@ -1,0 +1,69 @@
+# ADR-0015: Remove Service Locator Pattern
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-11
+
+## Context
+
+The codebase historically used a static `Application` class as a service locator, exposing
+`Application.Resolve<T>()`, `Application.ConfigProvider`, `Application.Speed`, and
+`Application.BuildContainer()`. A prior refactor (commit 5f44984) migrated most services to
+constructor injection, and PR #41 resolved resulting DI cycles with `Lazy<T>`. However,
+several residual usages of the static facade remained:
+
+- `Application.ConfigProvider` in `ConfigurableServiceBase` (fallback for a parameterless constructor)
+- `Application.ConfigProvider` in `IntelliTrader.Backtesting.AppModule` (registration-time config access)
+- `Application.Speed` in `TestableRulesService` (test double)
+- `Application.Initialize()` called from `ApplicationBootstrapper` to seed the static fields
+
+These usages kept the service locator pattern alive, making the dependency graph implicit and
+harder to test.
+
+## Decision
+
+Remove all static service-locator members from the `Application` class and replace every
+remaining usage with explicit dependency injection:
+
+1. **`ConfigurableServiceBase`** -- Remove the parameterless constructor and the
+   `Application.ConfigProvider` fallback. All concrete services already use the
+   `ConfigurableServiceBase(IConfigProvider)` constructor, so the fallback was dead code.
+
+2. **`Backtesting.AppModule`** -- Replace `Application.ConfigProvider` with
+   `builder.Properties[nameof(IConfigProvider)]`, a dictionary entry set by
+   `ApplicationBootstrapper` before module scanning. This is the idiomatic Autofac mechanism
+   for passing context to modules during registration.
+
+3. **Test doubles** -- Replace `Application.Speed` with an injected `IApplicationContext`
+   mock, matching how the production `RulesService` already works.
+
+4. **`ApplicationBootstrapper`** -- Remove the `Application.Initialize()` call. The static
+   facade is no longer seeded because nothing reads from it.
+
+5. **`Application` class** -- Strip all members. Retained as an empty static class / assembly
+   marker with a doc-comment pointing to this ADR.
+
+## Consequences
+
+### Positive
+
+- All dependencies are explicit and visible in constructor signatures.
+- No static mutable state; services are fully testable in isolation.
+- The Autofac container is the single source of truth for the object graph.
+- Removes the `[Obsolete]` suppression pragmas that were scattered across the codebase.
+
+### Negative
+
+- Autofac modules that need configuration at registration time must read from
+  `builder.Properties` instead of a convenient static accessor. This is a minor ergonomic
+  trade-off.
+
+### Neutral
+
+- `Program.cs` and `Web/Startup.cs` still call `container.Resolve<T>()` at the composition
+  root, which is standard and expected -- the service locator anti-pattern only applies when
+  resolution happens inside application services.

--- a/tests/IntelliTrader.Backtesting.Tests/BacktestingServiceTests.cs
+++ b/tests/IntelliTrader.Backtesting.Tests/BacktestingServiceTests.cs
@@ -11,9 +11,7 @@ namespace IntelliTrader.Backtesting.Tests;
 
 /// <summary>
 /// Tests for IBacktestingService interface behavior and BacktestingService functionality.
-/// Since BacktestingService depends on static Application.ConfigProvider, these tests
-/// focus on testing the interface contract and behavior through mocks where direct
-/// instantiation is not possible.
+/// These tests focus on testing the interface contract and behavior through mocks.
 /// </summary>
 public class BacktestingServiceInterfaceTests
 {

--- a/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
+++ b/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
@@ -343,7 +343,6 @@ public class CoreServiceTests
     #region Service Lifecycle Start Tests
 
     // Note: The following tests require the config directory to exist and are marked as integration tests.
-    // They test the full service lifecycle which depends on the Application.ConfigProvider static class.
     // To run these tests, ensure the config directory exists at the test output location.
 
     [Fact(Skip = "Requires config directory - integration test")]

--- a/tests/IntelliTrader.Rules.Tests/RulesServiceTests.cs
+++ b/tests/IntelliTrader.Rules.Tests/RulesServiceTests.cs
@@ -10,11 +10,14 @@ namespace IntelliTrader.Rules.Tests;
 public class RulesServiceTests
 {
     private readonly Mock<ILoggingService> _loggingServiceMock;
+    private readonly Mock<IApplicationContext> _applicationContextMock;
     private readonly TestableRulesService _sut;
 
     public RulesServiceTests()
     {
         _loggingServiceMock = new Mock<ILoggingService>();
+        _applicationContextMock = new Mock<IApplicationContext>();
+        _applicationContextMock.Setup(x => x.Speed).Returns(1);
         _sut = CreateRulesServiceWithConfig(CreateDefaultConfig());
     }
 
@@ -22,7 +25,7 @@ public class RulesServiceTests
 
     private TestableRulesService CreateRulesServiceWithConfig(IRulesConfig config)
     {
-        var service = new TestableRulesService(_loggingServiceMock.Object);
+        var service = new TestableRulesService(_loggingServiceMock.Object, _applicationContextMock.Object);
         service.SetConfig(config);
         return service;
     }
@@ -1074,11 +1077,13 @@ internal class TestableRulesService : IRulesService
     public IRulesConfig Config { get; private set; } = null!;
 
     private readonly ILoggingService _loggingService;
+    private readonly IApplicationContext _applicationContext;
     private readonly List<Action> _rulesChangeCallbacks = new List<Action>();
 
-    public TestableRulesService(ILoggingService loggingService)
+    public TestableRulesService(ILoggingService loggingService, IApplicationContext applicationContext)
     {
         _loggingService = loggingService;
+        _applicationContext = applicationContext;
     }
 
     public IConfigurationSection RawConfig => throw new NotImplementedException();
@@ -1124,10 +1129,10 @@ internal class TestableRulesService : IRulesService
                 condition.MaxGlobalRating != null && (globalRating == null || globalRating > condition.MaxGlobalRating) ||
                 condition.Pairs != null && (pair == null || !condition.Pairs.Contains(pair)) ||
 
-                condition.MinAge != null && (tradingPair == null || tradingPair.CurrentAge < condition.MinAge / Application.Speed) ||
-                condition.MaxAge != null && (tradingPair == null || tradingPair.CurrentAge > condition.MaxAge / Application.Speed) ||
-                condition.MinLastBuyAge != null && (tradingPair == null || tradingPair.LastBuyAge < condition.MinLastBuyAge / Application.Speed) ||
-                condition.MaxLastBuyAge != null && (tradingPair == null || tradingPair.LastBuyAge > condition.MaxLastBuyAge / Application.Speed) ||
+                condition.MinAge != null && (tradingPair == null || tradingPair.CurrentAge < condition.MinAge / _applicationContext.Speed) ||
+                condition.MaxAge != null && (tradingPair == null || tradingPair.CurrentAge > condition.MaxAge / _applicationContext.Speed) ||
+                condition.MinLastBuyAge != null && (tradingPair == null || tradingPair.LastBuyAge < condition.MinLastBuyAge / _applicationContext.Speed) ||
+                condition.MaxLastBuyAge != null && (tradingPair == null || tradingPair.LastBuyAge > condition.MaxLastBuyAge / _applicationContext.Speed) ||
                 condition.MinMargin != null && (tradingPair == null || tradingPair.CurrentMargin < condition.MinMargin) ||
                 condition.MaxMargin != null && (tradingPair == null || tradingPair.CurrentMargin > condition.MaxMargin) ||
                 condition.MinMarginChange != null && (tradingPair == null || tradingPair.Metadata.LastBuyMargin == null || (tradingPair.CurrentMargin - tradingPair.Metadata.LastBuyMargin) < condition.MinMarginChange) ||


### PR DESCRIPTION
## Summary

- Remove all static members from the `Application` class (`ConfigProvider`, `Speed`, `BuildContainer`, `Initialize`)
- Replace `Application.ConfigProvider` in `Backtesting.AppModule` with `builder.Properties` (idiomatic Autofac)
- Remove the parameterless `ConfigurableServiceBase` constructor and its `Application.ConfigProvider` fallback
- Update `TestableRulesService` to use injected `IApplicationContext` instead of `Application.Speed`
- Remove `Application.Initialize()` call from `ApplicationBootstrapper`
- Add ADR-0015 documenting the migration decision

Closes #20

## Test plan

- [ ] CI build passes (no compilation errors from removed members)
- [ ] All existing tests pass (RulesServiceTests now use mock IApplicationContext)
- [ ] Backtesting module correctly resolves config via builder.Properties
- [ ] No remaining references to Application.ConfigProvider, Application.Speed, or Application.Resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)