### PR TITLE
fix: resolve resource leaks in ManualResetEvent, Logger, HttpClient, and WebSocket

### DIFF
--- a/IntelliTrader.Core/Models/Tasks/HighResolutionTimedTask.cs
+++ b/IntelliTrader.Core/Models/Tasks/HighResolutionTimedTask.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace IntelliTrader.Core
 {
-    public abstract class HighResolutionTimedTask
+    public abstract class HighResolutionTimedTask : IDisposable
     {
         /// <summary>
         /// Raised on unhandled exception
@@ -133,5 +133,26 @@ namespace IntelliTrader.Core
         }
 
         public abstract void Run();
+
+        private bool disposed;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    Stop();
+                    resetEvent?.Dispose();
+                }
+                disposed = true;
+            }
+        }
     }
 }

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -175,7 +175,10 @@ namespace IntelliTrader.Core
 
         public void RemoveTask(string name)
         {
-            timedTasks.TryRemove(name, out HighResolutionTimedTask task);
+            if (timedTasks.TryRemove(name, out HighResolutionTimedTask task))
+            {
+                task?.Dispose();
+            }
         }
 
         public void RemoveAllTasks()

--- a/IntelliTrader.Core/Services/LoggingService.cs
+++ b/IntelliTrader.Core/Services/LoggingService.cs
@@ -266,6 +266,7 @@ namespace IntelliTrader.Core
         {
             lock (syncRoot)
             {
+                logger?.Dispose();
                 logger = CreateLogger();
             }
         }

--- a/IntelliTrader.Exchange.Binance/Services/BinanceWebSocketService.cs
+++ b/IntelliTrader.Exchange.Binance/Services/BinanceWebSocketService.cs
@@ -21,7 +21,7 @@ namespace IntelliTrader.Exchange.Binance
     /// Implements connection lifecycle management, automatic reconnection, ping/pong handling,
     /// and REST API fallback when WebSocket is unavailable.
     /// </summary>
-    internal class BinanceWebSocketService : IBinanceWebSocketService
+    internal class BinanceWebSocketService : IBinanceWebSocketService, IAsyncDisposable
     {
         // Use constants from Core for configuration values
         private static readonly string WebSocketBaseUrl = Constants.WebSocket.BinanceStreamUrl;
@@ -704,7 +704,17 @@ namespace IntelliTrader.Exchange.Binance
             if (_disposed) return;
             _disposed = true;
 
-            _ = DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+            DisconnectAsync(CancellationToken.None).GetAwaiter().GetResult();
+            _httpClient.Dispose();
+            _connectionLock.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            await DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
             _httpClient.Dispose();
             _connectionLock.Dispose();
         }

--- a/IntelliTrader.Signals.TradingView/TimedTasks/TradingViewCryptoSignalPollingTimedTask.cs
+++ b/IntelliTrader.Signals.TradingView/TimedTasks/TradingViewCryptoSignalPollingTimedTask.cs
@@ -236,6 +236,15 @@ namespace IntelliTrader.Signals.TradingView
             }
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                httpClient?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
         private HttpClient CreateHttpClient()
         {
             var httpClient = new HttpClient();

--- a/IntelliTrader.Trading/Models/Accounts/ExchangeAccount.cs
+++ b/IntelliTrader.Trading/Models/Accounts/ExchangeAccount.cs
@@ -469,10 +469,13 @@ namespace IntelliTrader.Trading
             }
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
-            healthCheckService.RemoveHealthCheck(Constants.HealthChecks.AccountRefreshed);
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                healthCheckService.RemoveHealthCheck(Constants.HealthChecks.AccountRefreshed);
+            }
         }
     }
 }

--- a/IntelliTrader.Trading/Models/Accounts/TradingAccountBase.cs
+++ b/IntelliTrader.Trading/Models/Accounts/TradingAccountBase.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace IntelliTrader.Trading
 {
-    internal abstract class TradingAccountBase : ITradingAccount
+    internal abstract class TradingAccountBase : ITradingAccount, IDisposable
     {
         private readonly object _syncRoot = new object();
         public object SyncRoot => _syncRoot;
@@ -272,12 +272,27 @@ namespace IntelliTrader.Trading
             }
         }
 
-        public virtual void Dispose()
+        private bool disposed;
+
+        public void Dispose()
         {
-            lock (SyncRoot)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
             {
-                Save();
-                tradingPairs.Clear();
+                if (disposing)
+                {
+                    lock (SyncRoot)
+                    {
+                        Save();
+                        tradingPairs.Clear();
+                    }
+                }
+                disposed = true;
             }
         }
     }

--- a/IntelliTrader.Trading/Models/Accounts/VirtualAccount.cs
+++ b/IntelliTrader.Trading/Models/Accounts/VirtualAccount.cs
@@ -165,10 +165,13 @@ namespace IntelliTrader.Trading
             }
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
-            healthCheckService.RemoveHealthCheck(Constants.HealthChecks.AccountRefreshed);
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                healthCheckService.RemoveHealthCheck(Constants.HealthChecks.AccountRefreshed);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **HighResolutionTimedTask**: Implement `IDisposable` to dispose `ManualResetEvent`; update `CoreService.RemoveTask` to dispose removed tasks
- **LoggingService.OnConfigReloaded**: Dispose old Serilog `Logger` before creating new one to prevent file handle leaks
- **TradingViewCryptoSignalPollingTimedTask**: Override `Dispose(bool)` to clean up `HttpClient`
- **BinanceWebSocketService**: Fix fire-and-forget `DisconnectAsync` in `Dispose()` by blocking with `GetAwaiter().GetResult()`; add `IAsyncDisposable` with proper `DisposeAsync()`
- **TradingAccountBase**: Implement `IDisposable` with standard Dispose pattern; update `VirtualAccount` and `ExchangeAccount` subclasses to override `Dispose(bool)`

## Test plan
- [ ] Verify solution builds successfully via CI
- [ ] Confirm no `ObjectDisposedException` in BinanceWebSocketService teardown
- [ ] Confirm Serilog file handles are released on config reload
- [ ] Verify HighResolutionTimedTask ManualResetEvent is disposed when tasks are removed

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)