### PR TITLE
fix(trading): resolve 6 critical trading logic bugs

### DIFF
--- a/IntelliTrader.Domain/Trading/Services/MarginCalculator.cs
+++ b/IntelliTrader.Domain/Trading/Services/MarginCalculator.cs
@@ -148,6 +148,19 @@ public sealed class MarginCalculator
     {
         ArgumentNullException.ThrowIfNull(position);
 
+        if (position.TotalQuantity.IsZero)
+        {
+            var zeroMoney = Money.Zero(position.Currency);
+            return new FeeImpactAnalysis(
+                BuyFees: position.TotalFees,
+                EstimatedSellFees: zeroMoney,
+                TotalFees: position.TotalFees,
+                BreakEvenPriceWithoutFees: Price.Zero,
+                BreakEvenPriceWithFees: Price.Zero,
+                FeeImpactOnBreakEven: Price.Zero,
+                FeePercentageOfCost: 0m);
+        }
+
         var buyFees = position.TotalFees;
         var estimatedSellFees = Money.Create(
             position.TotalCost.Amount * (sellFeePercentage / 100m),

--- a/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
+++ b/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
@@ -144,25 +144,14 @@ namespace IntelliTrader.Exchange.Binance.Resilience
         private ResiliencePipeline CreateOrderPipeline()
         {
             return new ResiliencePipelineBuilder()
-                // 1. Timeout - shorter for orders (markets move fast)
-                .AddTimeout(new TimeoutStrategyOptions
-                {
-                    Timeout = TimeSpan.FromSeconds(_config.OrderTimeoutSeconds),
-                    OnTimeout = args =>
-                    {
-                        _loggingService.Warning($"[Resilience] Order operation timed out after {args.Timeout.TotalSeconds}s - CHECK ORDER STATUS MANUALLY!");
-                        return default;
-                    }
-                })
-
-                // 2. Concurrency limiter - strict limit on concurrent orders
+                // 1. Concurrency limiter - strict limit on concurrent orders
                 .AddConcurrencyLimiter(new ConcurrencyLimiterOptions
                 {
                     PermitLimit = _config.MaxConcurrentOrders,
                     QueueLimit = _config.OrderQueueLimit
                 })
 
-                // 3. Circuit breaker - more sensitive for orders
+                // 2. Circuit breaker - more sensitive for orders
                 .AddCircuitBreaker(new CircuitBreakerStrategyOptions
                 {
                     FailureRatio = _config.OrderCircuitBreakerFailureRatio,
@@ -171,7 +160,6 @@ namespace IntelliTrader.Exchange.Binance.Resilience
                     BreakDuration = TimeSpan.FromSeconds(_config.OrderCircuitBreakerBreakDurationSeconds),
                     ShouldHandle = new PredicateBuilder()
                         .Handle<HttpRequestException>()
-                        .Handle<TaskCanceledException>()
                         .Handle<TimeoutRejectedException>(),
                     OnOpened = args =>
                     {
@@ -190,20 +178,35 @@ namespace IntelliTrader.Exchange.Binance.Resilience
                     }
                 })
 
-                // 4. Retry - VERY CONSERVATIVE for orders to prevent duplicates
+                // 3. Retry - VERY CONSERVATIVE for orders to prevent duplicates
+                // CRITICAL: Only retry on true connection errors where we know the request
+                // never reached the server. Do NOT retry on TaskCanceledException/timeout
+                // because the server may have executed the order but the response was slow.
                 .AddRetry(new RetryStrategyOptions
                 {
                     MaxRetryAttempts = _config.OrderMaxRetryAttempts, // Should be 1
                     BackoffType = DelayBackoffType.Exponential,
                     Delay = TimeSpan.FromMilliseconds(_config.OrderInitialDelayMs),
                     UseJitter = true,
-                    // ONLY retry on connection errors, NOT on any response
+                    // ONLY retry on connection errors, NOT on timeout or any response
                     ShouldHandle = new PredicateBuilder()
-                        .Handle<HttpRequestException>(ex => IsConnectionError(ex))
-                        .Handle<TaskCanceledException>(ex => !ex.CancellationToken.IsCancellationRequested),
+                        .Handle<HttpRequestException>(ex => IsConnectionError(ex)),
                     OnRetry = args =>
                     {
                         _loggingService.Warning($"[Resilience] RETRYING ORDER (attempt {args.AttemptNumber + 1}/{_config.OrderMaxRetryAttempts}) - VERIFY ORDER STATUS BEFORE RETRY! Reason: {args.Outcome.Exception?.Message ?? "Unknown"}");
+                        return default;
+                    }
+                })
+
+                // 4. Timeout - INSIDE retry so each attempt gets its own timeout.
+                // If a timeout fires, it will NOT trigger a retry (TaskCanceledException
+                // is excluded from retry ShouldHandle), preventing duplicate orders.
+                .AddTimeout(new TimeoutStrategyOptions
+                {
+                    Timeout = TimeSpan.FromSeconds(_config.OrderTimeoutSeconds),
+                    OnTimeout = args =>
+                    {
+                        _loggingService.Warning($"[Resilience] Order operation timed out after {args.Timeout.TotalSeconds}s - CHECK ORDER STATUS MANUALLY!");
                         return default;
                     }
                 })

--- a/IntelliTrader.Exchange.Binance/Services/BinanceExchangeService.cs
+++ b/IntelliTrader.Exchange.Binance/Services/BinanceExchangeService.cs
@@ -284,7 +284,7 @@ namespace IntelliTrader.Exchange.Binance
             }
             else
             {
-                return Task.FromResult(0m);
+                throw new InvalidOperationException($"No ticker data available for pair '{pair}'. The pair may not exist or ticker data has not been loaded yet.");
             }
         }
 

--- a/IntelliTrader.Trading/Services/ATRCalculator.cs
+++ b/IntelliTrader.Trading/Services/ATRCalculator.cs
@@ -63,23 +63,22 @@ namespace IntelliTrader.Trading
             }
 
             // Use Wilder's smoothing method (exponential moving average)
-            // First ATR = Simple average of first 'period' True Ranges
+            // First ATR = Simple average of first N (effectivePeriod) True Ranges
             // Subsequent ATR = ((Prior ATR * (period - 1)) + Current TR) / period
 
-            var recentTrueRanges = trueRanges.Skip(trueRanges.Count - effectivePeriod).ToList();
-
-            if (recentTrueRanges.Count <= effectivePeriod)
+            if (trueRanges.Count <= effectivePeriod)
             {
                 // Not enough data for Wilder's smoothing, use simple average
-                return recentTrueRanges.Average();
+                return trueRanges.Average();
             }
 
-            // Calculate using Wilder's smoothing
-            decimal atr = recentTrueRanges.Take(effectivePeriod).Average();
+            // Calculate initial ATR as simple average of first effectivePeriod values
+            decimal atr = trueRanges.Take(effectivePeriod).Average();
 
-            for (int i = effectivePeriod; i < recentTrueRanges.Count; i++)
+            // Apply Wilder's smoothing for remaining values
+            for (int i = effectivePeriod; i < trueRanges.Count; i++)
             {
-                atr = ((atr * (effectivePeriod - 1)) + recentTrueRanges[i]) / effectivePeriod;
+                atr = ((atr * (effectivePeriod - 1)) + trueRanges[i]) / effectivePeriod;
             }
 
             _loggingService.Debug($"ATR calculated: {atr:0.00000000} (period: {effectivePeriod}, candles: {candleList.Count})");

--- a/IntelliTrader.Trading/Services/SellOrchestrator.cs
+++ b/IntelliTrader.Trading/Services/SellOrchestrator.cs
@@ -112,10 +112,15 @@ namespace IntelliTrader.Trading
                 message = $"Cancel sell request for {options.Pair}. Reason: pair does not exist";
                 return false;
             }
-            else if ((DateTimeOffset.Now - Account.GetTradingPair(options.Pair).OrderDates.Max()).TotalMilliseconds < (MIN_INTERVAL_BETWEEN_BUY_AND_SELL / _applicationContext.Speed))
+            else
             {
-                message = $"Cancel sell request for {options.Pair}. Reason: pair just bought";
-                return false;
+                var orderDates = Account.GetTradingPair(options.Pair).OrderDates;
+                if (orderDates != null && orderDates.Any() &&
+                    (DateTimeOffset.Now - orderDates.Max()).TotalMilliseconds < (MIN_INTERVAL_BETWEEN_BUY_AND_SELL / _applicationContext.Speed))
+                {
+                    message = $"Cancel sell request for {options.Pair}. Reason: pair just bought";
+                    return false;
+                }
             }
             message = null;
             return true;

--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -418,7 +418,8 @@ namespace IntelliTrader.Trading
                 {
                     IPairConfig pairConfig = GetPairConfig(tradingPair.Pair);
                     return pairConfig.SellEnabled && pairConfig.SwapEnabled && pairConfig.SwapSignalRules != null && pairConfig.SwapSignalRules.Contains(options.Metadata.SignalRule) &&
-                           pairConfig.SwapTimeout < (DateTimeOffset.Now - tradingPair.OrderDates.Max()).TotalSeconds;
+                           tradingPair.OrderDates != null && tradingPair.OrderDates.Any() &&
+                       pairConfig.SwapTimeout < (DateTimeOffset.Now - tradingPair.OrderDates.Max()).TotalSeconds;
                 });
 
                 if (swappedPair != null)
@@ -524,8 +525,35 @@ namespace IntelliTrader.Trading
                 var newTradingPair = Account.GetTradingPair(options.NewPair) as TradingPair;
                 if (newTradingPair == null)
                 {
-                    loggingService.Info($"Unable to swap {options.OldPair} for {options.NewPair}. Reason: failed to buy {options.NewPair}");
-                    _ = notificationService.NotifyAsync($"Unable to swap {options.OldPair} for {options.NewPair}: Failed to buy {options.NewPair}");
+                    loggingService.Error($"SWAP INCOMPLETE: Sold {options.OldPair} but failed to buy {options.NewPair}. Funds may be in limbo! Attempting to re-buy old pair as compensation.");
+                    _ = notificationService.NotifyAsync($"SWAP INCOMPLETE: Sold {options.OldPair} but failed to buy {options.NewPair}. Attempting compensation re-buy of {options.OldPair}.");
+
+                    // Compensation: attempt to re-buy the old pair with the sell proceeds
+                    try
+                    {
+                        var compensationBuyOptions = new BuyOptions(options.OldPair)
+                        {
+                            ManualOrder = true,
+                            MaxCost = sellOrderDetails.AverageCost,
+                            Metadata = options.Metadata
+                        };
+                        IOrderDetails compensationOrder = PlaceBuyOrder(compensationBuyOptions);
+                        if (Account.HasTradingPair(options.OldPair))
+                        {
+                            loggingService.Warning($"Swap compensation successful: re-bought {options.OldPair}");
+                            _ = notificationService.NotifyAsync($"Swap compensation successful: re-bought {options.OldPair}");
+                        }
+                        else
+                        {
+                            loggingService.Error($"SWAP COMPENSATION FAILED: Could not re-buy {options.OldPair}. Manual intervention required! Sell proceeds: {sellOrderDetails.AverageCost:0.00000000}");
+                            _ = notificationService.NotifyAsync($"CRITICAL: Swap compensation failed for {options.OldPair}. Manual intervention required!");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        loggingService.Error($"SWAP COMPENSATION EXCEPTION for {options.OldPair}: {ex.Message}. Manual intervention required!");
+                        _ = notificationService.NotifyAsync($"CRITICAL: Swap compensation exception for {options.OldPair}. Manual intervention required!");
+                    }
                     return;
                 }
 
@@ -544,6 +572,7 @@ namespace IntelliTrader.Trading
             {
                 IPairConfig pairConfig = GetPairConfig(tradingPair.Pair);
                 return pairConfig.SellEnabled && pairConfig.SwapEnabled && pairConfig.SwapSignalRules != null && pairConfig.SwapSignalRules.Contains(options.Metadata.SignalRule) &&
+                       tradingPair.OrderDates != null && tradingPair.OrderDates.Any() &&
                        pairConfig.SwapTimeout < (DateTimeOffset.Now - tradingPair.OrderDates.Max()).TotalSeconds;
             });
 
@@ -644,8 +673,35 @@ namespace IntelliTrader.Trading
             var newTradingPair = Account.GetTradingPair(options.NewPair) as TradingPair;
             if (newTradingPair == null)
             {
-                loggingService.Info($"Unable to swap {options.OldPair} for {options.NewPair}. Reason: failed to buy {options.NewPair}");
-                _ = notificationService.NotifyAsync($"Unable to swap {options.OldPair} for {options.NewPair}: Failed to buy {options.NewPair}");
+                loggingService.Error($"SWAP INCOMPLETE: Sold {options.OldPair} but failed to buy {options.NewPair}. Funds may be in limbo! Attempting to re-buy old pair as compensation.");
+                _ = notificationService.NotifyAsync($"SWAP INCOMPLETE: Sold {options.OldPair} but failed to buy {options.NewPair}. Attempting compensation re-buy of {options.OldPair}.");
+
+                // Compensation: attempt to re-buy the old pair with the sell proceeds
+                try
+                {
+                    var compensationBuyOptions = new BuyOptions(options.OldPair)
+                    {
+                        ManualOrder = true,
+                        MaxCost = sellOrderDetails.AverageCost,
+                        Metadata = options.Metadata
+                    };
+                    IOrderDetails compensationOrder = await PlaceBuyOrderAsync(compensationBuyOptions, cancellationToken).ConfigureAwait(false);
+                    if (Account.HasTradingPair(options.OldPair))
+                    {
+                        loggingService.Warning($"Swap compensation successful: re-bought {options.OldPair}");
+                        _ = notificationService.NotifyAsync($"Swap compensation successful: re-bought {options.OldPair}");
+                    }
+                    else
+                    {
+                        loggingService.Error($"SWAP COMPENSATION FAILED: Could not re-buy {options.OldPair}. Manual intervention required! Sell proceeds: {sellOrderDetails.AverageCost:0.00000000}");
+                        _ = notificationService.NotifyAsync($"CRITICAL: Swap compensation failed for {options.OldPair}. Manual intervention required!");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    loggingService.Error($"SWAP COMPENSATION EXCEPTION for {options.OldPair}: {ex.Message}. Manual intervention required!");
+                    _ = notificationService.NotifyAsync($"CRITICAL: Swap compensation exception for {options.OldPair}. Manual intervention required!");
+                }
                 return;
             }
 
@@ -819,10 +875,15 @@ namespace IntelliTrader.Trading
                 message = $"Cancel sell request for {options.Pair}. Reason: pair does not exist";
                 return false;
             }
-            else if ((DateTimeOffset.Now - Account.GetTradingPair(options.Pair).OrderDates.Max()).TotalMilliseconds < (MIN_INTERVAL_BETWEEN_BUY_AND_SELL / _applicationContext.Speed))
+            else
             {
-                message = $"Cancel sell request for {options.Pair}. Reason: pair just bought";
-                return false;
+                var orderDates = Account.GetTradingPair(options.Pair).OrderDates;
+                if (orderDates != null && orderDates.Any() &&
+                    (DateTimeOffset.Now - orderDates.Max()).TotalMilliseconds < (MIN_INTERVAL_BETWEEN_BUY_AND_SELL / _applicationContext.Speed))
+                {
+                    message = $"Cancel sell request for {options.Pair}. Reason: pair just bought";
+                    return false;
+                }
             }
             message = null;
             return true;


### PR DESCRIPTION
## Summary

Fixes 6 trading logic bugs identified in issue #76, ordered by severity:

- **Duplicate order risk on timeout (High):** Restructured order resilience pipeline to place timeout *inside* retry, so each attempt gets its own timeout. Removed `TaskCanceledException` from retry's `ShouldHandle` — if Binance executes the order but the response takes >15s, we no longer retry and risk a duplicate.
- **NullReferenceException on empty OrderDates (High):** Added null/empty guards before calling `.Max()` on `OrderDates` in `TradingService.CanSell`, `Buy`, `BuyAsync`, and `SellOrchestrator.CanSell`.
- **Non-atomic swap leaves funds in limbo (High):** Added compensation logic to both sync `Swap` and async `SwapAsync` — if buy fails after a successful sell, we attempt to re-buy the old pair. Logs at Error level and sends notifications for manual intervention if compensation also fails.
- **GetLastPrice returns 0 for unknown pairs (Medium):** Now throws `InvalidOperationException` with descriptive message instead of silently returning 0. Note: callers outside the Exchange project may need updating (documented below, not modified per scoping rules).
- **MarginCalculator.AnalyzeFeeImpact DivideByZeroException (Medium):** Added early return when `TotalQuantity.IsZero`.
- **ATRCalculator Wilder smoothing unreachable (Low):** Fixed by using the full `trueRanges` list instead of the sliced `recentTrueRanges`, so the Wilder smoothing branch is reachable when data exceeds the period.

### GetLastPrice caller impact
The `GetLastPrice` change from returning `0m` to throwing `InvalidOperationException` may require callers in `IntelliTrader.Trading` and `IntelliTrader.Backtesting` to add try-catch or null-check patterns. Per issue scoping, those callers are not modified in this PR.

Closes #76

## Test plan
- [ ] Verify build succeeds
- [ ] Verify existing tests pass (OrderDates guards, ATR calculations)
- [ ] Manual test: swap where buy fails should trigger compensation re-buy
- [ ] Manual test: order timeout should not trigger retry
- [ ] Verify `GetLastPrice` callers handle `InvalidOperationException` appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)