### PR TITLE
fix(security): enhance audit logging, add hash chain, document /metrics exposure

### DIFF
--- a/IntelliTrader.Core/Services/AuditService.cs
+++ b/IntelliTrader.Core/Services/AuditService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 
@@ -8,6 +9,11 @@ namespace IntelliTrader.Core
     /// Writes structured audit log entries to a dedicated file, separate from application logs.
     /// Thread-safe; entries are flushed immediately so nothing is lost on crash.
     /// Supports configurable retention and file-size rolling.
+    ///
+    /// Each entry includes a SHA-256 hash chain: the IntegrityHash field is computed from
+    /// the previous entry's hash concatenated with the current entry's content. Any tampering
+    /// (modification or deletion of entries) breaks the chain and is detectable by walking
+    /// the log file and recomputing hashes.
     /// </summary>
     internal sealed class AuditService : IAuditService, IDisposable
     {
@@ -23,6 +29,12 @@ namespace IntelliTrader.Core
         private StreamWriter _writer;
         private bool _disposed;
 
+        /// <summary>
+        /// The hash of the most recent audit entry. Used to build the hash chain.
+        /// Initialized to a zero hash; on startup the last entry's hash is recovered from disk.
+        /// </summary>
+        private string _previousHash;
+
         public AuditService(AuditConfig config)
         {
             _config = config ?? new AuditConfig();
@@ -34,6 +46,10 @@ namespace IntelliTrader.Core
             Directory.CreateDirectory(logDir);
 
             _logFilePath = Path.Combine(logDir, _config.LogFileName);
+
+            // Seed the hash chain: recover the last IntegrityHash from the existing log,
+            // or start with a zero hash if the file is empty / missing.
+            _previousHash = RecoverLastHash(_logFilePath);
 
             if (_config.Enabled)
             {
@@ -47,23 +63,36 @@ namespace IntelliTrader.Core
             if (!_config.Enabled || _disposed)
                 return;
 
-            var entry = new
-            {
-                Timestamp = DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture),
-                Action = action ?? string.Empty,
-                Details = details ?? string.Empty,
-                User = user ?? "anonymous",
-                IpAddress = ipAddress ?? "unknown"
-            };
-
-            var json = JsonSerializer.Serialize(entry, JsonOptions);
-
             lock (_syncRoot)
             {
                 if (_disposed) return;
+
+                var timestamp = DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+                var actionVal = action ?? string.Empty;
+                var detailsVal = details ?? string.Empty;
+                var userVal = user ?? "anonymous";
+                var ipVal = ipAddress ?? "unknown";
+
+                // Compute integrity hash: SHA256(previousHash + timestamp + action + details + user + ip)
+                var integrityHash = ComputeHash(_previousHash, timestamp, actionVal, detailsVal, userVal, ipVal);
+
+                var entry = new
+                {
+                    Timestamp = timestamp,
+                    Action = actionVal,
+                    Details = detailsVal,
+                    User = userVal,
+                    IpAddress = ipVal,
+                    IntegrityHash = integrityHash
+                };
+
+                var json = JsonSerializer.Serialize(entry, JsonOptions);
+
                 RollFileIfNeeded();
                 _writer.WriteLine(json);
                 _writer.Flush();
+
+                _previousHash = integrityHash;
             }
         }
 
@@ -121,6 +150,58 @@ namespace IntelliTrader.Core
             {
                 // Retention cleanup is best-effort; do not crash the service.
             }
+        }
+
+        /// <summary>
+        /// Computes a SHA-256 hash over the concatenation of the previous hash and the
+        /// current entry fields, forming a tamper-evident hash chain.
+        /// </summary>
+        private static string ComputeHash(string previousHash, string timestamp, string action, string details, string user, string ip)
+        {
+            var payload = $"{previousHash}|{timestamp}|{action}|{details}|{user}|{ip}";
+            var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+            return Convert.ToHexString(bytes).ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Reads the last line of an existing audit log and extracts its IntegrityHash
+        /// to continue the hash chain after a restart. Returns a zero hash if the file
+        /// does not exist or cannot be parsed.
+        /// </summary>
+        private static string RecoverLastHash(string logFilePath)
+        {
+            const string zeroHash = "0000000000000000000000000000000000000000000000000000000000000000";
+            try
+            {
+                if (!File.Exists(logFilePath))
+                    return zeroHash;
+
+                // Read the last non-empty line.
+                string lastLine = null;
+                foreach (var line in File.ReadLines(logFilePath, Encoding.UTF8))
+                {
+                    if (!string.IsNullOrWhiteSpace(line))
+                        lastLine = line;
+                }
+
+                if (lastLine == null)
+                    return zeroHash;
+
+                using var doc = JsonDocument.Parse(lastLine);
+                if (doc.RootElement.TryGetProperty("IntegrityHash", out var hashProp))
+                {
+                    var hash = hashProp.GetString();
+                    if (!string.IsNullOrEmpty(hash))
+                        return hash;
+                }
+            }
+            catch
+            {
+                // If recovery fails, start a new chain. The break in continuity is
+                // itself an indicator that the log may have been tampered with.
+            }
+
+            return zeroHash;
         }
     }
 }

--- a/IntelliTrader.Web/Middleware/AuditMiddleware.cs
+++ b/IntelliTrader.Web/Middleware/AuditMiddleware.cs
@@ -9,7 +9,7 @@ namespace IntelliTrader.Web.Middleware
     ///
     /// Audited endpoints:
     ///   - POST /Login           -> authentication attempts (success / failure)
-    ///   - POST /Buy, /Sell, /Swap -> manual trading operations
+    ///   - POST /Buy, /Sell, /Swap -> manual trading operations (with pair/amount details)
     ///   - POST /SaveConfig, /Settings -> configuration changes
     ///   - POST /RestartServices, /SuspendTrading, /ResumeTrading -> service lifecycle
     /// </summary>
@@ -30,6 +30,25 @@ namespace IntelliTrader.Web.Middleware
             "/RestartServices",
             "/SuspendTrading",
             "/ResumeTrading"
+        };
+
+        // Trading endpoints where we capture form data (pair, amount) for audit detail.
+        private static readonly HashSet<string> TradingPaths = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "/Buy",
+            "/Sell",
+            "/Swap"
+        };
+
+        // Form field names that must never appear in audit logs.
+        private static readonly HashSet<string> SensitiveFields = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "password",
+            "passwordhash",
+            "secret",
+            "apikey",
+            "privatekey",
+            "token"
         };
 
         public AuditMiddleware(RequestDelegate next, IAuditService auditService)
@@ -65,10 +84,12 @@ namespace IntelliTrader.Web.Middleware
                 return;
             }
 
-            // For all other audited endpoints, log before delegating.
+            // For trading endpoints, capture request details (pair, amount) for richer audit trail.
+            var details = await BuildAuditDetailsAsync(context.Request, path);
+
             _auditService.LogAudit(
                 action: action,
-                details: $"POST {path}",
+                details: details,
                 user: user,
                 ipAddress: ip);
 
@@ -76,6 +97,52 @@ namespace IntelliTrader.Web.Middleware
         }
 
         // --- helpers ---
+
+        /// <summary>
+        /// Builds a human-readable audit detail string. For trading endpoints the form body
+        /// is read to include pair/amount information. Sensitive fields are filtered out.
+        /// </summary>
+        private static async Task<string> BuildAuditDetailsAsync(HttpRequest request, string path)
+        {
+            if (!IsTradingPath(path) || !request.HasFormContentType)
+            {
+                return $"POST {path}";
+            }
+
+            try
+            {
+                // Enable request body buffering so downstream middleware/controllers can still read it.
+                request.EnableBuffering();
+
+                var form = await request.ReadFormAsync();
+                var safeFields = new List<string>();
+
+                foreach (var field in form)
+                {
+                    if (SensitiveFields.Contains(field.Key))
+                        continue;
+
+                    safeFields.Add($"{field.Key}={field.Value}");
+                }
+
+                // Reset the request body position so MVC model binding still works.
+                if (request.Body.CanSeek)
+                {
+                    request.Body.Position = 0;
+                }
+
+                var fieldSummary = safeFields.Count > 0
+                    ? string.Join(", ", safeFields)
+                    : "(no form data)";
+
+                return $"POST {path} [{fieldSummary}]";
+            }
+            catch
+            {
+                // If form reading fails for any reason, fall back to basic detail.
+                return $"POST {path}";
+            }
+        }
 
         private static bool IsAuditedPath(PathString path)
         {
@@ -85,6 +152,11 @@ namespace IntelliTrader.Web.Middleware
         private static bool IsLoginPath(string path)
         {
             return string.Equals(path, "/Login", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsTradingPath(string path)
+        {
+            return path != null && TradingPaths.Contains(path);
         }
 
         private static string DeriveAction(string path)

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
@@ -246,6 +247,14 @@ namespace IntelliTrader.Web
             var enableSwagger = env.IsDevelopment() || Configuration.GetValue<bool>("Swagger:Enabled");
             if (enableSwagger)
             {
+                if (!env.IsDevelopment())
+                {
+                    var logger = app.ApplicationServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>();
+                    logger.LogWarning(
+                        "Swagger UI is enabled in a non-Development environment. " +
+                        "This exposes API surface details publicly. Disable via Swagger:Enabled=false in configuration.");
+                }
+
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>
                 {
@@ -254,8 +263,17 @@ namespace IntelliTrader.Web
                 });
             }
 
-            // Expose /metrics endpoint for Prometheus scraping
-            app.UseIntelliTraderPrometheusEndpoint();
+            // Expose /metrics endpoint for Prometheus scraping.
+            // NOTE: This endpoint is intentionally placed before UseAuthentication() because
+            // Prometheus scrapers typically cannot authenticate with cookie-based auth.
+            // The /metrics endpoint only exposes operational telemetry (request counts, latencies,
+            // runtime metrics) — no trading secrets or user data. This is standard practice
+            // for Prometheus integration. To disable metrics entirely, set Web:MetricsEnabled=false.
+            var metricsEnabled = Configuration.GetValue<bool?>("Web:MetricsEnabled") ?? true;
+            if (metricsEnabled)
+            {
+                app.UseIntelliTraderPrometheusEndpoint();
+            }
 
             app.UseRouting();
 


### PR DESCRIPTION
## Summary

Closes #90 — Security posture gaps.

- **Audit hash chain**: Each audit log entry now includes a `IntegrityHash` field (SHA-256 of previous hash + current entry). Tampering with or deleting any entry breaks the chain, making modifications detectable. On restart, the last hash is recovered from disk to continue the chain.
- **Audit trading details**: `AuditMiddleware` now captures form data (pair, amount) for `/Buy`, `/Sell`, `/Swap` endpoints. Sensitive fields (password, apikey, etc.) are filtered out. Request buffering is enabled so downstream model binding still works.
- **Prometheus /metrics documented and configurable**: Added documentation explaining why `/metrics` is intentionally before auth (standard Prometheus practice). Added `Web:MetricsEnabled` config flag (default: true) to disable the endpoint if needed.
- **Swagger prod warning**: Logs a warning when Swagger UI is enabled in non-Development environment.
- **PasswordStatus endpoint**: Already protected by `[Authorize(Policy = AuthPolicies.AdminOnly)]` — verified, no change needed.
- **Logout via GET**: Already fixed by #87 — skipped.

## Test plan

- [ ] Verify audit log entries for `/Buy` and `/Sell` now include `Pair` and `Amount` in the Details field
- [ ] Verify audit log entries contain `IntegrityHash` field
- [ ] Verify hash chain continuity: modify an entry in the middle and confirm chain verification detects it
- [ ] Verify `Web:MetricsEnabled=false` disables the `/metrics` endpoint
- [ ] Verify Swagger warning appears in logs when `Swagger:Enabled=true` in non-Development
- [ ] Verify existing audit, auth, and trading flows are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)