### PR TITLE
fix(security): remove Html.Raw XSS vectors from Razor views

### DIFF
--- a/IntelliTrader.Web/Views/Home/Log.cshtml
+++ b/IntelliTrader.Web/Views/Home/Log.cshtml
@@ -8,7 +8,7 @@
     <hr />
     <div class="log">
         @foreach (var entry in Model.LogEntries) {
-        <div>@Html.Raw(entry)</div>
+        <div>@entry</div>
         }
     </div>
     <hr />

--- a/IntelliTrader.Web/Views/Home/Settings.cshtml
+++ b/IntelliTrader.Web/Views/Home/Settings.cshtml
@@ -45,8 +45,8 @@
         {
             <div class="tab-pane" id="tab_@kvp.Key">
                 <div class="config-container">
-                    <div class="config-value" id="@Html.Raw(kvp.Key + "Value")" data-config="@kvp.Key">@Html.Raw(kvp.Value)</div>
-                    <div class="config-editor" id="@Html.Raw(kvp.Key + "Editor")" data-config="@kvp.Key"></div>
+                    <div class="config-value" id="@(kvp.Key + "Value")" data-config="@kvp.Key">@kvp.Value</div>
+                    <div class="config-editor" id="@(kvp.Key + "Editor")" data-config="@kvp.Key"></div>
                 </div>
                 <div class="config-options bg-dark">
                     <span class="save-config-status" id="saveConfigStatus"></span>

--- a/IntelliTrader.Web/Views/Home/Stats.cshtml
+++ b/IntelliTrader.Web/Views/Home/Stats.cshtml
@@ -34,15 +34,15 @@
                     <td>@kvp.Key.ToString("yyyy-MM-dd")</td>
                     <td>@Html.ActionLink(kvp.Value.Count.ToString(), "Trades", "Home", new { id = kvp.Key.ToString("o") }, new { @class = "btn btb-sm btn-success trades-link" })</td>
                     <td>@kvp.Value.Where(t => !t.IsSwap).Sum(t => t.Profit).ToString("0.00000000")</td>
-                    <td>@{ var percentage = kvp.Value.Where(t => !t.IsSwap).Sum(t => t.Profit) / Model.Balances[kvp.Key] * 100; @Html.Raw(percentage.ToString("0.00")); }</td>
+                    <td>@{ var percentage = kvp.Value.Where(t => !t.IsSwap).Sum(t => t.Profit) / Model.Balances[kvp.Key] * 100; @(percentage.ToString("0.00")); }</td>
                     <td>
                         @{ var trades = kvp.Value.Where(t => !t.IsSwap && t.OrderDates != null && t.OrderDates.Count == 1); if (trades.Count() > 0)
                             {
                                 var avgMargin = trades.Average(t => t.Profit / (t.AverageCost + (t.Metadata?.AdditionalCosts ?? 0)) * 100);
-                                @Html.Raw(avgMargin.ToString("0.00"));
+                                @(avgMargin.ToString("0.00"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>
@@ -50,10 +50,10 @@
                         @{ var tradesDCA = kvp.Value.Where(t => !t.IsSwap && t.OrderDates != null && t.OrderDates.Count > 1); if (tradesDCA.Count() > 0)
                             {
                                 var avgMargin = tradesDCA.Average(t => t.Profit / (t.AverageCost + (t.Metadata?.AdditionalCosts ?? 0)) * 100);
-                                @Html.Raw(avgMargin.ToString("0.00"));
+                                @(avgMargin.ToString("0.00"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>
@@ -61,10 +61,10 @@
                         @{ var tradesRatingBought = kvp.Value.Where(t => t.Metadata?.BoughtRating != null); if (tradesRatingBought.Count() > 0)
                             {
                                 var avgRatingBought = tradesRatingBought.Average(t => t.Metadata.BoughtRating.Value);
-                                @Html.Raw(avgRatingBought.ToString("0.000"));
+                                @(avgRatingBought.ToString("0.000"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>
@@ -72,10 +72,10 @@
                         @{ var tradesRatingSold = kvp.Value.Where(t => t.Metadata?.CurrentRating != null); if (tradesRatingSold.Count() > 0)
                             {
                                 var avgRatingSold = tradesRatingSold.Average(t => t.Metadata.CurrentRating.Value);
-                                @Html.Raw(avgRatingSold.ToString("0.000"));
+                                @(avgRatingSold.ToString("0.000"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>
@@ -83,10 +83,10 @@
                         @{ var tradesGlobalRatingBought = kvp.Value.Where(t => t.Metadata?.BoughtGlobalRating != null); if (tradesGlobalRatingBought.Count() > 0)
                             {
                                 var avgGlobalRatingBought = tradesGlobalRatingBought.Average(t => t.Metadata.BoughtGlobalRating.Value);
-                                @Html.Raw(avgGlobalRatingBought.ToString("0.000"));
+                                @(avgGlobalRatingBought.ToString("0.000"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>
@@ -94,10 +94,10 @@
                         @{ var tradesGlobalRatingSold = kvp.Value.Where(t => t.Metadata?.CurrentGlobalRating != null); if (tradesGlobalRatingSold.Count() > 0)
                             {
                                 var avgGlobalRatingSold = tradesGlobalRatingSold.Average(t => t.Metadata.CurrentGlobalRating.Value);
-                                @Html.Raw(avgGlobalRatingSold.ToString("0.000"));
+                                @(avgGlobalRatingSold.ToString("0.000"));
                             } else
                             {
-                                @Html.Raw("N/A");
+                                @:N/A
                             }
                         }
                     </td>

--- a/IntelliTrader.Web/Views/Home/Trades.cshtml
+++ b/IntelliTrader.Web/Views/Home/Trades.cshtml
@@ -33,15 +33,15 @@
             <tr>
                 <td>@trade.SellDate.ToOffset(TimeSpan.FromHours(Model.TimezoneOffset)).ToString("yyyy-MM-dd HH:mm:ss")</td>
                 <td>@trade.Pair</td>
-                <td>@Html.Raw((trade.OrderDates.Count - 1) + (trade.Metadata?.AdditionalDCALevels ?? 0))</td>
+                <td>@((trade.OrderDates.Count - 1) + (trade.Metadata?.AdditionalDCALevels ?? 0))</td>
                 <td>@trade.Profit.ToString("0.00000000")</td>
-                <td>@Html.Raw((trade.Profit / (trade.AverageCost + (trade.Metadata?.AdditionalCosts ?? 0)) * 100).ToString("0.00"))</td>
-                <td>@if (trade.Metadata?.BoughtRating != null) { @Html.Raw(trade.Metadata.BoughtRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
-                <td>@if (trade.Metadata?.CurrentRating != null) { @Html.Raw(trade.Metadata.CurrentRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
-                <td>@if (trade.Metadata?.BoughtGlobalRating != null) { @Html.Raw(trade.Metadata.BoughtGlobalRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
-                <td>@if (trade.Metadata?.CurrentGlobalRating != null) { @Html.Raw(trade.Metadata.CurrentGlobalRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
-                <td>@if (trade.Metadata?.SignalRule != null) { @Html.Raw(trade.Metadata.SignalRule); } else { <text>N/A</text> }</td>
-                <td>@if (trade.Metadata?.SwapPair != null && trade.IsSwap) { @Html.Raw(trade.Metadata.SwapPair); } else { <text>N/A</text> }</td>
+                <td>@((trade.Profit / (trade.AverageCost + (trade.Metadata?.AdditionalCosts ?? 0)) * 100).ToString("0.00"))</td>
+                <td>@if (trade.Metadata?.BoughtRating != null) { @(trade.Metadata.BoughtRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
+                <td>@if (trade.Metadata?.CurrentRating != null) { @(trade.Metadata.CurrentRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
+                <td>@if (trade.Metadata?.BoughtGlobalRating != null) { @(trade.Metadata.BoughtGlobalRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
+                <td>@if (trade.Metadata?.CurrentGlobalRating != null) { @(trade.Metadata.CurrentGlobalRating.Value.ToString("0.000")); } else { <text>N/A</text> }</td>
+                <td>@if (trade.Metadata?.SignalRule != null) { @(trade.Metadata.SignalRule); } else { <text>N/A</text> }</td>
+                <td>@if (trade.Metadata?.SwapPair != null && trade.IsSwap) { @(trade.Metadata.SwapPair); } else { <text>N/A</text> }</td>
             </tr>
             }
         </tbody>


### PR DESCRIPTION
## Summary

- Replaced all `@Html.Raw(...)` calls across 4 Razor view files with auto-encoded Razor equivalents (`@(...)`, `@entry`, `@kvp.Value`, `@:N/A`) to eliminate XSS vulnerabilities
- **Log.cshtml**: `@Html.Raw(entry)` -> `@entry` (log entries now HTML-encoded)
- **Settings.cshtml**: `@Html.Raw(kvp.Value)` -> `@kvp.Value` and `@Html.Raw(kvp.Key + ...)` -> `@(kvp.Key + ...)` (config JSON and element IDs now safe)
- **Trades.cshtml**: All 9 `Html.Raw` calls replaced with `@(...)` for computed values, `SignalRule`, and `SwapPair` metadata
- **Stats.cshtml**: All 13 `Html.Raw` calls replaced — numeric formatting uses `@(...)`, literal "N/A" uses `@:N/A`

Closes #73

## Test plan

- [ ] Verify Log page renders log entries correctly (special characters like `<`, `>`, `&` should appear as text, not HTML)
- [ ] Verify Settings page loads and JSON editor initializes properly (JS reads config via `.text()` which handles HTML-decoded content)
- [ ] Verify Trades page displays all columns including DCA Level, Margin, ratings, SignalRule, and SwapPair
- [ ] Verify Stats page displays percentage, margin, and rating columns with proper decimal formatting
- [ ] Confirm no `Html.Raw` calls remain in any `.cshtml` file under `Views/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security across application views by implementing proper HTML content escaping for dynamically rendered values throughout logs, settings, performance statistics, and trade history displays. This prevents potential script injection vulnerabilities and ensures all user-facing data is safely rendered without bypassing security protections, improving overall platform integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->