### PR TITLE
docs: add XML documentation comments to public API interfaces

### DIFF
--- a/IntelliTrader.Application/IntelliTrader.Application.csproj
+++ b/IntelliTrader.Application/IntelliTrader.Application.csproj
@@ -8,6 +8,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/IntelliTrader.Core/IntelliTrader.Core.csproj
+++ b/IntelliTrader.Core/IntelliTrader.Core.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>0.9.9.2</AssemblyVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IntelliTrader.Core/Interfaces/Configs/IAlertingConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IAlertingConfig.cs
@@ -4,15 +4,49 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the alerting subsystem that monitors trading health and notifies on anomalies.
+    /// </summary>
     public interface IAlertingConfig
     {
+        /// <summary>
+        /// Whether the alerting subsystem is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Interval in seconds between alert checks.
+        /// </summary>
         int CheckIntervalSeconds { get; }
+
+        /// <summary>
+        /// Whether to raise an alert when trading is suspended.
+        /// </summary>
         bool TradingSuspendedAlert { get; }
+
+        /// <summary>
+        /// Number of consecutive health check failures before triggering an alert.
+        /// </summary>
         int HealthCheckFailureThreshold { get; }
+
+        /// <summary>
+        /// Number of minutes after which a signal is considered stale and triggers an alert.
+        /// </summary>
         int SignalStalenessMinutes { get; }
+
+        /// <summary>
+        /// Whether connectivity-related alerts are enabled.
+        /// </summary>
         bool ConnectivityAlertEnabled { get; }
+
+        /// <summary>
+        /// Number of consecutive order failures before triggering an alert.
+        /// </summary>
         int ConsecutiveOrderFailureThreshold { get; }
+
+        /// <summary>
+        /// Error rate threshold (0.0-1.0) above which an alert is raised.
+        /// </summary>
         double HighErrorRateThreshold { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/IBacktestingConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IBacktestingConfig.cs
@@ -1,21 +1,67 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for backtesting mode, which replays historical snapshots to simulate trading.
+    /// </summary>
     public interface IBacktestingConfig
     {
+        /// <summary>
+        /// Whether backtesting mode is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Whether to replay historical snapshots.
+        /// </summary>
         bool Replay { get; }
+
+        /// <summary>
+        /// Whether to output detailed replay information during backtesting.
+        /// </summary>
         bool ReplayOutput { get; }
+
+        /// <summary>
+        /// Speed multiplier for replay (e.g., 2.0 replays at double speed).
+        /// </summary>
         double ReplaySpeed { get; }
+
+        /// <summary>
+        /// Optional starting snapshot index for partial replay.
+        /// </summary>
         int? ReplayStartIndex { get; }
+
+        /// <summary>
+        /// Optional ending snapshot index for partial replay.
+        /// </summary>
         int? ReplayEndIndex { get; }
+
+        /// <summary>
+        /// Whether to delete existing log files before starting backtesting.
+        /// </summary>
         bool DeleteLogs { get; }
+
+        /// <summary>
+        /// Whether to delete existing account data before starting backtesting.
+        /// </summary>
         bool DeleteAccountData { get; }
+
+        /// <summary>
+        /// File path to copy account data from before starting backtesting.
+        /// </summary>
         string CopyAccountDataPath { get; }
+
+        /// <summary>
+        /// Interval in seconds between snapshot captures.
+        /// </summary>
         int SnapshotsInterval { get; }
+
+        /// <summary>
+        /// Directory path where snapshots are stored.
+        /// </summary>
         string SnapshotsPath { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/ICachingConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/ICachingConfig.cs
@@ -1,15 +1,37 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the caching subsystem that stores and reuses frequently accessed data.
+    /// </summary>
     public interface ICachingConfig
     {
+        /// <summary>
+        /// Whether caching is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Whether to use a shared cache across multiple instances.
+        /// </summary>
         bool Shared { get; }
+
+        /// <summary>
+        /// File system path for the shared cache storage.
+        /// </summary>
         string SharedCachePath { get; }
+
+        /// <summary>
+        /// Interval in seconds between shared cache cleanup operations.
+        /// </summary>
         double SharedCacheCleanupInterval { get; }
+
+        /// <summary>
+        /// Maximum age (in seconds) for cached items, keyed by cache object name.
+        /// </summary>
         IEnumerable<KeyValuePair<string, double>> MaxAge { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/IConfigProvider.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IConfigProvider.cs
@@ -1,15 +1,44 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Provides access to application configuration sections with support for hot-reload and change notifications.
+    /// </summary>
     public interface IConfigProvider
     {
+        /// <summary>
+        /// Gets the raw JSON string for a configuration section.
+        /// </summary>
+        /// <param name="sectionName">The name of the configuration section.</param>
+        /// <returns>The JSON string representation of the section.</returns>
         string GetSectionJson(string sectionName);
+
+        /// <summary>
+        /// Sets the raw JSON string for a configuration section.
+        /// </summary>
+        /// <param name="sectionName">The name of the configuration section.</param>
+        /// <param name="definition">The JSON string to set.</param>
         void SetSectionJson(string sectionName, string definition);
+
+        /// <summary>
+        /// Gets a configuration section with an optional change callback for hot-reload.
+        /// </summary>
+        /// <param name="sectionName">The name of the configuration section.</param>
+        /// <param name="onChange">Optional callback invoked when the section changes.</param>
+        /// <returns>The configuration section.</returns>
         IConfigurationSection GetSection(string sectionName, Action<IConfigurationSection> onChange = null);
+
+        /// <summary>
+        /// Gets a strongly-typed configuration section with an optional change callback for hot-reload.
+        /// </summary>
+        /// <typeparam name="T">The type to bind the configuration section to.</typeparam>
+        /// <param name="sectionName">The name of the configuration section.</param>
+        /// <param name="onChange">Optional callback invoked with the updated configuration when the section changes.</param>
+        /// <returns>The bound configuration object.</returns>
         T GetSection<T>(string sectionName, Action<T> onChange = null) where T : class;
 
         /// <summary>

--- a/IntelliTrader.Core/Interfaces/Configs/ICoreConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/ICoreConfig.cs
@@ -1,19 +1,57 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Core application configuration controlling debug mode, authentication, and health checks.
+    /// </summary>
     public interface ICoreConfig
     {
+        /// <summary>
+        /// Whether debug mode is enabled, providing additional logging and diagnostics.
+        /// </summary>
         bool DebugMode { get; }
+
+        /// <summary>
+        /// Whether the web dashboard requires password authentication.
+        /// </summary>
         bool PasswordProtected { get; }
+
+        /// <summary>
+        /// The password hash used for web dashboard authentication.
+        /// </summary>
         string Password { get; }
+
+        /// <summary>
+        /// Display name for this bot instance, used in notifications and the dashboard.
+        /// </summary>
         string InstanceName { get; }
+
+        /// <summary>
+        /// Timezone offset in hours from UTC for display purposes.
+        /// </summary>
         double TimezoneOffset { get; }
+
+        /// <summary>
+        /// Whether periodic health checks are enabled.
+        /// </summary>
         bool HealthCheckEnabled { get; set; }
+
+        /// <summary>
+        /// Interval in seconds between health check evaluations.
+        /// </summary>
         double HealthCheckInterval { get; }
+
+        /// <summary>
+        /// Time in seconds after which trading is suspended if a health check fails continuously.
+        /// </summary>
         double HealthCheckSuspendTradingTimeout { get; }
+
+        /// <summary>
+        /// Number of consecutive health check failures that trigger a service restart.
+        /// </summary>
         int HealthCheckFailuresToRestartServices { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/ILoggingConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/ILoggingConfig.cs
@@ -4,8 +4,14 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the logging subsystem including structured JSON output.
+    /// </summary>
     public interface ILoggingConfig
     {
+        /// <summary>
+        /// Whether logging is enabled.
+        /// </summary>
         bool Enabled { get; }
 
         /// <summary>

--- a/IntelliTrader.Core/Interfaces/Configs/INotificationConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/INotificationConfig.cs
@@ -1,15 +1,37 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the notification subsystem that sends alerts via Telegram.
+    /// </summary>
     public interface INotificationConfig
     {
+        /// <summary>
+        /// Whether the notification subsystem is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Whether Telegram notifications are enabled.
+        /// </summary>
         bool TelegramEnabled { get; }
+
+        /// <summary>
+        /// The Telegram bot API token used for sending messages.
+        /// </summary>
         string TelegramBotToken { get; }
+
+        /// <summary>
+        /// The Telegram chat ID to send notifications to.
+        /// </summary>
         long TelegramChatId { get; }
+
+        /// <summary>
+        /// Whether alert-type Telegram notifications are enabled (e.g., health check failures).
+        /// </summary>
         bool TelegramAlertsEnabled { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/IRulesConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IRulesConfig.cs
@@ -1,11 +1,17 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration containing the set of rule modules used for signal and trading evaluation.
+    /// </summary>
     public interface IRulesConfig
     {
+        /// <summary>
+        /// The collection of rule modules (e.g., signal rules, trading rules) with their entries and configurations.
+        /// </summary>
         IEnumerable<IModuleRules> Modules { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/ISignalsConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/ISignalsConfig.cs
@@ -1,13 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the signal acquisition subsystem that collects and aggregates trading signals.
+    /// </summary>
     public interface ISignalsConfig
     {
+        /// <summary>
+        /// Whether signal processing is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Names of signals used to compute the global market rating.
+        /// </summary>
         IEnumerable<string> GlobalRatingSignals { get; }
+
+        /// <summary>
+        /// Signal source definitions specifying receivers and their configurations.
+        /// </summary>
         IEnumerable<ISignalDefinition> Definitions { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Configs/ITradingConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/ITradingConfig.cs
@@ -4,26 +4,89 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Master trading configuration combining buy, sell, and DCA settings with exchange and account parameters.
+    /// </summary>
     public interface ITradingConfig : IBuyConfig, IBuyDCAConfig, ISellConfig, ISellDCAConfig
     {
+        /// <summary>
+        /// Whether trading is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// The market to trade on (e.g., "BTC", "USDT").
+        /// </summary>
         string Market { get; }
+
+        /// <summary>
+        /// The exchange identifier (e.g., "Binance").
+        /// </summary>
         string Exchange { get; }
+
+        /// <summary>
+        /// Maximum number of concurrent trading pairs allowed.
+        /// </summary>
         int MaxPairs { get; }
+
+        /// <summary>
+        /// Minimum order cost in market currency (orders below this are rejected by the exchange).
+        /// </summary>
         decimal MinCost { get; }
+
+        /// <summary>
+        /// Trading pairs excluded from signal evaluation and trading.
+        /// </summary>
         List<string> ExcludedPairs { get; }
 
+        /// <summary>
+        /// Whether to repeat the last DCA level configuration for additional DCA levels beyond those defined.
+        /// </summary>
         bool RepeatLastDCALevel { get; }
+
+        /// <summary>
+        /// The configured DCA levels with their margin thresholds and multipliers.
+        /// </summary>
         List<DCALevel> DCALevels { get; }
 
+        /// <summary>
+        /// Interval in seconds between trading rule evaluations.
+        /// </summary>
         double TradingCheckInterval { get; }
+
+        /// <summary>
+        /// Interval in seconds between account balance refreshes.
+        /// </summary>
         double AccountRefreshInterval { get; }
+
+        /// <summary>
+        /// The initial account balance for profit tracking.
+        /// </summary>
         decimal AccountInitialBalance { get; }
+
+        /// <summary>
+        /// The date of the initial account balance for profit tracking.
+        /// </summary>
         DateTimeOffset AccountInitialBalanceDate { get; }
+
+        /// <summary>
+        /// File path for persisting account state (positions and orders).
+        /// </summary>
         string AccountFilePath { get; }
 
+        /// <summary>
+        /// Whether to use virtual (paper) trading instead of live trading.
+        /// </summary>
         bool VirtualTrading { get; }
+
+        /// <summary>
+        /// Initial balance for the virtual trading account.
+        /// </summary>
         decimal VirtualAccountInitialBalance { get; }
+
+        /// <summary>
+        /// File path for persisting virtual account state.
+        /// </summary>
         string VirtualAccountFilePath { get; }
 
         /// <summary>
@@ -42,6 +105,10 @@ namespace IntelliTrader.Core
         /// </summary>
         PositionSizingConfig PositionSizing { get; }
 
+        /// <summary>
+        /// Creates a deep copy of this trading configuration.
+        /// </summary>
+        /// <returns>A new instance with identical settings.</returns>
         ITradingConfig Clone();
 
     }

--- a/IntelliTrader.Core/Interfaces/Configs/IWebConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IWebConfig.cs
@@ -1,13 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for the ASP.NET Core web dashboard.
+    /// </summary>
     public interface IWebConfig
     {
+        /// <summary>
+        /// Whether the web dashboard is enabled.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Whether to run the web dashboard in debug mode with detailed error pages.
+        /// </summary>
         bool DebugMode { get; }
+
+        /// <summary>
+        /// The TCP port the web dashboard listens on.
+        /// </summary>
         int Port { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Exchange/ITicker.cs
+++ b/IntelliTrader.Core/Interfaces/Exchange/ITicker.cs
@@ -1,14 +1,32 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents real-time price data for a trading pair from the exchange.
+    /// </summary>
     public interface ITicker
     {
+        /// <summary>
+        /// The trading pair symbol (e.g., "BTCUSDT").
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// The current best bid (buy) price.
+        /// </summary>
         decimal BidPrice { get; }
+
+        /// <summary>
+        /// The current best ask (sell) price.
+        /// </summary>
         decimal AskPrice { get; }
+
+        /// <summary>
+        /// The price of the last executed trade.
+        /// </summary>
         decimal LastPrice { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/IHealthCheck.cs
+++ b/IntelliTrader.Core/Interfaces/IHealthCheck.cs
@@ -1,14 +1,32 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents the current state of a named health check.
+    /// </summary>
     public interface IHealthCheck
     {
+        /// <summary>
+        /// The unique name identifying this health check.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// A human-readable message describing the health check status.
+        /// </summary>
         string Message { get; }
+
+        /// <summary>
+        /// The timestamp of the last health check update.
+        /// </summary>
         DateTimeOffset LastUpdated { get; }
+
+        /// <summary>
+        /// Whether this health check is currently in a failed state.
+        /// </summary>
         bool Failed { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/IModuleRules.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/IModuleRules.cs
@@ -1,16 +1,35 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents a named group of trading rules belonging to a specific module (e.g., signals, trading).
+    /// </summary>
     public interface IModuleRules
     {
+        /// <summary>
+        /// The module name this rule group belongs to (e.g., "Signals", "Trading").
+        /// </summary>
         string Module { get; }
+
+        /// <summary>
+        /// The raw configuration section for module-level settings.
+        /// </summary>
         IConfigurationSection Configuration { get; }
+
+        /// <summary>
+        /// The collection of individual rules within this module.
+        /// </summary>
         IEnumerable<IRule> Entries { get; }
 
+        /// <summary>
+        /// Gets the module configuration bound to a strongly-typed object.
+        /// </summary>
+        /// <typeparam name="T">The configuration type to bind to.</typeparam>
+        /// <returns>The bound configuration object.</returns>
         T GetConfiguration<T>();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/IRule.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/IRule.cs
@@ -1,18 +1,50 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents a single trading rule with conditions, trailing settings, and action modifiers.
+    /// </summary>
     public interface IRule
     {
+        /// <summary>
+        /// Whether this rule is active and should be evaluated.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// The display name of this rule.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// The action to execute when all conditions are met (e.g., "Buy", "Sell", "DCA").
+        /// </summary>
         string Action { get; }
+
+        /// <summary>
+        /// The conditions that must all be satisfied for this rule to trigger.
+        /// </summary>
         IEnumerable<IRuleCondition> Conditions { get; }
+
+        /// <summary>
+        /// Optional trailing configuration that delays action execution for confirmation.
+        /// </summary>
         IRuleTrailing Trailing { get; }
+
+        /// <summary>
+        /// Raw configuration section containing action-specific modifiers.
+        /// </summary>
         IConfigurationSection Modifiers { get; }
+
+        /// <summary>
+        /// Gets the action modifiers bound to a strongly-typed object.
+        /// </summary>
+        /// <typeparam name="T">The modifier type to bind to.</typeparam>
+        /// <returns>The bound modifier object.</returns>
         T GetModifiers<T>();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/IRuleCondition.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/IRuleCondition.cs
@@ -1,44 +1,178 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Defines a set of min/max conditions evaluated against signal data and trading pair state.
+    /// All specified conditions must be satisfied simultaneously for the rule to match.
+    /// </summary>
     public interface IRuleCondition
     {
+        /// <summary>
+        /// The signal name this condition evaluates against.
+        /// </summary>
         string Signal { get; }
+
+        /// <summary>
+        /// Minimum 24h volume required.
+        /// </summary>
         long? MinVolume { get; }
+
+        /// <summary>
+        /// Maximum 24h volume allowed.
+        /// </summary>
         long? MaxVolume { get; }
+
+        /// <summary>
+        /// Minimum volume change percentage required.
+        /// </summary>
         double? MinVolumeChange { get; }
+
+        /// <summary>
+        /// Maximum volume change percentage allowed.
+        /// </summary>
         double? MaxVolumeChange { get; }
+
+        /// <summary>
+        /// Minimum price required.
+        /// </summary>
         decimal? MinPrice { get; }
+
+        /// <summary>
+        /// Maximum price allowed.
+        /// </summary>
         decimal? MaxPrice { get; }
+
+        /// <summary>
+        /// Minimum price change percentage required.
+        /// </summary>
         decimal? MinPriceChange { get; }
+
+        /// <summary>
+        /// Maximum price change percentage allowed.
+        /// </summary>
         decimal? MaxPriceChange { get; }
+
+        /// <summary>
+        /// Minimum signal rating required.
+        /// </summary>
         double? MinRating { get; }
+
+        /// <summary>
+        /// Maximum signal rating allowed.
+        /// </summary>
         double? MaxRating { get; }
+
+        /// <summary>
+        /// Minimum rating change required.
+        /// </summary>
         double? MinRatingChange { get; }
+
+        /// <summary>
+        /// Maximum rating change allowed.
+        /// </summary>
         double? MaxRatingChange { get; }
+
+        /// <summary>
+        /// Minimum volatility required.
+        /// </summary>
         double? MinVolatility { get; }
+
+        /// <summary>
+        /// Maximum volatility allowed.
+        /// </summary>
         double? MaxVolatility { get; }
+
+        /// <summary>
+        /// Minimum global market rating required.
+        /// </summary>
         double? MinGlobalRating { get; }
+
+        /// <summary>
+        /// Maximum global market rating allowed.
+        /// </summary>
         double? MaxGlobalRating { get; }
 
+        /// <summary>
+        /// Specific trading pairs this condition applies to. Empty means all pairs.
+        /// </summary>
         List<string> Pairs { get; }
+
+        /// <summary>
+        /// Minimum position age in minutes.
+        /// </summary>
         double? MinAge { get; }
+
+        /// <summary>
+        /// Maximum position age in minutes.
+        /// </summary>
         double? MaxAge { get; }
+
+        /// <summary>
+        /// Minimum time in minutes since last buy for this pair.
+        /// </summary>
         double? MinLastBuyAge { get; }
+
+        /// <summary>
+        /// Maximum time in minutes since last buy for this pair.
+        /// </summary>
         double? MaxLastBuyAge { get; }
+
+        /// <summary>
+        /// Minimum profit/loss margin percentage required.
+        /// </summary>
         decimal? MinMargin { get; }
+
+        /// <summary>
+        /// Maximum profit/loss margin percentage allowed.
+        /// </summary>
         decimal? MaxMargin { get; }
+
+        /// <summary>
+        /// Minimum margin change percentage required.
+        /// </summary>
         decimal? MinMarginChange { get; }
+
+        /// <summary>
+        /// Maximum margin change percentage allowed.
+        /// </summary>
         decimal? MaxMarginChange { get; }
+
+        /// <summary>
+        /// Minimum position amount required.
+        /// </summary>
         decimal? MinAmount { get; set; }
+
+        /// <summary>
+        /// Maximum position amount allowed.
+        /// </summary>
         decimal? MaxAmount { get; set; }
+
+        /// <summary>
+        /// Minimum position cost required.
+        /// </summary>
         decimal? MinCost { get; }
+
+        /// <summary>
+        /// Maximum position cost allowed.
+        /// </summary>
         decimal? MaxCost { get; }
+
+        /// <summary>
+        /// Minimum DCA level required.
+        /// </summary>
         int? MinDCALevel { get; }
+
+        /// <summary>
+        /// Maximum DCA level allowed.
+        /// </summary>
         int? MaxDCALevel { get; }
+
+        /// <summary>
+        /// Signal rule names that must have been triggered for this pair.
+        /// </summary>
         List<string> SignalRules { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/IRuleTrailing.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/IRuleTrailing.cs
@@ -1,14 +1,32 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for trailing behavior that delays rule action execution to confirm signal persistence.
+    /// </summary>
     public interface IRuleTrailing
     {
+        /// <summary>
+        /// Whether trailing is enabled for this rule.
+        /// </summary>
         bool Enabled { get; }
+
+        /// <summary>
+        /// Minimum duration in seconds that conditions must be met before the action triggers.
+        /// </summary>
         int MinDuration { get; }
+
+        /// <summary>
+        /// Maximum duration in seconds after which the trailing expires without triggering.
+        /// </summary>
         int MaxDuration { get; }
+
+        /// <summary>
+        /// Conditions that must be met to initiate trailing. Separate from the rule's main conditions.
+        /// </summary>
         IEnumerable<IRuleCondition> StartConditions { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/ISignalRulesConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/ISignalRulesConfig.cs
@@ -1,12 +1,22 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for signal rule processing behavior.
+    /// </summary>
     public interface ISignalRulesConfig
     {
+        /// <summary>
+        /// How rules are processed: stop at first match or evaluate all.
+        /// </summary>
         RuleProcessingMode ProcessingMode { get; }
+
+        /// <summary>
+        /// Interval in seconds between signal rule evaluations.
+        /// </summary>
         double CheckInterval { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Rules/RuleProcessingMode.cs
+++ b/IntelliTrader.Core/Interfaces/Rules/RuleProcessingMode.cs
@@ -1,12 +1,22 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Determines how multiple matching rules are handled during evaluation.
+    /// </summary>
     public enum RuleProcessingMode
     {
+        /// <summary>
+        /// Stop evaluating after the first matching rule is found.
+        /// </summary>
         FirstMatch,
+
+        /// <summary>
+        /// Evaluate and apply all matching rules.
+        /// </summary>
         AllMatches
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/Base/IConfigurableService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/Base/IConfigurableService.cs
@@ -1,12 +1,18 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Base interface for services that have associated configuration sections.
+    /// </summary>
     public interface IConfigurableService : INamedService
     {
+        /// <summary>
+        /// The raw configuration section bound to this service.
+        /// </summary>
         IConfigurationSection RawConfig { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/Base/INamedService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/Base/INamedService.cs
@@ -1,11 +1,17 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Base interface for services that expose a human-readable name for logging and diagnostics.
+    /// </summary>
     public interface INamedService
     {
+        /// <summary>
+        /// The display name of this service, used in logging and health checks.
+        /// </summary>
         string ServiceName { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IAlertingService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IAlertingService.cs
@@ -4,10 +4,25 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service that monitors trading health and triggers alerts for anomalies
+    /// such as stale signals, connectivity issues, and high error rates.
+    /// </summary>
     public interface IAlertingService
     {
+        /// <summary>
+        /// Starts the periodic alert monitoring loop.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the alert monitoring loop.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Performs a single alert evaluation cycle, checking all configured alert conditions.
+        /// </summary>
         void CheckAlerts();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IBacktestingService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IBacktestingService.cs
@@ -1,19 +1,64 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for replaying historical trading snapshots to backtest strategies.
+    /// </summary>
     public interface IBacktestingService : IConfigurableService
     {
+        /// <summary>
+        /// The backtesting configuration.
+        /// </summary>
         IBacktestingConfig Config { get; }
+
+        /// <summary>
+        /// Synchronization object for thread-safe snapshot access.
+        /// </summary>
         object SyncRoot { get; }
+
+        /// <summary>
+        /// Starts the backtesting replay.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the backtesting replay.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Marks the backtesting run as complete and logs summary statistics.
+        /// </summary>
+        /// <param name="skippedSignalSnapshots">Number of signal snapshots that were skipped.</param>
+        /// <param name="skippedTickerSnapshots">Number of ticker snapshots that were skipped.</param>
         void Complete(int skippedSignalSnapshots, int skippedTickerSnapshots);
+
+        /// <summary>
+        /// Gets the file path for a specific snapshot entity.
+        /// </summary>
+        /// <param name="snapshotEntity">The entity name (e.g., "signals", "tickers").</param>
+        /// <returns>The full file path for the snapshot.</returns>
         string GetSnapshotFilePath(string snapshotEntity);
+
+        /// <summary>
+        /// Gets the current signal data from the active snapshot.
+        /// </summary>
+        /// <returns>Dictionary of signal name to signal collection.</returns>
         Dictionary<string, IEnumerable<ISignal>> GetCurrentSignals();
+
+        /// <summary>
+        /// Gets the current ticker data from the active snapshot.
+        /// </summary>
+        /// <returns>Dictionary of pair name to ticker data.</returns>
         Dictionary<string, ITicker> GetCurrentTickers();
+
+        /// <summary>
+        /// Gets the total number of snapshots available for replay.
+        /// </summary>
+        /// <returns>The total snapshot count.</returns>
         int GetTotalSnapshots();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ICachingService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ICachingService.cs
@@ -1,12 +1,26 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for caching frequently accessed data with configurable expiration.
+    /// </summary>
     public interface ICachingService : IConfigurableService
     {
+        /// <summary>
+        /// The caching configuration.
+        /// </summary>
         ICachingConfig Config { get; }
+
+        /// <summary>
+        /// Gets a cached object or refreshes it if expired or missing.
+        /// </summary>
+        /// <typeparam name="T">The type of the cached object.</typeparam>
+        /// <param name="objectName">The unique name identifying the cached object.</param>
+        /// <param name="refresh">Factory function to create or refresh the object.</param>
+        /// <returns>The cached or freshly created object.</returns>
         T GetOrRefresh<T>(string objectName, Func<T> refresh);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ICoreService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ICoreService.cs
@@ -1,31 +1,103 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Central orchestrator service that manages the application lifecycle and all timed tasks.
+    /// </summary>
     public interface ICoreService : IConfigurableService
     {
+        /// <summary>
+        /// The core configuration.
+        /// </summary>
         ICoreConfig Config { get; }
+
+        /// <summary>
+        /// The current application version string.
+        /// </summary>
         string Version { get; }
+
         /// <summary>
         /// True once <see cref="Start"/> has completed and all timed
         /// tasks are active. Used by Kubernetes readiness probes to
         /// decide whether the bot is ready to serve traffic.
         /// </summary>
         bool Running { get; }
+
+        /// <summary>
+        /// Starts all registered timed tasks and begins the trading loop.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops all timed tasks and shuts down gracefully.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Stops and then restarts all services and timed tasks.
+        /// </summary>
         void Restart();
+
+        /// <summary>
+        /// Asynchronously stops and restarts all services and timed tasks.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for the operation.</param>
         Task RestartAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Registers a named timed task for periodic execution.
+        /// </summary>
+        /// <param name="name">The unique name for the task.</param>
+        /// <param name="task">The timed task to register.</param>
         void AddTask(string name, HighResolutionTimedTask task);
+
+        /// <summary>
+        /// Removes a named timed task from the registry.
+        /// </summary>
+        /// <param name="name">The name of the task to remove.</param>
         void RemoveTask(string name);
+
+        /// <summary>
+        /// Removes all registered timed tasks.
+        /// </summary>
         void RemoveAllTasks();
+
+        /// <summary>
+        /// Starts a specific named timed task.
+        /// </summary>
+        /// <param name="name">The name of the task to start.</param>
         void StartTask(string name);
+
+        /// <summary>
+        /// Starts all registered timed tasks.
+        /// </summary>
         void StartAllTasks();
+
+        /// <summary>
+        /// Stops a specific named timed task.
+        /// </summary>
+        /// <param name="name">The name of the task to stop.</param>
         void StopTask(string name);
+
+        /// <summary>
+        /// Stops all registered timed tasks.
+        /// </summary>
         void StopAllTasks();
+
+        /// <summary>
+        /// Gets a specific named timed task.
+        /// </summary>
+        /// <param name="name">The name of the task.</param>
+        /// <returns>The timed task instance.</returns>
         HighResolutionTimedTask GetTask(string name);
+
+        /// <summary>
+        /// Gets all registered timed tasks.
+        /// </summary>
+        /// <returns>Dictionary of task name to task instance.</returns>
         ConcurrentDictionary<string, HighResolutionTimedTask> GetAllTasks();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IExchangeService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IExchangeService.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service abstracting the exchange API for market data retrieval and order execution.
+    /// Supports both WebSocket streaming and REST polling with automatic fallback.
+    /// </summary>
     public interface IExchangeService : IConfigurableService
     {
         /// <summary>
@@ -27,13 +31,56 @@ namespace IntelliTrader.Core
         /// </summary>
         TimeSpan TimeSinceLastTickerUpdate { get; }
 
+        /// <summary>
+        /// Starts the exchange service and connects to the exchange API.
+        /// </summary>
+        /// <param name="virtualTrading">Whether to run in virtual (paper) trading mode.</param>
         void Start(bool virtualTrading);
+
+        /// <summary>
+        /// Stops the exchange service and disconnects from the API.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Gets current ticker data for all pairs in a market.
+        /// </summary>
+        /// <param name="market">The market name (e.g., "BTC", "USDT").</param>
+        /// <returns>Collection of tickers for the market.</returns>
         Task<IEnumerable<ITicker>> GetTickers(string market);
+
+        /// <summary>
+        /// Gets all available trading pair symbols for a market.
+        /// </summary>
+        /// <param name="market">The market name.</param>
+        /// <returns>Collection of pair symbols.</returns>
         Task<IEnumerable<string>> GetMarketPairs(string market);
+
+        /// <summary>
+        /// Gets available asset amounts (balances) from the exchange account.
+        /// </summary>
+        /// <returns>Dictionary of asset symbol to available amount.</returns>
         Task<Dictionary<string, decimal>> GetAvailableAmounts();
+
+        /// <summary>
+        /// Gets the user's recent trade history for a specific pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>Collection of order details for the pair.</returns>
         Task<IEnumerable<IOrderDetails>> GetMyTrades(string pair);
+
+        /// <summary>
+        /// Gets the last traded price for a pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>The last trade price.</returns>
         Task<decimal> GetLastPrice(string pair);
+
+        /// <summary>
+        /// Places an order on the exchange.
+        /// </summary>
+        /// <param name="order">The order to place.</param>
+        /// <returns>The order execution details.</returns>
         Task<IOrderDetails> PlaceOrder(IOrder order);
 
         /// <summary>

--- a/IntelliTrader.Core/Interfaces/Services/IHealthCheckService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IHealthCheckService.cs
@@ -1,15 +1,42 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for managing health check registrations and monitoring service health.
+    /// </summary>
     public interface IHealthCheckService
     {
+        /// <summary>
+        /// Starts the health check monitoring service.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the health check monitoring service.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Creates or updates a named health check with the current status.
+        /// </summary>
+        /// <param name="name">The unique health check name.</param>
+        /// <param name="message">Optional status message.</param>
+        /// <param name="failed">Whether the health check is in a failed state.</param>
         void UpdateHealthCheck(string name, string message = null, bool failed = false);
+
+        /// <summary>
+        /// Removes a named health check from monitoring.
+        /// </summary>
+        /// <param name="name">The health check name to remove.</param>
         void RemoveHealthCheck(string name);
+
+        /// <summary>
+        /// Gets all currently registered health checks.
+        /// </summary>
+        /// <returns>Collection of health check statuses.</returns>
         IEnumerable<IHealthCheck> GetHealthChecks();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IIntegrationService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IIntegrationService.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for third-party integrations and external system connectivity.
+    /// </summary>
     public interface IIntegrationService : IConfigurableService
     {
     }

--- a/IntelliTrader.Core/Interfaces/Services/ILoggingService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ILoggingService.cs
@@ -4,21 +4,104 @@ using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for structured logging with support for scoped contexts, correlation tracking, and sampled output.
+    /// </summary>
     public interface ILoggingService : IConfigurableService
     {
+        /// <summary>
+        /// Logs a debug-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Debug(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs a debug-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Debug(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Logs an error-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Error(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs an error-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Error(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Logs a fatal-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Fatal(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs a fatal-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Fatal(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Logs an info-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Info(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs an info-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Info(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Logs a verbose-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Verbose(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs a verbose-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Verbose(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Logs a warning-level message with an optional exception.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="exception">Optional exception to include.</param>
         void Warning(string message, Exception exception = null);
+
+        /// <summary>
+        /// Logs a warning-level message with structured property values.
+        /// </summary>
+        /// <param name="message">The log message template.</param>
+        /// <param name="propertyValues">Structured property values.</param>
         void Warning(string message, params object[] propertyValues);
+
+        /// <summary>
+        /// Deletes all log files.
+        /// </summary>
         void DeleteAllLogs();
+
+        /// <summary>
+        /// Gets recent log entries as an array of strings.
+        /// </summary>
+        /// <returns>Array of log entry strings.</returns>
         string[] GetLogEntries();
 
         /// <summary>

--- a/IntelliTrader.Core/Interfaces/Services/INotificationService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/INotificationService.cs
@@ -1,15 +1,34 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for sending notifications (e.g., Telegram messages) about trading events.
+    /// </summary>
     public interface INotificationService
     {
+        /// <summary>
+        /// The notification configuration.
+        /// </summary>
         INotificationConfig Config { get; }
+
+        /// <summary>
+        /// Starts the notification service and connects to notification channels.
+        /// </summary>
         Task StartAsync();
+
+        /// <summary>
+        /// Stops the notification service.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Sends a notification message asynchronously.
+        /// </summary>
+        /// <param name="message">The message text to send.</param>
         Task NotifyAsync(string message);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IRulesService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IRulesService.cs
@@ -1,15 +1,47 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for evaluating trading rules against signal and position data.
+    /// </summary>
     public interface IRulesService : IConfigurableService
     {
+        /// <summary>
+        /// The rules configuration containing all rule modules.
+        /// </summary>
         IRulesConfig Config { get; }
+
+        /// <summary>
+        /// Gets the rule entries for a specific module.
+        /// </summary>
+        /// <param name="module">The module name (e.g., "Signals", "Trading").</param>
+        /// <returns>The module rules.</returns>
         IModuleRules GetRules(string module);
+
+        /// <summary>
+        /// Evaluates a set of rule conditions against current signal and position data.
+        /// </summary>
+        /// <param name="conditions">The conditions to check.</param>
+        /// <param name="signals">Current signal data keyed by signal name.</param>
+        /// <param name="globalRating">The current global market rating.</param>
+        /// <param name="pair">The trading pair being evaluated, if applicable.</param>
+        /// <param name="tradingPair">The active trading pair position, if applicable.</param>
+        /// <returns>True if all conditions are satisfied.</returns>
         bool CheckConditions(IEnumerable<IRuleCondition> conditions, Dictionary<string, ISignal> signals, double? globalRating, string? pair, ITradingPair? tradingPair);
+
+        /// <summary>
+        /// Registers a callback to be invoked when rules configuration changes.
+        /// </summary>
+        /// <param name="callback">The callback action.</param>
         void RegisterRulesChangeCallback(Action callback);
+
+        /// <summary>
+        /// Unregisters a previously registered rules change callback.
+        /// </summary>
+        /// <param name="callback">The callback action to remove.</param>
         void UnregisterRulesChangeCallback(Action callback);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ISecretRotationService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ISecretRotationService.cs
@@ -3,10 +3,25 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for automatic rotation of API credentials and secrets.
+    /// </summary>
     public interface ISecretRotationService
     {
+        /// <summary>
+        /// Starts the secret rotation monitoring service.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the secret rotation monitoring service.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Attempts to rotate the exchange API credentials.
+        /// </summary>
+        /// <returns>True if rotation was successful; false otherwise.</returns>
         Task<bool> RotateCredentialsAsync();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ISignalsService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ISignalsService.cs
@@ -1,25 +1,103 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service for acquiring, aggregating, and querying trading signals from configured signal sources.
+    /// </summary>
     public interface ISignalsService : IConfigurableService
     {
+        /// <summary>
+        /// The signals configuration.
+        /// </summary>
         ISignalsConfig Config { get; }
+
+        /// <summary>
+        /// The signal rules module containing buy signal rules.
+        /// </summary>
         IModuleRules Rules { get; }
+
+        /// <summary>
+        /// The signal rules processing configuration.
+        /// </summary>
         ISignalRulesConfig RulesConfig { get; }
+
+        /// <summary>
+        /// Starts signal acquisition from all configured sources.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops signal acquisition.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Clears all active trailing signals.
+        /// </summary>
         void ClearTrailing();
+
+        /// <summary>
+        /// Gets the list of pairs that currently have active trailing signals.
+        /// </summary>
+        /// <returns>List of pair symbols with active trailing.</returns>
         List<string> GetTrailingSignals();
+
+        /// <summary>
+        /// Gets detailed trailing information for a specific pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>Collection of active trailing info for the pair.</returns>
         IEnumerable<ISignalTrailingInfo> GetTrailingInfo(string pair);
+
+        /// <summary>
+        /// Gets the names of all configured signal sources.
+        /// </summary>
+        /// <returns>Collection of signal names.</returns>
         IEnumerable<string> GetSignalNames();
+
+        /// <summary>
+        /// Gets all current signals across all sources.
+        /// </summary>
+        /// <returns>Collection of all signals.</returns>
         IEnumerable<ISignal> GetAllSignals();
+
+        /// <summary>
+        /// Gets all signals from a specific signal source.
+        /// </summary>
+        /// <param name="signalName">The signal source name.</param>
+        /// <returns>Collection of signals from the source.</returns>
         IEnumerable<ISignal> GetSignalsByName(string signalName);
+
+        /// <summary>
+        /// Gets all signals for a specific trading pair across all sources.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>Collection of signals for the pair.</returns>
         IEnumerable<ISignal> GetSignalsByPair(string pair);
+
+        /// <summary>
+        /// Gets the rating for a pair from a specific signal source.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <param name="signalName">The signal source name.</param>
+        /// <returns>The rating value, or null if no signal data exists.</returns>
         double? GetRating(string pair, string signalName);
+
+        /// <summary>
+        /// Gets the combined rating for a pair across multiple signal sources.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <param name="signalNames">The signal source names to combine.</param>
+        /// <returns>The combined rating value, or null if no signal data exists.</returns>
         double? GetRating(string pair, IEnumerable<string> signalNames);
+
+        /// <summary>
+        /// Gets the global market rating computed from configured global rating signals.
+        /// </summary>
+        /// <returns>The global rating value, or null if insufficient data.</returns>
         double? GetGlobalRating();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ITradingService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ITradingService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -6,30 +6,88 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Central trading service that coordinates buy/sell/swap operations, manages positions, and provides market data access.
+    /// </summary>
     public interface ITradingService : IConfigurableService
     {
+        /// <summary>
+        /// The trading configuration.
+        /// </summary>
         ITradingConfig Config { get; }
+
+        /// <summary>
+        /// The trading rules module containing sell/DCA rules.
+        /// </summary>
         IModuleRules Rules { get; }
+
+        /// <summary>
+        /// Whether trading is currently suspended (e.g., due to health check failures or circuit breaker).
+        /// </summary>
         bool IsTradingSuspended { get; }
+
+        /// <summary>
+        /// Starts the trading service and initializes the trading account.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the trading service.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Resumes trading after a suspension.
+        /// </summary>
+        /// <param name="forced">If true, resumes even if automatic conditions are not met.</param>
         void ResumeTrading(bool forced = false);
+
+        /// <summary>
+        /// Suspends all trading operations.
+        /// </summary>
+        /// <param name="forced">If true, prevents automatic resumption.</param>
         void SuspendTrading(bool forced = false);
+
+        /// <summary>
+        /// The trading account managing positions and balances.
+        /// </summary>
         ITradingAccount Account { get; }
 
         /// <summary>
         /// Gets the bounded order history collection. Oldest orders are automatically removed when MaxOrderHistorySize is exceeded.
         /// </summary>
         BoundedConcurrentStack<IOrderDetails> OrderHistory { get; }
+
+        /// <summary>
+        /// Gets the pair-specific configuration, which may override global settings.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>The effective configuration for the pair.</returns>
         IPairConfig GetPairConfig(string pair);
+
+        /// <summary>
+        /// Reapplies trading rules from the current configuration (used after hot-reload).
+        /// </summary>
         void ReapplyTradingRules();
 
-        // Synchronous trading methods (for backward compatibility)
+        /// <summary>
+        /// Executes a buy operation with swap detection and trailing buy support.
+        /// </summary>
+        /// <param name="options">Buy options including pair, amount, and metadata.</param>
         void Buy(BuyOptions options);
+
+        /// <summary>
+        /// Executes a sell operation with trailing sell support.
+        /// </summary>
+        /// <param name="options">Sell options including pair and amount.</param>
         void Sell(SellOptions options);
+
+        /// <summary>
+        /// Executes a swap operation (sell one pair and buy another).
+        /// </summary>
+        /// <param name="options">Swap options including old pair, new pair, and metadata.</param>
         void Swap(SwapOptions options);
 
-        // Async trading methods (preferred for new code)
         /// <summary>
         /// Asynchronously executes a buy operation with swap detection and trailing buy support.
         /// </summary>
@@ -51,27 +109,124 @@ namespace IntelliTrader.Core
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         Task SwapAsync(SwapOptions options, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Validates whether a buy operation can be executed.
+        /// </summary>
+        /// <param name="options">Buy options to validate.</param>
+        /// <param name="message">Output message explaining why the buy cannot proceed, or null if valid.</param>
+        /// <returns>True if buy can proceed; false otherwise.</returns>
         bool CanBuy(BuyOptions options, out string message);
+
+        /// <summary>
+        /// Validates whether a sell operation can be executed.
+        /// </summary>
+        /// <param name="options">Sell options to validate.</param>
+        /// <param name="message">Output message explaining why the sell cannot proceed, or null if valid.</param>
+        /// <returns>True if sell can proceed; false otherwise.</returns>
         bool CanSell(SellOptions options, out string message);
+
+        /// <summary>
+        /// Validates whether a swap operation can be executed.
+        /// </summary>
+        /// <param name="options">Swap options to validate.</param>
+        /// <param name="message">Output message explaining why the swap cannot proceed, or null if valid.</param>
+        /// <returns>True if swap can proceed; false otherwise.</returns>
         bool CanSwap(SwapOptions options, out string message);
+
+        /// <summary>
+        /// Logs an executed order to the order history.
+        /// </summary>
+        /// <param name="order">The order details to log.</param>
         void LogOrder(IOrderDetails order);
+
+        /// <summary>
+        /// Gets the list of pairs with active trailing buy orders.
+        /// </summary>
+        /// <returns>List of pair symbols.</returns>
         List<string> GetTrailingBuys();
+
+        /// <summary>
+        /// Gets the list of pairs with active trailing sell orders.
+        /// </summary>
+        /// <returns>List of pair symbols.</returns>
         List<string> GetTrailingSells();
 
-        // Synchronous methods (for backward compatibility and use in locked sections)
+        /// <summary>
+        /// Gets current ticker data for the configured market.
+        /// </summary>
+        /// <returns>Collection of tickers.</returns>
         IEnumerable<ITicker> GetTickers();
+
+        /// <summary>
+        /// Gets all trading pair symbols for the configured market.
+        /// </summary>
+        /// <returns>Collection of pair symbols.</returns>
         IEnumerable<string> GetMarketPairs();
+
+        /// <summary>
+        /// Gets available asset amounts from the exchange.
+        /// </summary>
+        /// <returns>Dictionary of asset to available amount.</returns>
         Dictionary<string, decimal> GetAvailableAmounts();
+
+        /// <summary>
+        /// Gets the user's trade history for a pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>Collection of order details.</returns>
         IEnumerable<IOrderDetails> GetMyTrades(string pair);
+
+        /// <summary>
+        /// Places an order on the exchange through the trading account.
+        /// </summary>
+        /// <param name="order">The order to place.</param>
+        /// <returns>The order execution details.</returns>
         IOrderDetails PlaceOrder(IOrder order);
+
+        /// <summary>
+        /// Gets the current market price for a pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>The current price.</returns>
         decimal GetCurrentPrice(string pair);
 
-        // Async methods (preferred for new code)
+        /// <summary>
+        /// Asynchronously gets current ticker data for the configured market.
+        /// </summary>
+        /// <returns>Collection of tickers.</returns>
         Task<IEnumerable<ITicker>> GetTickersAsync();
+
+        /// <summary>
+        /// Asynchronously gets all trading pair symbols for the configured market.
+        /// </summary>
+        /// <returns>Collection of pair symbols.</returns>
         Task<IEnumerable<string>> GetMarketPairsAsync();
+
+        /// <summary>
+        /// Asynchronously gets available asset amounts from the exchange.
+        /// </summary>
+        /// <returns>Dictionary of asset to available amount.</returns>
         Task<Dictionary<string, decimal>> GetAvailableAmountsAsync();
+
+        /// <summary>
+        /// Asynchronously gets the user's trade history for a pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>Collection of order details.</returns>
         Task<IEnumerable<IOrderDetails>> GetMyTradesAsync(string pair);
+
+        /// <summary>
+        /// Asynchronously places an order on the exchange.
+        /// </summary>
+        /// <param name="order">The order to place.</param>
+        /// <returns>The order execution details.</returns>
         Task<IOrderDetails> PlaceOrderAsync(IOrder order);
+
+        /// <summary>
+        /// Asynchronously gets the current market price for a pair.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>The current price.</returns>
         Task<decimal> GetCurrentPriceAsync(string pair);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/IWebService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IWebService.cs
@@ -1,13 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Service hosting the ASP.NET Core web dashboard for monitoring and control.
+    /// </summary>
     public interface IWebService
     {
+        /// <summary>
+        /// The web service configuration.
+        /// </summary>
         IWebConfig Config { get; }
+
+        /// <summary>
+        /// Starts the web dashboard server.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Stops the web dashboard server.
+        /// </summary>
         void Stop();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Signals/ISignal.cs
+++ b/IntelliTrader.Core/Interfaces/Signals/ISignal.cs
@@ -1,19 +1,57 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents a trading signal containing price, volume, rating, and volatility data for a pair.
+    /// </summary>
     public interface ISignal
     {
+        /// <summary>
+        /// The signal source name (e.g., "TradingView-5m").
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// The trading pair this signal applies to (e.g., "BTCUSDT").
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// The 24-hour trading volume.
+        /// </summary>
         long? Volume { get; }
+
+        /// <summary>
+        /// The percentage change in volume.
+        /// </summary>
         double? VolumeChange { get; set; }
+
+        /// <summary>
+        /// The current price from the signal source.
+        /// </summary>
         decimal? Price { get; }
+
+        /// <summary>
+        /// The percentage change in price.
+        /// </summary>
         decimal? PriceChange { get; }
+
+        /// <summary>
+        /// The signal rating (e.g., TradingView recommendation score).
+        /// </summary>
         double? Rating { get; }
+
+        /// <summary>
+        /// The change in signal rating since the last update.
+        /// </summary>
         double? RatingChange { get; }
+
+        /// <summary>
+        /// The price volatility measurement.
+        /// </summary>
         double? Volatility { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Signals/ISignalDefinition.cs
+++ b/IntelliTrader.Core/Interfaces/Signals/ISignalDefinition.cs
@@ -1,14 +1,28 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Defines a signal source including its receiver type and configuration.
+    /// </summary>
     public interface ISignalDefinition
     {
+        /// <summary>
+        /// The unique name for this signal definition (e.g., "TradingView-5m").
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// The signal receiver type that processes this signal (e.g., "TradingViewCryptoSignalReceiver").
+        /// </summary>
         string Receiver { get; }
+
+        /// <summary>
+        /// The receiver-specific configuration section.
+        /// </summary>
         IConfigurationSection Configuration { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Signals/ISignalTrailingInfo.cs
+++ b/IntelliTrader.Core/Interfaces/Signals/ISignalTrailingInfo.cs
@@ -1,13 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Provides information about an active trailing signal for a trading pair.
+    /// </summary>
     public interface ISignalTrailingInfo
     {
+        /// <summary>
+        /// The rule that initiated the trailing.
+        /// </summary>
         IRule Rule { get; }
+
+        /// <summary>
+        /// The timestamp when trailing started.
+        /// </summary>
         DateTimeOffset StartTime { get; }
+
+        /// <summary>
+        /// The elapsed duration of the trailing in seconds.
+        /// </summary>
         double Duration { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/IBuyConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/IBuyConfig.cs
@@ -1,19 +1,57 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for buy order parameters including cost limits, trailing, and balance requirements.
+    /// </summary>
     public interface IBuyConfig
     {
+        /// <summary>
+        /// Whether buying is enabled.
+        /// </summary>
         bool BuyEnabled { get; set; }
+
+        /// <summary>
+        /// The order type for buy orders (e.g., Market, Limit).
+        /// </summary>
         OrderType BuyType { get; }
+
+        /// <summary>
+        /// Maximum cost per buy order in market currency.
+        /// </summary>
         decimal BuyMaxCost { get; }
+
+        /// <summary>
+        /// Multiplier applied to the buy cost calculation.
+        /// </summary>
         decimal BuyMultiplier { get; }
+
+        /// <summary>
+        /// Minimum account balance required to place a buy order.
+        /// </summary>
         decimal BuyMinBalance { get; }
+
+        /// <summary>
+        /// Timeout in minutes before the same pair can be bought again.
+        /// </summary>
         double BuySamePairTimeout { get; }
+
+        /// <summary>
+        /// Trailing percentage for buy orders (price must drop this much from peak before buying).
+        /// </summary>
         decimal BuyTrailing { get; }
+
+        /// <summary>
+        /// Stop margin for trailing buy - maximum allowed price increase from trailing low.
+        /// </summary>
         decimal BuyTrailingStopMargin { get; }
+
+        /// <summary>
+        /// Action to take when the trailing buy stop margin is reached.
+        /// </summary>
         BuyTrailingStopAction BuyTrailingStopAction { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/IBuyDCAConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/IBuyDCAConfig.cs
@@ -1,17 +1,47 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for Dollar Cost Averaging (DCA) buy operations that add to existing positions.
+    /// </summary>
     public interface IBuyDCAConfig
     {
+        /// <summary>
+        /// Whether DCA buying is enabled.
+        /// </summary>
         bool BuyDCAEnabled { get; set; }
+
+        /// <summary>
+        /// Multiplier applied to the DCA buy cost calculation.
+        /// </summary>
         decimal BuyDCAMultiplier { get; }
+
+        /// <summary>
+        /// Minimum account balance required to place a DCA buy order.
+        /// </summary>
         decimal BuyDCAMinBalance { get; }
+
+        /// <summary>
+        /// Timeout in minutes before the same pair can receive another DCA buy.
+        /// </summary>
         double BuyDCASamePairTimeout { get; }
+
+        /// <summary>
+        /// Trailing percentage for DCA buy orders.
+        /// </summary>
         decimal BuyDCATrailing { get; }
+
+        /// <summary>
+        /// Stop margin for trailing DCA buy.
+        /// </summary>
         decimal BuyDCATrailingStopMargin { get; }
+
+        /// <summary>
+        /// Action to take when the trailing DCA buy stop margin is reached.
+        /// </summary>
         BuyTrailingStopAction BuyDCATrailingStopAction { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/IOrder.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/IOrder.cs
@@ -1,16 +1,42 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents an order to be placed on the exchange.
+    /// </summary>
     public interface IOrder
     {
+        /// <summary>
+        /// The order side (Buy or Sell).
+        /// </summary>
         OrderSide Side { get; }
+
+        /// <summary>
+        /// The order type (Market or Limit).
+        /// </summary>
         OrderType Type { get; }
+
+        /// <summary>
+        /// The date and time the order was created.
+        /// </summary>
         DateTimeOffset Date { get; }
+
+        /// <summary>
+        /// The trading pair symbol (e.g., "BTCUSDT").
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// The order amount in the pair's base currency.
+        /// </summary>
         decimal Amount { get; }
+
+        /// <summary>
+        /// The order price (for limit orders).
+        /// </summary>
         decimal Price { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/IOrderDetails.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/IOrderDetails.cs
@@ -1,25 +1,88 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents the detailed result of an executed order, including fill information and fees.
+    /// </summary>
     public interface IOrderDetails
     {
+        /// <summary>
+        /// The order side (Buy or Sell).
+        /// </summary>
         OrderSide Side { get; }
+
+        /// <summary>
+        /// The result status of the order (e.g., Filled, Error).
+        /// </summary>
         OrderResult Result { get; }
+
+        /// <summary>
+        /// The date and time the order was executed.
+        /// </summary>
         DateTimeOffset Date { get; }
+
+        /// <summary>
+        /// The exchange-assigned order identifier.
+        /// </summary>
         string OrderId { get; }
+
+        /// <summary>
+        /// The trading pair symbol.
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// A human-readable message about the order result.
+        /// </summary>
         string Message { get; }
+
+        /// <summary>
+        /// The requested order amount.
+        /// </summary>
         decimal Amount { get; }
+
+        /// <summary>
+        /// The actually filled amount (may differ from requested for partial fills).
+        /// </summary>
         decimal AmountFilled { get; }
+
+        /// <summary>
+        /// The requested order price.
+        /// </summary>
         decimal Price { get; }
+
+        /// <summary>
+        /// The volume-weighted average fill price.
+        /// </summary>
         decimal AveragePrice { get; }
+
+        /// <summary>
+        /// The total fees paid for this order.
+        /// </summary>
         decimal Fees { get; }
+
+        /// <summary>
+        /// The currency in which fees were charged.
+        /// </summary>
         string FeesCurrency { get; }
+
+        /// <summary>
+        /// The average cost per unit including fees.
+        /// </summary>
         decimal AverageCost { get; }
+
+        /// <summary>
+        /// Additional metadata attached to the order (e.g., signal rule, swap info).
+        /// </summary>
         OrderMetadata Metadata { get; }
+
+        /// <summary>
+        /// Attaches metadata to this order.
+        /// </summary>
+        /// <param name="metadata">The metadata to attach.</param>
         void SetMetadata(OrderMetadata metadata);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/IPairConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/IPairConfig.cs
@@ -1,18 +1,42 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Per-pair trading configuration that overrides global buy/sell settings for specific pairs.
+    /// </summary>
     public interface IPairConfig : IBuyConfig, ISellConfig
     {
+        /// <summary>
+        /// Names of the trading rules that apply to this pair.
+        /// </summary>
         IEnumerable<string> Rules { get; }
 
+        /// <summary>
+        /// Whether swapping (selling this pair to buy another) is enabled.
+        /// </summary>
         bool SwapEnabled { get; }
+
+        /// <summary>
+        /// Signal rule names that can trigger a swap for this pair.
+        /// </summary>
         List<string> SwapSignalRules { get; }
+
+        /// <summary>
+        /// Timeout in seconds for swap operations.
+        /// </summary>
         int SwapTimeout { get; }
 
+        /// <summary>
+        /// The margin threshold for the current DCA level, if applicable.
+        /// </summary>
         decimal? CurrentDCAMargin { get; }
+
+        /// <summary>
+        /// The margin threshold for the next DCA level, if applicable.
+        /// </summary>
         decimal? NextDCAMargin { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/ISellConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/ISellConfig.cs
@@ -1,20 +1,62 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for sell order parameters including margin targets, trailing, and stop-loss.
+    /// </summary>
     public interface ISellConfig
     {
+        /// <summary>
+        /// Whether selling is enabled.
+        /// </summary>
         bool SellEnabled { get; set; }
+
+        /// <summary>
+        /// The order type for sell orders (e.g., Market, Limit).
+        /// </summary>
         OrderType SellType { get; }
+
+        /// <summary>
+        /// Target profit margin percentage to trigger a sell.
+        /// </summary>
         decimal SellMargin { get; }
+
+        /// <summary>
+        /// Trailing percentage for sell orders (price must drop this much from peak before selling).
+        /// </summary>
         decimal SellTrailing { get; }
+
+        /// <summary>
+        /// Stop margin for trailing sell - triggers sell when margin drops below this from trailing high.
+        /// </summary>
         decimal SellTrailingStopMargin { get; }
+
+        /// <summary>
+        /// Action to take when the trailing sell stop margin is reached.
+        /// </summary>
         SellTrailingStopAction SellTrailingStopAction { get; }
+
+        /// <summary>
+        /// Whether stop-loss selling is enabled.
+        /// </summary>
         bool SellStopLossEnabled { get; }
+
+        /// <summary>
+        /// Whether stop-loss only activates after at least one DCA level has been executed.
+        /// </summary>
         bool SellStopLossAfterDCA { get; }
+
+        /// <summary>
+        /// Minimum position age in minutes before stop-loss can trigger.
+        /// </summary>
         double SellStopLossMinAge { get; }
+
+        /// <summary>
+        /// The stop-loss margin percentage (negative value indicating loss threshold).
+        /// </summary>
         decimal SellStopLossMargin { get; }
 
         /// <summary>

--- a/IntelliTrader.Core/Interfaces/Trading/ISellDCAConfig.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/ISellDCAConfig.cs
@@ -1,14 +1,32 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Configuration for sell parameters specific to DCA (Dollar Cost Averaging) positions.
+    /// </summary>
     public interface ISellDCAConfig
     {
+        /// <summary>
+        /// Target profit margin percentage for DCA positions.
+        /// </summary>
         decimal SellDCAMargin { get; }
+
+        /// <summary>
+        /// Trailing percentage for DCA sell orders.
+        /// </summary>
         decimal SellDCATrailing { get; }
+
+        /// <summary>
+        /// Stop margin for trailing DCA sell.
+        /// </summary>
         decimal SellDCATrailingStopMargin { get; }
+
+        /// <summary>
+        /// Action to take when the trailing DCA sell stop margin is reached.
+        /// </summary>
         SellTrailingStopAction SellDCATrailingStopAction { get; }
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/ITradeResult.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/ITradeResult.cs
@@ -1,27 +1,93 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents the complete result of a closed trade including profit/loss calculations.
+    /// </summary>
     public interface ITradeResult
     {
+        /// <summary>
+        /// Whether the trade executed successfully.
+        /// </summary>
         bool IsSuccessful { get; }
+
+        /// <summary>
+        /// Whether the trade was part of a swap operation.
+        /// </summary>
         bool IsSwap { get; }
+
+        /// <summary>
+        /// The trading pair symbol.
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// The total amount sold.
+        /// </summary>
         decimal Amount { get; }
+
+        /// <summary>
+        /// The dates of all buy orders that built up this position.
+        /// </summary>
         List<DateTimeOffset> OrderDates { get; }
+
+        /// <summary>
+        /// The volume-weighted average price paid across all buy orders.
+        /// </summary>
         decimal AveragePricePaid { get; }
+
+        /// <summary>
+        /// Total fees paid in the pair's base currency.
+        /// </summary>
         decimal FeesPairCurrency { get; }
+
+        /// <summary>
+        /// Total fees paid in the market currency.
+        /// </summary>
         decimal FeesMarketCurrency { get; }
+
+        /// <summary>
+        /// The average cost per unit including fees.
+        /// </summary>
         decimal AverageCost { get; }
+
+        /// <summary>
+        /// The date and time of the sell order.
+        /// </summary>
         DateTimeOffset SellDate { get; }
+
+        /// <summary>
+        /// The price at which the position was sold.
+        /// </summary>
         decimal SellPrice { get; }
+
+        /// <summary>
+        /// The total cost received from the sell (amount * price).
+        /// </summary>
         decimal SellCost { get; }
+
+        /// <summary>
+        /// The difference between sell proceeds and total cost paid.
+        /// </summary>
         decimal BalanceDifference { get; }
+
+        /// <summary>
+        /// The profit percentage of the trade.
+        /// </summary>
         decimal Profit { get; }
+
+        /// <summary>
+        /// Additional metadata about the trade.
+        /// </summary>
         OrderMetadata Metadata { get; }
 
+        /// <summary>
+        /// Marks this trade result as part of a swap operation.
+        /// </summary>
+        /// <param name="isSwap">Whether this trade is a swap.</param>
         void SetSwap(bool isSwap);
     }
 }

--- a/IntelliTrader.Core/Interfaces/Trading/ITradingAccount.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/ITradingAccount.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -6,23 +6,80 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Manages the trading account state including positions, orders, and balances.
+    /// Provides both synchronous and asynchronous methods for order management.
+    /// </summary>
     public interface ITradingAccount : IDisposable
     {
+        /// <summary>
+        /// Synchronization object for thread-safe account operations.
+        /// </summary>
         object SyncRoot { get; }
 
-        // Synchronous methods (for backward compatibility)
+        /// <summary>
+        /// Refreshes account state from the exchange (balances, positions).
+        /// </summary>
         void Refresh();
+
+        /// <summary>
+        /// Persists the current account state to disk.
+        /// </summary>
         void Save();
+
+        /// <summary>
+        /// Records an order in the account (without updating position state).
+        /// </summary>
+        /// <param name="order">The order details to record.</param>
         void AddOrder(IOrderDetails order);
+
+        /// <summary>
+        /// Adds a buy order to the account and updates the corresponding trading pair position.
+        /// </summary>
+        /// <param name="order">The buy order details.</param>
         void AddBuyOrder(IOrderDetails order);
+
+        /// <summary>
+        /// Adds a sell order to the account, closes the position, and returns the trade result.
+        /// </summary>
+        /// <param name="order">The sell order details.</param>
+        /// <returns>The calculated trade result including profit/loss.</returns>
         ITradeResult AddSellOrder(IOrderDetails order);
+
+        /// <summary>
+        /// Places an order on the exchange.
+        /// </summary>
+        /// <param name="order">The order to place.</param>
+        /// <param name="metadata">Metadata to attach to the order.</param>
+        /// <returns>The order details if successful; null otherwise.</returns>
         IOrderDetails PlaceOrder(IOrder order, OrderMetadata metadata);
+
+        /// <summary>
+        /// Gets the current available account balance in market currency.
+        /// </summary>
+        /// <returns>The available balance.</returns>
         decimal GetBalance();
+
+        /// <summary>
+        /// Checks if a trading pair has an active position.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>True if the pair has an active position.</returns>
         bool HasTradingPair(string pair);
+
+        /// <summary>
+        /// Gets the trading pair position data.
+        /// </summary>
+        /// <param name="pair">The trading pair symbol.</param>
+        /// <returns>The trading pair position.</returns>
         ITradingPair GetTradingPair(string pair);
+
+        /// <summary>
+        /// Gets all active trading pair positions.
+        /// </summary>
+        /// <returns>Collection of active trading pairs.</returns>
         IEnumerable<ITradingPair> GetTradingPairs();
 
-        // Async methods (preferred for new code)
         /// <summary>
         /// Asynchronously refreshes the account state from the exchange.
         /// </summary>

--- a/IntelliTrader.Core/Interfaces/Trading/ITradingPair.cs
+++ b/IntelliTrader.Core/Interfaces/Trading/ITradingPair.cs
@@ -1,28 +1,98 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace IntelliTrader.Core
 {
+    /// <summary>
+    /// Represents an active trading position for a specific pair, including cost basis and current valuation.
+    /// </summary>
     public interface ITradingPair
     {
+        /// <summary>
+        /// The trading pair symbol (e.g., "BTCUSDT").
+        /// </summary>
         string Pair { get; }
+
+        /// <summary>
+        /// The formatted display name for this pair.
+        /// </summary>
         string FormattedName { get; }
+
+        /// <summary>
+        /// The current DCA (Dollar Cost Averaging) level (0 = initial buy, 1+ = DCA buys).
+        /// </summary>
         int DCALevel { get; }
+
+        /// <summary>
+        /// Exchange-assigned order IDs for all buy orders in this position.
+        /// </summary>
         List<string> OrderIds { get; }
+
+        /// <summary>
+        /// Timestamps of all buy orders in this position.
+        /// </summary>
         List<DateTimeOffset> OrderDates { get; }
+
+        /// <summary>
+        /// Total amount held in the pair's base currency.
+        /// </summary>
         decimal TotalAmount { get; }
+
+        /// <summary>
+        /// Volume-weighted average price paid across all buys.
+        /// </summary>
         decimal AveragePricePaid { get; }
+
+        /// <summary>
+        /// Total fees paid in the pair's base currency.
+        /// </summary>
         decimal FeesPairCurrency { get; }
+
+        /// <summary>
+        /// Total fees paid in the market currency.
+        /// </summary>
         decimal FeesMarketCurrency { get; }
+
+        /// <summary>
+        /// Average cost per unit including fees.
+        /// </summary>
         decimal AverageCostPaid { get; }
+
+        /// <summary>
+        /// Current cost of the position at market price (amount * current price).
+        /// </summary>
         decimal CurrentCost { get; }
+
+        /// <summary>
+        /// The current market price.
+        /// </summary>
         decimal CurrentPrice { get; }
+
+        /// <summary>
+        /// Current profit/loss margin as a percentage.
+        /// </summary>
         decimal CurrentMargin { get; }
+
+        /// <summary>
+        /// Time in minutes since the first buy order.
+        /// </summary>
         double CurrentAge { get; }
+
+        /// <summary>
+        /// Time in minutes since the most recent buy order.
+        /// </summary>
         double LastBuyAge { get; }
+
+        /// <summary>
+        /// Additional metadata attached to this position.
+        /// </summary>
         OrderMetadata Metadata { get; }
 
+        /// <summary>
+        /// Updates the current market price and recalculates derived values.
+        /// </summary>
+        /// <param name="currentPrice">The new current market price.</param>
         void SetCurrentPrice(decimal currentPrice);
     }
 }

--- a/IntelliTrader.Domain/IntelliTrader.Domain.csproj
+++ b/IntelliTrader.Domain/IntelliTrader.Domain.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>IntelliTrader.Domain</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/IntelliTrader.Domain/Rules/RuleEvaluationContext.cs
+++ b/IntelliTrader.Domain/Rules/RuleEvaluationContext.cs
@@ -31,6 +31,11 @@ public record RuleEvaluationContext
     /// </summary>
     public double SpeedMultiplier { get; init; } = 1.0;
 
+    /// <summary>
+    /// Gets the signal snapshot for a specific signal name.
+    /// </summary>
+    /// <param name="signalName">The signal name to look up.</param>
+    /// <returns>The signal snapshot, or null if not found.</returns>
     public SignalSnapshot? GetSignal(string? signalName)
     {
         if (signalName is null) return null;
@@ -43,14 +48,31 @@ public record RuleEvaluationContext
 /// </summary>
 public record SignalSnapshot
 {
+    /// <summary>The signal source name.</summary>
     public string Name { get; init; } = string.Empty;
+
+    /// <summary>The trading pair symbol.</summary>
     public string Pair { get; init; } = string.Empty;
+
+    /// <summary>The 24-hour trading volume.</summary>
     public long? Volume { get; init; }
+
+    /// <summary>The percentage change in volume.</summary>
     public double? VolumeChange { get; init; }
+
+    /// <summary>The current price from the signal source.</summary>
     public decimal? Price { get; init; }
+
+    /// <summary>The percentage change in price.</summary>
     public decimal? PriceChange { get; init; }
+
+    /// <summary>The signal rating score.</summary>
     public double? Rating { get; init; }
+
+    /// <summary>The change in signal rating.</summary>
     public double? RatingChange { get; init; }
+
+    /// <summary>The price volatility measurement.</summary>
     public double? Volatility { get; init; }
 }
 
@@ -59,13 +81,30 @@ public record SignalSnapshot
 /// </summary>
 public record PositionSnapshot
 {
+    /// <summary>The trading pair symbol.</summary>
     public string Pair { get; init; } = string.Empty;
+
+    /// <summary>Time since the first buy order.</summary>
     public TimeSpan CurrentAge { get; init; }
+
+    /// <summary>Time since the most recent buy order.</summary>
     public TimeSpan LastBuyAge { get; init; }
+
+    /// <summary>Current profit/loss margin as a percentage.</summary>
     public decimal CurrentMargin { get; init; }
+
+    /// <summary>Margin at the time of the last buy, if available.</summary>
     public decimal? LastBuyMargin { get; init; }
+
+    /// <summary>Total amount held in the pair's base currency.</summary>
     public decimal TotalAmount { get; init; }
+
+    /// <summary>Current cost of the position at market price.</summary>
     public decimal CurrentCost { get; init; }
+
+    /// <summary>The current DCA level (0 = initial buy).</summary>
     public int DCALevel { get; init; }
+
+    /// <summary>The signal rule that triggered the initial buy.</summary>
     public string? SignalRule { get; init; }
 }

--- a/IntelliTrader.Domain/Rules/Specifications/GlobalSpecifications.cs
+++ b/IntelliTrader.Domain/Rules/Specifications/GlobalSpecifications.cs
@@ -4,6 +4,9 @@ namespace IntelliTrader.Domain.Rules.Specifications;
 
 #region Global Rating Specifications
 
+/// <summary>
+/// Specification that checks if the global market rating is at or above a minimum threshold.
+/// </summary>
 public class MinGlobalRatingSpecification : Specification<RuleEvaluationContext>
 {
     private readonly double _minGlobalRating;
@@ -19,6 +22,9 @@ public class MinGlobalRatingSpecification : Specification<RuleEvaluationContext>
     }
 }
 
+/// <summary>
+/// Specification that checks if the global market rating is at or below a maximum threshold.
+/// </summary>
 public class MaxGlobalRatingSpecification : Specification<RuleEvaluationContext>
 {
     private readonly double _maxGlobalRating;
@@ -38,6 +44,9 @@ public class MaxGlobalRatingSpecification : Specification<RuleEvaluationContext>
 
 #region Pair Filter Specifications
 
+/// <summary>
+/// Specification that checks if the trading pair is in an allowed whitelist.
+/// </summary>
 public class PairWhitelistSpecification : Specification<RuleEvaluationContext>
 {
     private readonly HashSet<string> _allowedPairs;


### PR DESCRIPTION
## Summary
- Enable XML documentation file generation (`GenerateDocumentationFile`) in Core, Domain, and Application csproj files with CS1591 warning suppression
- Add comprehensive XML doc comments (`<summary>`, `<param>`, `<returns>`, `<remarks>`) to **all 50+ public interfaces** in `IntelliTrader.Core/Interfaces/`
- Document key Domain types: `RuleEvaluationContext`, `SignalSnapshot`, `PositionSnapshot`, and `GlobalSpecifications`
- No logic changes -- documentation only

## Coverage
- **Config interfaces**: IAlertingConfig, IBacktestingConfig, ICachingConfig, IConfigProvider, ICoreConfig, ILoggingConfig, INotificationConfig, IRiskManagementConfig, IRulesConfig, ISignalsConfig, ITradingConfig, IWebConfig
- **Service interfaces**: IAlertingService, IATRCalculator, IAuditService, IBacktestingService, ICachingService, ICoreService, IDynamicStopLossManager, IExchangeService, IHealthCheckService, IIntegrationService, ILoggingService, INotificationService, IPasswordService, IPortfolioRiskManager, IRulesService, ISecretRotationService, ISignalsService, ITradingHubNotifier, ITradingService, IWebService
- **Trading interfaces**: IBuyConfig, IBuyDCAConfig, IBuyOrchestrator, IOrder, IOrderDetails, IPairConfig, IPositionSizer, ISellConfig, ISellDCAConfig, ISellOrchestrator, IStopLossConfig, ISwapOrchestrator, ITradeResult, ITradingAccount, ITradingPair, ITrailingOrderManager
- **Signal/Rule interfaces**: ISignal, ISignalDefinition, ISignalTrailingInfo, IModuleRules, IRule, IRuleCondition, IRuleTrailing, ISignalRulesConfig, RuleProcessingMode
- **Base**: IConfigurableService, INamedService, IHealthCheck, ITicker

Closes #25

## Test plan
- [ ] Verify solution builds without errors
- [ ] Verify XML documentation files are generated in build output
- [ ] Spot-check generated XML docs render correctly in IDE tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)