### PR TITLE
fix: address miscellaneous code quality findings from Codex review

### DIFF
--- a/IntelliTrader.Core/Models/Tasks/HighResolutionTimedTask.cs
+++ b/IntelliTrader.Core/Models/Tasks/HighResolutionTimedTask.cs
@@ -129,7 +129,7 @@ namespace IntelliTrader.Core
                 resetEvent.Set();
                 timeWatcher.Stop();
 
-                if (!terminateThread)
+                if (terminateThread)
                 {
                     timerThread?.Join();
                     timerThread = null;

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -92,8 +92,16 @@ namespace IntelliTrader.Core
             // to avoid blocking a thread pool thread during the delay
             _ = Task.Run(async () =>
             {
-                await Task.Delay(Constants.Timeouts.StartupDelayMs).ConfigureAwait(false);
-                StartAllTasks();
+                try
+                {
+                    await Task.Delay(Constants.Timeouts.StartupDelayMs).ConfigureAwait(false);
+                    StartAllTasks();
+                }
+                catch (Exception ex)
+                {
+                    loggingService.Error("Failed to start timed tasks", ex);
+                    Running = false;
+                }
             });
 
             Running = true;

--- a/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
+++ b/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
@@ -277,9 +277,16 @@ namespace IntelliTrader.Exchange.Binance.Resilience
 
         /// <summary>
         /// Determines if an exception indicates a server-side error (5xx or 429).
+        /// Uses HttpRequestException.StatusCode when available, falls back to message matching.
         /// </summary>
         private static bool IsServerError(Exception ex)
         {
+            if (ex is System.Net.Http.HttpRequestException httpEx && httpEx.StatusCode.HasValue)
+            {
+                var code = (int)httpEx.StatusCode.Value;
+                return code == 429 || (code >= 500 && code <= 504);
+            }
+
             var message = ex.Message;
             return message.Contains("500") ||
                    message.Contains("502") ||
@@ -290,9 +297,16 @@ namespace IntelliTrader.Exchange.Binance.Resilience
 
         /// <summary>
         /// Determines if an exception is a transient error that should be retried.
+        /// Uses HttpRequestException.StatusCode when available, falls back to message matching.
         /// </summary>
         private static bool IsTransientError(Exception ex)
         {
+            if (ex is System.Net.Http.HttpRequestException httpEx && httpEx.StatusCode.HasValue)
+            {
+                var code = (int)httpEx.StatusCode.Value;
+                return code == 429 || code == 500 || code == 502 || code == 503 || code == 504;
+            }
+
             var message = ex.Message;
             return message.Contains("429") ||    // Rate limit
                    message.Contains("503") ||    // Service unavailable

--- a/IntelliTrader.Signals.Base/Services/SignalsService.cs
+++ b/IntelliTrader.Signals.Base/Services/SignalsService.cs
@@ -143,20 +143,13 @@ namespace IntelliTrader.Signals.Base
 
         public IEnumerable<ISignal> GetSignalsByName(string signalName)
         {
-            IEnumerable<ISignal> signals = null;
+            IEnumerable<ISignal> signals = Enumerable.Empty<ISignal>();
             foreach (var kvp in signalReceivers.OrderBy(r => r.Value.GetPeriod()))
             {
                 if (signalName == null || signalName == kvp.Key)
                 {
                     ISignalReceiver receiver = kvp.Value;
-                    if (signals == null)
-                    {
-                        signals = receiver.GetSignals();
-                    }
-                    else
-                    {
-                        signals = signals.Concat(receiver.GetSignals());
-                    }
+                    signals = signals.Concat(receiver.GetSignals());
                 }
             }
             return signals;

--- a/IntelliTrader.Signals.TradingView/TimedTasks/TradingViewCryptoSignalPollingTimedTask.cs
+++ b/IntelliTrader.Signals.TradingView/TimedTasks/TradingViewCryptoSignalPollingTimedTask.cs
@@ -222,14 +222,9 @@ namespace IntelliTrader.Signals.TradingView
                 {
                     return 100 * Math.Sign((double)b);
                 }
-                else if (b == 0)
-                {
-                    return -100 * Math.Sign((double)a);
-                }
                 else
                 {
-                    var change = Math.Abs((double)((b - a) / a * 100));
-                    return (a < b) ? change : change * -1;
+                    return ((double)b - (double)a) / Math.Abs((double)a) * 100;
                 }
             }
             else

--- a/IntelliTrader.Web/Controllers/HomeController.cs
+++ b/IntelliTrader.Web/Controllers/HomeController.cs
@@ -652,7 +652,20 @@ namespace IntelliTrader.Web.Controllers
 
             if (Directory.Exists(logsPath))
             {
-                foreach (var tradesLogFilePath in Directory.EnumerateFiles(logsPath, "*-trades.txt", SearchOption.TopDirectoryOnly))
+                var logFiles = Directory.EnumerateFiles(logsPath, "*-trades.txt", SearchOption.TopDirectoryOnly);
+
+                // When filtering by a specific date, skip log files that were last modified
+                // before the requested date to avoid reading irrelevant files
+                if (date != null)
+                {
+                    logFiles = logFiles.Where(f =>
+                    {
+                        var lastWrite = File.GetLastWriteTimeUtc(f);
+                        return lastWrite >= date.Value.UtcDateTime.Date;
+                    });
+                }
+
+                foreach (var tradesLogFilePath in logFiles)
                 {
                     IEnumerable<string> logLines = Utils.ReadAllLinesWriteSafe(tradesLogFilePath);
                     foreach (var logLine in logLines)

--- a/IntelliTrader.Web/Hubs/TradingHub.cs
+++ b/IntelliTrader.Web/Hubs/TradingHub.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace IntelliTrader.Web.Hubs
@@ -27,6 +28,13 @@ namespace IntelliTrader.Web.Hubs
         /// Prefix for pair-specific groups.
         /// </summary>
         public const string PairGroupPrefix = "Pair_";
+
+        /// <summary>
+        /// Maximum number of pair subscriptions allowed per connection.
+        /// </summary>
+        private const int MaxSubscriptionsPerConnection = 50;
+
+        private static readonly Regex ValidPairPattern = new(@"^[A-Z0-9]{2,20}$", RegexOptions.Compiled);
 
         private static readonly ConcurrentDictionary<string, HashSet<string>> _pairSubscriptions = new();
         private static readonly object _subscriptionLock = new();
@@ -89,6 +97,24 @@ namespace IntelliTrader.Web.Hubs
             }
 
             var normalizedPair = pair.ToUpperInvariant();
+
+            if (!ValidPairPattern.IsMatch(normalizedPair))
+            {
+                _logger.LogWarning("Client {ConnectionId} attempted to subscribe with invalid pair format: {Pair}", Context.ConnectionId, normalizedPair);
+                return;
+            }
+
+            // Check subscription limit per connection
+            lock (_subscriptionLock)
+            {
+                int currentCount = _pairSubscriptions.Count(kvp => kvp.Value.Contains(Context.ConnectionId));
+                if (currentCount >= MaxSubscriptionsPerConnection)
+                {
+                    _logger.LogWarning("Client {ConnectionId} exceeded max subscriptions ({Max})", Context.ConnectionId, MaxSubscriptionsPerConnection);
+                    return;
+                }
+            }
+
             var groupName = $"{PairGroupPrefix}{normalizedPair}";
 
             await Groups.AddToGroupAsync(Context.ConnectionId, groupName);


### PR DESCRIPTION
## Summary

Addresses code quality findings from issue #78 (Codex review). Each fix was verified against current `main` to ensure it hadn't already been resolved by PRs #79-#83.

### Changes

- **CoreService.Start**: Wrap fire-and-forget `Task.Run` lambda in try/catch with logging; set `Running = false` on failure
- **SignalsService.GetSignalsByName**: Initialize `signals` to `Enumerable.Empty<ISignal>()` instead of `null` to prevent NullReferenceExceptions in callers
- **CalculatePercentageChange**: Replace fragile conditional logic with `(b - a) / Math.Abs(a) * 100` for correct handling of negative base values
- **HighResolutionTimedTask.Stop**: Invert `terminateThread` condition — `Join()` now executes when `terminateThread` is `true` (matching the parameter name and intent)
- **TradingHub.SubscribeToPair**: Add regex validation for pair format (`^[A-Z0-9]{2,20}$`) and cap subscriptions at 50 per connection
- **HomeController.GetTrades**: Skip log files whose last-modified date precedes the requested filter date
- **ExchangeResiliencePipelines**: Check `HttpRequestException.StatusCode` before falling back to message string matching

### Skipped (already fixed)

- Item 8 (OTLP exporter no-op): Already fully implemented in PR #55
- Item 9 (InMemoryDomainEventDispatcher mutable List): Lock discipline already correctly applied around all List access points

## Test plan

- [ ] Verify solution builds cleanly
- [ ] CI passes all existing tests
- [ ] Verify `GetSignalsByName` no longer returns null for unknown signal names
- [ ] Verify `HighResolutionTimedTask.Stop(true)` properly joins the thread

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)