### PR TITLE
fix(security): add login rate limiting and fix CSRF logout

### DIFF
--- a/IntelliTrader.Web/Controllers/HomeController.cs
+++ b/IntelliTrader.Web/Controllers/HomeController.cs
@@ -83,6 +83,7 @@ namespace IntelliTrader.Web.Controllers
 
         [HttpPost]
         [AllowAnonymous]
+        [EnableRateLimiting("login")]
         public async Task<IActionResult> Login(LoginViewModel model)
         {
             if (ModelState.IsValid)
@@ -137,7 +138,9 @@ namespace IntelliTrader.Web.Controllers
             }
         }
 
+        [HttpPost]
         [AllowAnonymous]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Logout()
         {
             await HttpContext.SignOutAsync();

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -182,6 +182,12 @@ namespace IntelliTrader.Web
                     opt.QueueLimit = 0;
                 });
 
+                options.AddFixedWindowLimiter("login", opt =>
+                {
+                    opt.PermitLimit = 5;
+                    opt.Window = TimeSpan.FromMinutes(1);
+                });
+
                 options.OnRejected = async (context, cancellationToken) =>
                 {
                     context.HttpContext.Response.Headers.RetryAfter =

--- a/IntelliTrader.Web/Views/Home/Settings.cshtml
+++ b/IntelliTrader.Web/Views/Home/Settings.cshtml
@@ -24,7 +24,10 @@
         <input type="submit" value="Save" class="btn btn-primary" onclick="return confirm('Save settings?');" />
     </div>
     }
-    <button class="btn btn-info settings-btn" onclick="logout();">Log Out</button>
+    <form method="post" action="/Logout" style="display:inline">
+        @Html.AntiForgeryToken()
+        <button type="submit" class="btn btn-info settings-btn">Log Out</button>
+    </form>
     <button class="btn btn-info settings-btn" onclick="refreshAccount();">Refresh Account</button>
     <button class="btn btn-info settings-btn" onclick="restartServices();">Restart Services</button>
 

--- a/IntelliTrader.Web/Views/Shared/_Layout.cshtml
+++ b/IntelliTrader.Web/Views/Shared/_Layout.cshtml
@@ -57,6 +57,10 @@
                     <a class="nav-item nav-link" href="/Settings">Settings</a>
                     <a class="nav-item nav-link" href="/Log">Log</a>
                     <a class="nav-item nav-link" href="/Help">Help</a>
+                    <form method="post" action="/Logout" style="display:inline">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="nav-item nav-link btn btn-link" style="cursor:pointer">Logout</button>
+                    </form>
                     <span class="nav-item nav-link text-muted" title="Lovingly handcrafted by Jazzo"><text>v</text>@Model.Version</span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add fixed-window rate limiter policy `login` (5 requests/minute) to prevent brute-force attacks on the POST Login endpoint
- Change Logout from GET to `[HttpPost]` + `[ValidateAntiForgeryToken]` to prevent CSRF logout attacks
- Update logout UI in Settings.cshtml and _Layout.cshtml to use form POST with anti-forgery tokens

## Files changed
- `IntelliTrader.Web/Startup.cs` -- added `login` rate limiter policy in ConfigureServices
- `IntelliTrader.Web/Controllers/HomeController.cs` -- added `[EnableRateLimiting("login")]` to POST Login, changed Logout to `[HttpPost]` + `[ValidateAntiForgeryToken]`
- `IntelliTrader.Web/Views/Home/Settings.cshtml` -- replaced JS `logout()` button with form POST
- `IntelliTrader.Web/Views/Shared/_Layout.cshtml` -- added logout form in navbar

## Test plan
- [ ] Verify login works normally under 5 attempts/minute
- [ ] Verify 6th login attempt within 1 minute returns 429
- [ ] Verify logout works via POST form submission
- [ ] Verify GET /Logout no longer works (should return 405)
- [ ] Verify anti-forgery token is validated on logout

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)