### PR TITLE
docs: update stale documentation after 42-PR modernization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,4 +90,8 @@ ASPNETCORE_ENVIRONMENT=Production
 #INTELLITRADER_MASTER_PASSWORD=
 
 # --- Headless mode (not a config override, standalone env var) ---
-#INTELLITRADER_HEADLESS=true
+# When true, suppresses interactive console prompts (e.g. "Press Enter to
+# exit"). Required for Docker / Kubernetes / CI environments where no TTY
+# is attached. The Dockerfile already sets this; uncomment below to enable
+# headless mode for bare-metal or systemd deployments.
+INTELLITRADER_HEADLESS=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,21 +17,22 @@ This repository contains two distinct projects:
 # Build
 dotnet build IntelliTrader.sln
 
-# Run (Windows)
-Start-IntelliTrader.bat
-# Or directly:
-dotnet bin/Debug/netcoreapp2.1/IntelliTrader.dll
+# Run
+dotnet run --project IntelliTrader
 
 # Encrypt API keys for live trading
-dotnet bin/Debug/netcoreapp2.1/IntelliTrader.dll --encrypt --path keys.bin --publickey YOUR_API_KEY --privatekey YOUR_API_SECRET
+dotnet run --project IntelliTrader -- --encrypt --path keys.bin --publickey YOUR_API_KEY --privatekey YOUR_API_SECRET
 ```
 
 ### Architecture
 
-**Solution Structure** - Multi-project .NET Core 2.1 solution with Autofac DI:
+**Solution Structure** - Multi-project .NET 9 solution with Autofac DI:
 
 - `IntelliTrader/` - Main executable, configuration files, entry point (`Program.cs`)
 - `IntelliTrader.Core/` - Core services, interfaces, models, timed tasks (`Application.cs` manages DI container)
+- `IntelliTrader.Application/` - CQRS commands, queries, handlers, and ports
+- `IntelliTrader.Domain/` - Domain entities, value objects, aggregates, events, and specifications
+- `IntelliTrader.Infrastructure/` - Infrastructure adapters, persistence, telemetry, messaging
 - `IntelliTrader.Trading/` - Buy/sell/swap order execution
 - `IntelliTrader.Signals.Base/TradingView/` - Signal acquisition from TradingView
 - `IntelliTrader.Rules/` - Rule engine for trading decisions
@@ -58,16 +59,28 @@ dotnet bin/Debug/netcoreapp2.1/IntelliTrader.dll --encrypt --path keys.bin --pub
 All JSON configs in `IntelliTrader/config/` with hot-reload support:
 - `core.json` - Health checks, debug mode, instance name
 - `trading.json` - Market, exchange, buy/sell/DCA parameters, virtual trading toggle
+- `exchange.json` - API keys path, rate limiting
 - `signals.json` - TradingView signal definitions
 - `rules.json` - Signal rules (buy triggers) and trading rules (sell/DCA triggers)
 - `web.json` - Web interface port and settings
+- `logging.json` - Serilog levels, file paths
 - `notification.json` - Telegram alerts
+- `paths.json` - References to all other config files
+- `alerting.json` - Alert configuration
+- `audit.json` - Audit trail settings
+- `secret-rotation.json` - Secret rotation policies
+- `users.json` - User accounts and roles
 
 ### Key Patterns
 
 - **Timed Tasks**: `HighResolutionTimedTask` for concurrent polling operations
 - **Rule Engine**: Conditions checked via `IRulesService.CheckConditions()` with signal-specific and pair-specific conditions
 - **Plugin Architecture**: Modules auto-discovered from `IntelliTrader.*.dll` assemblies via `AppModule : Module`
+- **Clean Architecture**: Domain-centric layering with Application, Domain, and Infrastructure separation
+- **CQRS**: Command/Query separation with dedicated dispatchers and handlers
+- **Domain Events**: Async event dispatch (e.g., `OrderPlacedEvent`, `OrderFilledEvent`) via `EventDispatcher`
+- **Resilience Pipelines (Polly v8)**: Retry, circuit breaker, bulkhead, and timeout policies for exchange API calls
+- **Specification Pattern**: Composable business rules via specifications in the Domain layer
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -590,6 +590,9 @@ This works with `docker run -e`, `docker compose` environment blocks, Kubernetes
 | `GET` | `/api/health` | Health check endpoint |
 | `POST` | `/api/trading-pairs` | Active positions |
 | `POST` | `/api/market-pairs` | Market data + signals |
+| `POST` | `/api/market-pairs/filtered` | Filtered market data |
+| `GET` | `/health/live` | Kubernetes liveness probe |
+| `GET` | `/health/ready` | Kubernetes readiness probe |
 
 ### Trading Operations
 
@@ -631,7 +634,7 @@ connection.on("OrderPlaced", (order) => { /* ... */ });
 | `P2` | PostgreSQL persistence option | 🔲 Planned |
 | `P2` | Event sourcing for positions | 🔬 Research |
 | `P2` | ML-enhanced signal analysis | 🔬 Research |
-| `P3` | Kubernetes Helm chart | 📋 Backlog |
+| `P3` | ~~Kubernetes Helm chart~~ | ✅ Done |
 | `P3` | GraphQL API layer | 📋 Backlog |
 | `P3` | Strategy marketplace | 📋 Backlog |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,7 @@
 # Local development overrides live in `docker-compose.override.yml`,
 # which Compose merges automatically. To run *only* this base file (i.e.
 # without dev overrides) use `docker compose -f docker-compose.yml ...`.
-#
-# NOTE: A pre-existing systemic Autofac DI bug (tracked in #38) currently
-# prevents the application from starting end-to-end. The container will
-# build and reach `Welcome to IntelliTrader`, then crash on bootstrap.
-# This compose file is correct and will work as soon as #38 is fixed.
+
 
 services:
   intellitrader:


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Replace `netcoreapp2.1` references with `net9.0`, add missing projects (Application, Domain, Infrastructure), add missing config files (exchange.json, logging.json, paths.json, alerting.json, audit.json, secret-rotation.json, users.json), add key patterns (CQRS, Domain Events, Polly resilience, Specification Pattern, Clean Architecture), update run commands
- **README.md**: Update Helm chart roadmap status from Backlog to Done, add missing API endpoints (`/api/market-pairs/filtered`, `/health/live`, `/health/ready`)
- **docker-compose.yml**: Remove stale NOTE comment about #38 DI bug (fixed in PR #41)
- **.env.example**: Uncomment `INTELLITRADER_HEADLESS=true` with detailed explanation

Closes #89

## Test plan

- [ ] Verify `CLAUDE.md` no longer references `netcoreapp2.1`
- [ ] Verify README roadmap shows Helm chart as Done
- [ ] Verify README API table includes health probe endpoints
- [ ] Verify docker-compose.yml has no stale #38 comment
- [ ] Verify `.env.example` has `INTELLITRADER_HEADLESS=true` uncommented with explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)