### PR TITLE
fix(security): add CSRF tokens to all AJAX POST calls

### DIFF
--- a/IntelliTrader.Web/Static/Scripts/intellitrader.js
+++ b/IntelliTrader.Web/Static/Scripts/intellitrader.js
@@ -1,3 +1,14 @@
+// Automatically include CSRF anti-forgery token in all AJAX POST requests
+$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+    if (options.type.toUpperCase() === 'POST') {
+        var token = $('input[name="__RequestVerificationToken"]').val();
+        if (token) {
+            if (options.data) { options.data += '&'; } else { options.data = ''; }
+            options.data += '__RequestVerificationToken=' + encodeURIComponent(token);
+        }
+    }
+});
+
 // Use SignalR for real-time updates if available, fallback to polling
 var useSignalR = typeof IntelliTraderSignalR !== "undefined";
 var pollingInterval = null;

--- a/IntelliTrader.Web/Views/Home/Dashboard.cshtml
+++ b/IntelliTrader.Web/Views/Home/Dashboard.cshtml
@@ -4,6 +4,8 @@
     ViewData["Instance"] = Model.InstanceName;
 }
 
+@Html.AntiForgeryToken()
+
 @section AddToHead{
     <link rel="stylesheet" type="text/css" href="@Url.Content("~/Static/Styles/Views/dashboard.css")">
     <script type="text/javascript" src="@Url.Content("~/Static/Scripts/Views/dashboard.js")"></script>

--- a/IntelliTrader.Web/Views/Home/Market.cshtml
+++ b/IntelliTrader.Web/Views/Home/Market.cshtml
@@ -4,6 +4,8 @@
     ViewData["Instance"] = Model.InstanceName;
 }
 
+@Html.AntiForgeryToken()
+
 @section AddToHead{
     <link rel="stylesheet" type="text/css" href="@Url.Content("~/Static/Styles/Vendor/bootstrap-multiselect.min.css")">
     <link rel="stylesheet" type="text/css" href="@Url.Content("~/Static/Styles/Views/market.css")">

--- a/IntelliTrader.Web/Views/Home/Settings.cshtml
+++ b/IntelliTrader.Web/Views/Home/Settings.cshtml
@@ -5,6 +5,8 @@
     ViewData["CustomPageHeader"] = true;
 }
 
+@Html.AntiForgeryToken()
+
 @section AddToHead{
     <link rel="stylesheet" type="text/css" href="@Url.Content("~/Static/Styles/Vendor/jsoneditor.min.css")">
     <link rel="stylesheet" type="text/css" href="@Url.Content("~/Static/Styles/Views/settings.css")">


### PR DESCRIPTION
## Summary

- Added `@Html.AntiForgeryToken()` to Dashboard, Market, and Settings views so the anti-forgery hidden input is present in the DOM
- Added a global `$.ajaxPrefilter` in `intellitrader.js` that automatically appends `__RequestVerificationToken` to all AJAX POST requests
- This fixes 400 errors on Buy/Sell/Swap/SaveConfig actions caused by PR #80 adding `[ValidateAntiForgeryToken]` without updating JS callers

Closes #85

## Files changed
- `IntelliTrader.Web/Views/Home/Dashboard.cshtml` — added `@Html.AntiForgeryToken()`
- `IntelliTrader.Web/Views/Home/Market.cshtml` — added `@Html.AntiForgeryToken()`
- `IntelliTrader.Web/Views/Home/Settings.cshtml` — added `@Html.AntiForgeryToken()`
- `IntelliTrader.Web/Static/Scripts/intellitrader.js` — added global AJAX prefilter

## Test plan
- [ ] Verify Dashboard Buy/Sell/Swap buttons no longer return 400
- [ ] Verify Market Buy/Buy Default buttons work
- [ ] Verify Settings Save (both form and config editor) work
- [ ] Verify the anti-forgery token is included in POST request body via browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security validation for form submissions and API requests across the application dashboard, market, and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->