### PR TITLE
fix(security): replace XSS-vulnerable jQuery .html() with .text()

### DIFF
--- a/IntelliTrader.Web/Static/Scripts/Views/dashboard.js
+++ b/IntelliTrader.Web/Static/Scripts/Views/dashboard.js
@@ -273,7 +273,7 @@ function showSettings(e) {
     var row = table.row(tr);
     var config = row.data().Config;
     $("#modalTitle").text(pair + " Settings");
-    $("#modalContent").html("<pre>" + JSON.stringify(config, null, 4) + "</pre>");
+    $("#modalContent").empty().append($("<pre>").text(JSON.stringify(config, null, 4)));
     $("#modal").modal('show');
 }
 

--- a/IntelliTrader.Web/Static/Scripts/Views/market.js
+++ b/IntelliTrader.Web/Static/Scripts/Views/market.js
@@ -263,7 +263,7 @@ function showSettings(e) {
     var row = table.row(tr);
     var config = row.data().Config;
     $("#modalTitle").text(pair + " Settings");
-    $("#modalContent").html("<pre>" + JSON.stringify(config, null, 4) + "</pre>");
+    $("#modalContent").empty().append($("<pre>").text(JSON.stringify(config, null, 4)));
     $("#modal").modal('show');
 }
 

--- a/IntelliTrader.Web/Static/Scripts/intellitrader.js
+++ b/IntelliTrader.Web/Static/Scripts/intellitrader.js
@@ -128,7 +128,10 @@ function updateStatus() {
         data.HealthChecks.sort(function (a, b) { return a.Name > b.Name; });
         healthChecks.attr("title", data.HealthChecks.map(function (check) { return check.Name + ": " + new Date(check.LastUpdated).toTimeString().split(' ')[0] + (check.Failed ? " (Failed)" : " (OK)"); }).join("\r\n"));
         var logEntries = $("#logEntries");
-        logEntries.html(data.LogEntries.join("<br />"));
+        logEntries.empty();
+        data.LogEntries.forEach(function(entry) {
+            $("<div>").text(entry).appendTo(logEntries);
+        });
         setStatus("none");
     }).fail(function (data) {
         setStatus("error");

--- a/IntelliTrader.Web/Static/Scripts/signalr-client.js
+++ b/IntelliTrader.Web/Static/Scripts/signalr-client.js
@@ -310,7 +310,10 @@ var IntelliTraderSignalR = (function () {
         // Update log entries
         if (data.LogEntries && data.LogEntries.length > 0) {
             var logEntries = $("#logEntries");
-            logEntries.html(data.LogEntries.join("<br />"));
+            logEntries.empty();
+            data.LogEntries.forEach(function(entry) {
+                $("<div>").text(entry).appendTo(logEntries);
+            });
         }
 
         setConnectionStatus("connected");


### PR DESCRIPTION
## Summary
- Replace unsafe jQuery `.html()` calls with safe DOM manipulation (`.text()`, `.empty()`, `.append()`) in 4 JavaScript files to prevent stored XSS via server-injected data
- Fixes log entry rendering in `intellitrader.js` and `signalr-client.js` (used `<br />` join pattern)
- Fixes modal config display in `dashboard.js` and `market.js` (used `<pre>` wrapper with `JSON.stringify`)

## Details
PR #79 fixed `Html.Raw` in Razor views but missed JavaScript-side XSS where jQuery `.html()` injects server data into the DOM. An attacker who can control log entries or config values could inject arbitrary HTML/JS.

### Changes
| File | Before (vulnerable) | After (safe) |
|------|-------------------|--------------|
| `intellitrader.js:131` | `logEntries.html(data.LogEntries.join("<br />"))` | `logEntries.empty()` + `forEach` with `$("<div>").text(entry)` |
| `signalr-client.js:313` | Same pattern | Same fix |
| `dashboard.js:276` | `$("#modalContent").html("<pre>" + JSON.stringify(...) + "</pre>")` | `$("#modalContent").empty().append($("<pre>").text(...))` |
| `market.js:266` | Same pattern | Same fix |

### Not changed (safe)
- `dashboard.js:151-158` footer callbacks: computed numeric values (`.length`, `.toFixed()`, `.sum()`, `.average()`) — no server strings
- `dashboard.js:250` / `market.js:246`: reading from `#rowDetails` template — not injecting external data
- `settings.js:23`: static string literal
- All `Vendor/` files: third-party libraries, out of scope

Closes #86

## Test plan
- [ ] Verify log entries render correctly on the dashboard (each entry in its own `<div>`)
- [ ] Verify SignalR live updates still show log entries properly
- [ ] Verify pair settings modal displays formatted JSON correctly
- [ ] Verify no HTML entities are rendered as raw HTML in any of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)