### PR TITLE
fix: resolve thread safety bugs across concurrent services

### DIFF
--- a/IntelliTrader.Core/Services/CachingService.cs
+++ b/IntelliTrader.Core/Services/CachingService.cs
@@ -21,26 +21,27 @@ namespace IntelliTrader.Core
 
         ICachingConfig ICachingService.Config => Config;
 
-        private readonly ConcurrentDictionary<string, CachedObject> cachedObjects = new ConcurrentDictionary<string, CachedObject>();
+        private readonly ConcurrentDictionary<string, Lazy<CachedObject>> cachedObjects = new ConcurrentDictionary<string, Lazy<CachedObject>>();
 
         // Shared cache
         private readonly JsonSerializerOptions serializerOptions = new JsonSerializerOptions();
         private DateTimeOffset lastSharedCacheCleanup = DateTimeOffset.Now;
         private DirectoryInfo? sharedCacheDirectoryInfo;
         private readonly int processId = Process.GetCurrentProcess().Id;
+        private readonly object sharedCacheLock = new object();
 
         public T? GetOrRefresh<T>(string objectName, Func<T> refresh)
         {
-            lock (cachedObjects)
-            {
-                T? value = default;
+            T? value = default;
 
-                if (Config.Enabled)
+            if (Config.Enabled)
+            {
+                var maxAge = Config.MaxAge.FirstOrDefault(m => m.Key == objectName).Value;
+                if (maxAge > 0)
                 {
-                    var maxAge = Config.MaxAge.FirstOrDefault(m => m.Key == objectName).Value;
-                    if (maxAge > 0)
+                    if (Config.Shared)
                     {
-                        if (Config.Shared)
+                        lock (sharedCacheLock)
                         {
                             if (sharedCacheDirectoryInfo == null)
                             {
@@ -85,42 +86,50 @@ namespace IntelliTrader.Core
                                 ThreadPool.QueueUserWorkItem((state) => CleanupSharedCache());
                             }
                         }
-                        else
-                        {
-                            if (cachedObjects.TryGetValue(objectName, out CachedObject? obj) && (DateTimeOffset.Now - obj.LastUpdated).TotalSeconds <= maxAge)
-                            {
-                                value = (T?)obj.Value;
-                            }
-                            else
-                            {
-                                value = refresh();
-
-                                cachedObjects[objectName] = new CachedObject
-                                {
-                                    LastUpdated = DateTimeOffset.Now,
-                                    Value = value
-                                };
-
-                            }
-                        }
                     }
                     else
                     {
-                        value = refresh();
+                        var lazyObj = cachedObjects.GetOrAdd(objectName, _ => new Lazy<CachedObject>(() => new CachedObject
+                        {
+                            LastUpdated = DateTimeOffset.Now,
+                            Value = refresh()
+                        }));
+
+                        var obj = lazyObj.Value;
+
+                        if ((DateTimeOffset.Now - obj.LastUpdated).TotalSeconds <= maxAge)
+                        {
+                            value = (T?)obj.Value;
+                        }
+                        else
+                        {
+                            // Entry expired, replace it atomically
+                            var newLazy = new Lazy<CachedObject>(() => new CachedObject
+                            {
+                                LastUpdated = DateTimeOffset.Now,
+                                Value = refresh()
+                            });
+                            cachedObjects[objectName] = newLazy;
+                            value = (T?)newLazy.Value.Value;
+                        }
                     }
                 }
                 else
                 {
                     value = refresh();
                 }
-
-                return value;
             }
+            else
+            {
+                value = refresh();
+            }
+
+            return value;
         }
 
         private void CleanupSharedCache()
         {
-            lock (cachedObjects)
+            lock (sharedCacheLock)
             {
                 if ((DateTimeOffset.Now - lastSharedCacheCleanup).TotalSeconds > Config.SharedCacheCleanupInterval)
                 {

--- a/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
+++ b/IntelliTrader.Core/Services/ConfigurableServiceBase.cs
@@ -73,15 +73,25 @@ namespace IntelliTrader.Core
 
         private void OnRawConfigChanged(IConfigurationSection changedRawConfig)
         {
+            bool shouldReload;
             lock (syncRoot)
             {
                 rawConfig = changedRawConfig;
                 config = null;
+
+                if ((DateTimeOffset.Now - lastReloadDate).TotalMilliseconds > DELAY_BETWEEN_CONFIG_RELOADS_MILLISECONDS)
+                {
+                    lastReloadDate = DateTimeOffset.Now;
+                    shouldReload = true;
+                }
+                else
+                {
+                    shouldReload = false;
+                }
             }
 
-            if ((DateTimeOffset.Now - lastReloadDate).TotalMilliseconds > DELAY_BETWEEN_CONFIG_RELOADS_MILLISECONDS)
+            if (shouldReload)
             {
-                lastReloadDate = DateTimeOffset.Now;
                 PrepareConfig();
                 OnConfigReloaded();
                 LoggingService?.Info($"{ServiceName} configuration reloaded");

--- a/IntelliTrader.Core/Services/HealthCheckService.cs
+++ b/IntelliTrader.Core/Services/HealthCheckService.cs
@@ -47,22 +47,22 @@ namespace IntelliTrader.Core
 
         public void UpdateHealthCheck(string name, string message = null, bool failed = false)
         {
-            if (!healthChecks.TryGetValue(name, out HealthCheck existingHealthCheck))
-            {
-                healthChecks.TryAdd(name, new HealthCheck
+            healthChecks.AddOrUpdate(
+                name,
+                _ => new HealthCheck
                 {
                     Name = name,
                     Message = message,
                     LastUpdated = DateTimeOffset.Now,
                     Failed = failed
+                },
+                (_, existing) =>
+                {
+                    existing.Message = message;
+                    existing.LastUpdated = DateTimeOffset.Now;
+                    existing.Failed = failed;
+                    return existing;
                 });
-            }
-            else
-            {
-                healthChecks[name].Message = message;
-                healthChecks[name].LastUpdated = DateTimeOffset.Now;
-                healthChecks[name].Failed = failed;
-            }
         }
 
         public void RemoveHealthCheck(string name)

--- a/IntelliTrader.Domain/Trading/Aggregates/Portfolio/Portfolio.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Portfolio/Portfolio.cs
@@ -12,6 +12,7 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
 {
     private readonly Dictionary<TradingPair, PositionId> _activePositions = new();
     private readonly Dictionary<PositionId, Money> _positionCosts = new();
+    private readonly object _positionLock = new();
 
     /// <summary>
     /// The name of this portfolio.
@@ -140,37 +141,40 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
         ArgumentNullException.ThrowIfNull(cost);
         EnsureSameCurrency(cost);
 
-        if (HasPositionFor(pair))
-            throw new InvalidOperationException($"Position already exists for {pair}");
-
-        if (IsAtMaxPositions)
+        lock (_positionLock)
         {
-            AddDomainEvent(new MaxPositionsReached(Id, MaxPositions, ActivePositionCount));
-            throw new InvalidOperationException($"Maximum positions ({MaxPositions}) reached");
+            if (HasPositionFor(pair))
+                throw new InvalidOperationException($"Position already exists for {pair}");
+
+            if (IsAtMaxPositions)
+            {
+                AddDomainEvent(new MaxPositionsReached(Id, MaxPositions, ActivePositionCount));
+                throw new InvalidOperationException($"Maximum positions ({MaxPositions}) reached");
+            }
+
+            if (!CanAfford(cost))
+                throw new InvalidOperationException($"Insufficient funds. Available: {Balance.Available}, Required: {cost}");
+
+            var previousBalance = Balance;
+            Balance = Balance.Reserve(cost);
+            _activePositions[pair] = positionId;
+            _positionCosts[positionId] = cost;
+
+            AddDomainEvent(new PositionAddedToPortfolio(
+                Id,
+                positionId,
+                pair,
+                cost,
+                ActivePositionCount));
+
+            AddDomainEvent(new PortfolioBalanceChanged(
+                Id,
+                previousBalance.Total,
+                Balance.Total,
+                previousBalance.Available,
+                Balance.Available,
+                $"Position opened for {pair}"));
         }
-
-        if (!CanAfford(cost))
-            throw new InvalidOperationException($"Insufficient funds. Available: {Balance.Available}, Required: {cost}");
-
-        var previousBalance = Balance;
-        Balance = Balance.Reserve(cost);
-        _activePositions[pair] = positionId;
-        _positionCosts[positionId] = cost;
-
-        AddDomainEvent(new PositionAddedToPortfolio(
-            Id,
-            positionId,
-            pair,
-            cost,
-            ActivePositionCount));
-
-        AddDomainEvent(new PortfolioBalanceChanged(
-            Id,
-            previousBalance.Total,
-            Balance.Total,
-            previousBalance.Available,
-            Balance.Available,
-            $"Position opened for {pair}"));
     }
 
     /// <summary>
@@ -183,26 +187,29 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
         ArgumentNullException.ThrowIfNull(additionalCost);
         EnsureSameCurrency(additionalCost);
 
-        if (!HasPositionFor(pair))
-            throw new InvalidOperationException($"No position exists for {pair}");
+        lock (_positionLock)
+        {
+            if (!HasPositionFor(pair))
+                throw new InvalidOperationException($"No position exists for {pair}");
 
-        if (_activePositions[pair] != positionId)
-            throw new InvalidOperationException($"Position ID mismatch for {pair}");
+            if (_activePositions[pair] != positionId)
+                throw new InvalidOperationException($"Position ID mismatch for {pair}");
 
-        if (!CanAfford(additionalCost))
-            throw new InvalidOperationException($"Insufficient funds. Available: {Balance.Available}, Required: {additionalCost}");
+            if (!CanAfford(additionalCost))
+                throw new InvalidOperationException($"Insufficient funds. Available: {Balance.Available}, Required: {additionalCost}");
 
-        var previousBalance = Balance;
-        Balance = Balance.Reserve(additionalCost);
-        _positionCosts[positionId] = _positionCosts[positionId] + additionalCost;
+            var previousBalance = Balance;
+            Balance = Balance.Reserve(additionalCost);
+            _positionCosts[positionId] = _positionCosts[positionId] + additionalCost;
 
-        AddDomainEvent(new PortfolioBalanceChanged(
-            Id,
-            previousBalance.Total,
-            Balance.Total,
-            previousBalance.Available,
-            Balance.Available,
-            $"DCA executed for {pair}"));
+            AddDomainEvent(new PortfolioBalanceChanged(
+                Id,
+                previousBalance.Total,
+                Balance.Total,
+                previousBalance.Available,
+                Balance.Available,
+                $"DCA executed for {pair}"));
+        }
     }
 
     /// <summary>
@@ -215,39 +222,42 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
         ArgumentNullException.ThrowIfNull(proceeds);
         EnsureSameCurrency(proceeds);
 
-        if (!HasPositionFor(pair))
-            throw new InvalidOperationException($"No position exists for {pair}");
+        lock (_positionLock)
+        {
+            if (!HasPositionFor(pair))
+                throw new InvalidOperationException($"No position exists for {pair}");
 
-        if (_activePositions[pair] != positionId)
-            throw new InvalidOperationException($"Position ID mismatch for {pair}");
+            if (_activePositions[pair] != positionId)
+                throw new InvalidOperationException($"Position ID mismatch for {pair}");
 
-        var cost = _positionCosts[positionId];
-        var pnl = proceeds - cost;
+            var cost = _positionCosts[positionId];
+            var pnl = proceeds - cost;
 
-        var previousBalance = Balance;
+            var previousBalance = Balance;
 
-        // Release the reserved cost and record PnL
-        Balance = Balance.Release(cost);
-        Balance = Balance.RecordPnL(pnl);
+            // Release the reserved cost and record PnL
+            Balance = Balance.Release(cost);
+            Balance = Balance.RecordPnL(pnl);
 
-        _activePositions.Remove(pair);
-        _positionCosts.Remove(positionId);
+            _activePositions.Remove(pair);
+            _positionCosts.Remove(positionId);
 
-        AddDomainEvent(new PositionRemovedFromPortfolio(
-            Id,
-            positionId,
-            pair,
-            proceeds,
-            pnl,
-            ActivePositionCount));
+            AddDomainEvent(new PositionRemovedFromPortfolio(
+                Id,
+                positionId,
+                pair,
+                proceeds,
+                pnl,
+                ActivePositionCount));
 
-        AddDomainEvent(new PortfolioBalanceChanged(
-            Id,
-            previousBalance.Total,
-            Balance.Total,
-            previousBalance.Available,
-            Balance.Available,
-            $"Position closed for {pair}, PnL: {pnl}"));
+            AddDomainEvent(new PortfolioBalanceChanged(
+                Id,
+                previousBalance.Total,
+                Balance.Total,
+                previousBalance.Available,
+                Balance.Available,
+                $"Position closed for {pair}, PnL: {pnl}"));
+        }
     }
 
     /// <summary>
@@ -297,9 +307,12 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
     /// </summary>
     public Money GetTotalInvestedCost()
     {
-        return _positionCosts.Values.Aggregate(
-            Money.Zero(Market),
-            (sum, cost) => sum + cost);
+        lock (_positionLock)
+        {
+            return _positionCosts.Values.Aggregate(
+                Money.Zero(Market),
+                (sum, cost) => sum + cost);
+        }
     }
 
     /// <summary>
@@ -315,7 +328,10 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
     /// </summary>
     public IReadOnlyCollection<TradingPair> GetActivePairs()
     {
-        return _activePositions.Keys.ToList().AsReadOnly();
+        lock (_positionLock)
+        {
+            return _activePositions.Keys.ToList().AsReadOnly();
+        }
     }
 
     /// <summary>

--- a/IntelliTrader.Exchange.Binance/Services/BinanceWebSocketService.cs
+++ b/IntelliTrader.Exchange.Binance/Services/BinanceWebSocketService.cs
@@ -37,8 +37,9 @@ namespace IntelliTrader.Exchange.Binance
         private readonly IHealthCheckService _healthCheckService;
         private readonly HttpClient _httpClient;
         private readonly ConcurrentDictionary<string, Ticker> _tickers;
-        private readonly HashSet<string> _subscribedPairs;
+        private readonly ConcurrentDictionary<string, byte> _subscribedPairs;
         private readonly SemaphoreSlim _connectionLock;
+        private bool _reconnecting;
         private readonly object _stateLock = new();
 
         private ClientWebSocket? _webSocket;
@@ -100,7 +101,7 @@ namespace IntelliTrader.Exchange.Binance
             };
 
             _tickers = new ConcurrentDictionary<string, Ticker>();
-            _subscribedPairs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _subscribedPairs = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
             _connectionLock = new SemaphoreSlim(1, 1);
             _lastUpdateTime = DateTimeOffset.MinValue;
         }
@@ -251,7 +252,7 @@ namespace IntelliTrader.Exchange.Binance
 
             foreach (var pair in pairsList)
             {
-                _subscribedPairs.Add(pair.ToUpperInvariant());
+                _subscribedPairs.TryAdd(pair.ToUpperInvariant(), 0);
             }
 
             if (!IsConnected || _webSocket == null)
@@ -280,7 +281,7 @@ namespace IntelliTrader.Exchange.Binance
 
             foreach (var pair in pairsList)
             {
-                _subscribedPairs.Remove(pair.ToUpperInvariant());
+                _subscribedPairs.TryRemove(pair.ToUpperInvariant(), out _);
             }
 
             if (!IsConnected || _webSocket == null)
@@ -314,9 +315,10 @@ namespace IntelliTrader.Exchange.Binance
                 await ConnectInternalAsync(cancellationToken);
 
                 // Resubscribe to any previously subscribed pairs
-                if (_subscribedPairs.Count > 0)
+                var pairs = _subscribedPairs.Keys.ToList();
+                if (pairs.Count > 0)
                 {
-                    await SubscribeToTickersAsync(_subscribedPairs, cancellationToken);
+                    await SubscribeToTickersAsync(pairs, cancellationToken);
                 }
             }
             catch (Exception ex)
@@ -607,31 +609,47 @@ namespace IntelliTrader.Exchange.Binance
         {
             if (_disposed) return;
 
+            lock (_stateLock)
+            {
+                if (_reconnecting) return;
+                _reconnecting = true;
+            }
+
             _loggingService.Warning("WebSocket connection lost, attempting reconnect...");
 
             // Ensure we don't hold the connection lock during reconnect
             _ = Task.Run(async () =>
             {
-                while (_reconnectAttempts < MaxReconnectAttempts && !_disposed)
+                try
                 {
-                    _reconnectAttempts++;
-                    _loggingService.Info($"Reconnection attempt {_reconnectAttempts}/{MaxReconnectAttempts}");
+                    while (_reconnectAttempts < MaxReconnectAttempts && !_disposed)
+                    {
+                        _reconnectAttempts++;
+                        _loggingService.Info($"Reconnection attempt {_reconnectAttempts}/{MaxReconnectAttempts}");
 
-                    try
-                    {
-                        await ReconnectAsync(CancellationToken.None);
-                        _loggingService.Info("WebSocket reconnected successfully");
-                        return;
+                        try
+                        {
+                            await ReconnectAsync(CancellationToken.None);
+                            _loggingService.Info("WebSocket reconnected successfully");
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            _loggingService.Warning($"Reconnection attempt failed: {ex.Message}");
+                            await Task.Delay(TimeSpan.FromSeconds(ReconnectDelaySeconds * _reconnectAttempts));
+                        }
                     }
-                    catch (Exception ex)
+
+                    // Max reconnect attempts reached, switch to REST fallback
+                    await HandleReconnectFailureAsync(CancellationToken.None);
+                }
+                finally
+                {
+                    lock (_stateLock)
                     {
-                        _loggingService.Warning($"Reconnection attempt failed: {ex.Message}");
-                        await Task.Delay(TimeSpan.FromSeconds(ReconnectDelaySeconds * _reconnectAttempts));
+                        _reconnecting = false;
                     }
                 }
-
-                // Max reconnect attempts reached, switch to REST fallback
-                await HandleReconnectFailureAsync(CancellationToken.None);
             });
         }
 

--- a/IntelliTrader.Rules/Services/RulesService.cs
+++ b/IntelliTrader.Rules/Services/RulesService.cs
@@ -20,6 +20,7 @@ namespace IntelliTrader.Rules
         IRulesConfig IRulesService.Config => Config;
 
         private readonly List<Action> rulesChangeCallbacks = new List<Action>();
+        private readonly object _callbackLock = new object();
 
         public IModuleRules GetRules(string module)
         {
@@ -78,17 +79,28 @@ namespace IntelliTrader.Rules
 
         public void RegisterRulesChangeCallback(Action callback)
         {
-            rulesChangeCallbacks.Add(callback);
+            lock (_callbackLock)
+            {
+                rulesChangeCallbacks.Add(callback);
+            }
         }
 
         public void UnregisterRulesChangeCallback(Action callback)
         {
-            rulesChangeCallbacks.Remove(callback);
+            lock (_callbackLock)
+            {
+                rulesChangeCallbacks.Remove(callback);
+            }
         }
 
         protected override void OnConfigReloaded()
         {
-            foreach (var callback in rulesChangeCallbacks)
+            Action[] callbacks;
+            lock (_callbackLock)
+            {
+                callbacks = rulesChangeCallbacks.ToArray();
+            }
+            foreach (var callback in callbacks)
             {
                 callback();
             }

--- a/IntelliTrader.Trading/Services/PortfolioRiskManager.cs
+++ b/IntelliTrader.Trading/Services/PortfolioRiskManager.cs
@@ -185,19 +185,22 @@ namespace IntelliTrader.Trading
 
             decimal currentEquity = GetCurrentEquity();
 
-            if (_peakEquity <= 0)
+            lock (_syncRoot)
             {
-                _peakEquity = currentEquity;
-                return 0m;
-            }
+                if (_peakEquity <= 0)
+                {
+                    _peakEquity = currentEquity;
+                    return 0m;
+                }
 
-            if (currentEquity >= _peakEquity)
-            {
-                _peakEquity = currentEquity;
-                return 0m;
-            }
+                if (currentEquity >= _peakEquity)
+                {
+                    _peakEquity = currentEquity;
+                    return 0m;
+                }
 
-            return ((_peakEquity - currentEquity) / _peakEquity) * 100m;
+                return ((_peakEquity - currentEquity) / _peakEquity) * 100m;
+            }
         }
 
         /// <inheritdoc />
@@ -279,9 +282,12 @@ namespace IntelliTrader.Trading
                 return;
             }
 
-            if (currentEquity > _peakEquity)
+            lock (_syncRoot)
             {
-                _peakEquity = currentEquity;
+                if (currentEquity > _peakEquity)
+                {
+                    _peakEquity = currentEquity;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- **BinanceWebSocketService**: Replace `HashSet<string>` with `ConcurrentDictionary<string, byte>` for `_subscribedPairs`; add `_reconnecting` flag guarded by `_stateLock` to prevent unbounded parallel reconnect attempts
- **CachingService**: Remove global lock serializing all cache access; use `ConcurrentDictionary.GetOrAdd` with `Lazy<T>` for per-key locking on in-memory cache; use dedicated lock for shared (file-based) cache
- **PortfolioRiskManager**: Guard `_peakEquity` reads/writes with `_syncRoot` lock consistently in `UpdatePeakEquity` and `GetCurrentDrawdown`
- **RulesService**: Add lock around `rulesChangeCallbacks` list for register/unregister/iterate to prevent concurrent modification
- **Portfolio**: Add `_positionLock` around dictionary mutations and reads (`RecordPositionOpened`, `RecordPositionClosed`, `RecordPositionCostIncreased`, `GetActivePairs`, `GetTotalInvestedCost`)
- **ConfigurableServiceBase**: Move throttle check and `lastReloadDate` update inside the existing `syncRoot` lock to eliminate race condition
- **HealthCheckService**: Use `AddOrUpdate` instead of `TryGetValue` + mutate to eliminate TOCTOU race

Closes #75

## Test plan

- [ ] Verify solution builds successfully
- [ ] Run existing unit tests to confirm no regressions
- [ ] Review each fix for correctness of lock scope (no deadlocks, minimal contention)
- [ ] Confirm `Dispose()` in BinanceWebSocketService was NOT modified (scoped to #77)
- [ ] Confirm no files in `IntelliTrader.Web/` were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)