### PR TITLE
fix(trading): address failure modes with financial/data loss risk

### DIFF
--- a/IntelliTrader.Core/Models/Constants.cs
+++ b/IntelliTrader.Core/Models/Constants.cs
@@ -153,9 +153,9 @@ namespace IntelliTrader.Core
 
             /// <summary>
             /// Maximum retry attempts for order operations.
-            /// CRITICAL: Keep at 1 to prevent duplicate orders.
+            /// CRITICAL: Must be 0 — orders must not be retried to prevent duplicates.
             /// </summary>
-            public const int DefaultOrderMaxRetryAttempts = 1;
+            public const int DefaultOrderMaxRetryAttempts = 0;
 
             /// <summary>Initial delay before first retry for orders (ms)</summary>
             public const int DefaultOrderInitialDelayMs = 500;

--- a/IntelliTrader.Exchange.Binance/Config/ResilienceConfig.cs
+++ b/IntelliTrader.Exchange.Binance/Config/ResilienceConfig.cs
@@ -55,10 +55,11 @@ namespace IntelliTrader.Exchange.Binance.Config
 
         /// <summary>
         /// Maximum retry attempts for order operations.
-        /// CRITICAL: Keep very low (1) to prevent duplicate orders.
-        /// Only retries on connection errors, not response errors.
+        /// CRITICAL: Set to 0 — orders must NOT be retried automatically.
+        /// Even a single retry risks duplicate orders if the original request
+        /// reached the exchange but the response was lost.
         /// </summary>
-        public int OrderMaxRetryAttempts { get; set; } = 1;
+        public int OrderMaxRetryAttempts { get; set; } = 0;
 
         /// <summary>
         /// Initial delay before first retry for order operations (milliseconds).

--- a/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
+++ b/IntelliTrader.Exchange.Binance/Resilience/ExchangeResiliencePipelines.cs
@@ -178,29 +178,14 @@ namespace IntelliTrader.Exchange.Binance.Resilience
                     }
                 })
 
-                // 3. Retry - VERY CONSERVATIVE for orders to prevent duplicates
-                // CRITICAL: Only retry on true connection errors where we know the request
-                // never reached the server. Do NOT retry on TaskCanceledException/timeout
-                // because the server may have executed the order but the response was slow.
-                .AddRetry(new RetryStrategyOptions
-                {
-                    MaxRetryAttempts = _config.OrderMaxRetryAttempts, // Should be 1
-                    BackoffType = DelayBackoffType.Exponential,
-                    Delay = TimeSpan.FromMilliseconds(_config.OrderInitialDelayMs),
-                    UseJitter = true,
-                    // ONLY retry on connection errors, NOT on timeout or any response
-                    ShouldHandle = new PredicateBuilder()
-                        .Handle<HttpRequestException>(ex => IsConnectionError(ex)),
-                    OnRetry = args =>
-                    {
-                        _loggingService.Warning($"[Resilience] RETRYING ORDER (attempt {args.AttemptNumber + 1}/{_config.OrderMaxRetryAttempts}) - VERIFY ORDER STATUS BEFORE RETRY! Reason: {args.Outcome.Exception?.Message ?? "Unknown"}");
-                        return default;
-                    }
-                })
+                // 3. NO RETRY for order operations.
+                // CRITICAL: Orders must NOT be retried automatically to prevent duplicate orders.
+                // A failed order should be logged and the operator notified, not retried blindly.
+                // The retry has been removed entirely (OrderMaxRetryAttempts = 0) as even a single
+                // retry risks placing a duplicate order if the original request reached the exchange
+                // but the response was lost.
 
-                // 4. Timeout - INSIDE retry so each attempt gets its own timeout.
-                // If a timeout fires, it will NOT trigger a retry (TaskCanceledException
-                // is excluded from retry ShouldHandle), preventing duplicate orders.
+                // 4. Timeout - applied once per order attempt.
                 .AddTimeout(new TimeoutStrategyOptions
                 {
                     Timeout = TimeSpan.FromSeconds(_config.OrderTimeoutSeconds),

--- a/IntelliTrader.Exchange.Binance/Services/BinanceExchangeService.cs
+++ b/IntelliTrader.Exchange.Binance/Services/BinanceExchangeService.cs
@@ -280,6 +280,14 @@ namespace IntelliTrader.Exchange.Binance
         {
             if (_tickers.TryGetValue(pair, out Ticker? ticker))
             {
+                // Stale price protection: if ticker data is older than 60 seconds,
+                // return 0 to prevent trading on outdated prices. The calling code
+                // in TradingService.CanBuy() already checks price <= 0 and blocks the trade.
+                if (TimeSinceLastTickerUpdate.TotalSeconds > MaxTickersAgeToReconnectSeconds)
+                {
+                    _loggingService.Warning($"[StalePrice] Ticker data for {pair} is {TimeSinceLastTickerUpdate.TotalSeconds:F0}s old (limit: {MaxTickersAgeToReconnectSeconds}s). Returning 0 to block trading.");
+                    return Task.FromResult(0m);
+                }
                 return Task.FromResult(ticker.LastPrice);
             }
             else

--- a/IntelliTrader.Trading/Models/Accounts/ExchangeAccount.cs
+++ b/IntelliTrader.Trading/Models/Accounts/ExchangeAccount.cs
@@ -28,45 +28,76 @@ namespace IntelliTrader.Trading
             DateTimeOffset refreshStart = DateTimeOffset.Now;
 
             // Preload account data without locking the account
-            try
-            {
-                loggingService.Info("Load account data...");
+            // On initial refresh (startup), retry up to 3 times with 10s delay to handle
+            // transient exchange outages that would otherwise crash the bot.
+            int maxAttempts = isInitialRefresh ? 3 : 1;
+            Exception lastException = null;
 
-                foreach (var kvp in tradingService.GetAvailableAmounts())
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
                 {
-                    string currency = kvp.Key;
-                    string pair = currency + tradingService.Config.Market;
-                    decimal amount = kvp.Value;
-                    decimal price = tradingService.GetCurrentPrice(pair);
-                    decimal cost = amount * price;
+                    loggingService.Info(isInitialRefresh && attempt > 1
+                        ? $"Load account data (attempt {attempt}/{maxAttempts})..."
+                        : "Load account data...");
 
-                    if (currency == tradingService.Config.Market)
+                    foreach (var kvp in tradingService.GetAvailableAmounts())
                     {
-                        newBalance = amount;
-                    }
-                    else if (cost > tradingService.Config.MinCost && !tradingService.Config.ExcludedPairs.Contains(pair))
-                    {
-                        try
+                        string currency = kvp.Key;
+                        string pair = currency + tradingService.Config.Market;
+                        decimal amount = kvp.Value;
+                        decimal price = tradingService.GetCurrentPrice(pair);
+                        decimal cost = amount * price;
+
+                        if (currency == tradingService.Config.Market)
                         {
-                            IEnumerable<IOrderDetails> trades = tradingService.GetMyTrades(pair);
-                            availableTrades.Add(pair, trades);
-                            availableAmounts.Add(pair, amount);
+                            newBalance = amount;
                         }
-                        catch (Exception ex) when (ex.Message != null && ex.Message.Contains("Invalid symbol"))
+                        else if (cost > tradingService.Config.MinCost && !tradingService.Config.ExcludedPairs.Contains(pair))
                         {
-                            loggingService.Info($"Skip invalid pair: {pair}");
+                            try
+                            {
+                                IEnumerable<IOrderDetails> trades = tradingService.GetMyTrades(pair);
+                                availableTrades.Add(pair, trades);
+                                availableAmounts.Add(pair, amount);
+                            }
+                            catch (Exception ex) when (ex.Message != null && ex.Message.Contains("Invalid symbol"))
+                            {
+                                loggingService.Info($"Skip invalid pair: {pair}");
+                            }
                         }
                     }
+
+                    loggingService.Info("Account data loaded");
+                    lastException = null;
+                    break; // Success, exit retry loop
                 }
-
-                loggingService.Info("Account data loaded");
-            }
-            catch (Exception ex) when (!isInitialRefresh)
-            {
-                healthCheckService.UpdateHealthCheck(Constants.HealthChecks.AccountRefreshed, ex.Message, true);
-                loggingService.Error("Unable to load account data", ex);
-                _ = notificationService.NotifyAsync("Unable to load account data");
-                return;
+                catch (Exception ex) when (!isInitialRefresh)
+                {
+                    healthCheckService.UpdateHealthCheck(Constants.HealthChecks.AccountRefreshed, ex.Message, true);
+                    loggingService.Error("Unable to load account data", ex);
+                    _ = notificationService.NotifyAsync("Unable to load account data");
+                    return;
+                }
+                catch (Exception ex) when (isInitialRefresh && attempt < maxAttempts)
+                {
+                    lastException = ex;
+                    loggingService.Warning($"Unable to load account data on startup (attempt {attempt}/{maxAttempts}), retrying in 10s: {ex.Message}");
+                    availableAmounts.Clear();
+                    availableTrades.Clear();
+                    newBalance = 0;
+                    Thread.Sleep(10000);
+                }
+                catch (Exception ex) when (isInitialRefresh && attempt == maxAttempts)
+                {
+                    lastException = ex;
+                    loggingService.Error($"Unable to load account data after {maxAttempts} attempts. Suspending trading instead of crashing.", ex);
+                    healthCheckService.UpdateHealthCheck(Constants.HealthChecks.AccountRefreshed, ex.Message, true);
+                    _ = notificationService.NotifyAsync($"CRITICAL: Unable to load account data after {maxAttempts} attempts. Trading suspended.");
+                    tradingService.SuspendTrading();
+                    isInitialRefresh = false;
+                    return;
+                }
             }
 
             // Lock the account and reapply all trades
@@ -196,7 +227,11 @@ namespace IntelliTrader.Trading
                     string accountJson = JsonSerializer.Serialize(data, options);
                     var accountFile = new FileInfo(accountFilePath);
                     accountFile.Directory?.Create();
-                    File.WriteAllText(accountFile.FullName, accountJson);
+
+                    // Atomic write: write to temp file first, then rename
+                    var tempPath = accountFile.FullName + ".tmp";
+                    File.WriteAllText(tempPath, accountJson);
+                    File.Move(tempPath, accountFile.FullName, overwrite: true);
                 }
                 catch (Exception ex)
                 {
@@ -399,11 +434,18 @@ namespace IntelliTrader.Trading
                 var accountFile = new FileInfo(accountFilePath);
                 accountFile.Directory?.Create();
 
+                // Atomic write: write to temp file first, then rename
+                var tempPath = accountFile.FullName + ".tmp";
 #if NETCOREAPP2_1
                 // .NET Core 2.1 doesn't have WriteAllTextAsync
-                await Task.Run(() => File.WriteAllText(accountFile.FullName, accountJson), cancellationToken).ConfigureAwait(false);
+                await Task.Run(() =>
+                {
+                    File.WriteAllText(tempPath, accountJson);
+                    File.Move(tempPath, accountFile.FullName, overwrite: true);
+                }, cancellationToken).ConfigureAwait(false);
 #else
-                await File.WriteAllTextAsync(accountFile.FullName, accountJson, cancellationToken).ConfigureAwait(false);
+                await File.WriteAllTextAsync(tempPath, accountJson, cancellationToken).ConfigureAwait(false);
+                File.Move(tempPath, accountFile.FullName, overwrite: true);
 #endif
             }
             catch (Exception ex)

--- a/IntelliTrader.Trading/Models/Accounts/VirtualAccount.cs
+++ b/IntelliTrader.Trading/Models/Accounts/VirtualAccount.cs
@@ -37,19 +37,30 @@ namespace IntelliTrader.Trading
         {
             lock (SyncRoot)
             {
-                string virtualAccountFilePath = Path.Combine(Directory.GetCurrentDirectory(), tradingService.Config.VirtualAccountFilePath);
-
-                var data = new TradingAccountData
+                try
                 {
-                    Balance = balance,
-                    TradingPairs = tradingPairs
-                };
+                    string virtualAccountFilePath = Path.Combine(Directory.GetCurrentDirectory(), tradingService.Config.VirtualAccountFilePath);
 
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                string virtualAccountJson = JsonSerializer.Serialize(data, options);
-                var virtualAccountFile = new FileInfo(virtualAccountFilePath);
-                virtualAccountFile.Directory?.Create();
-                File.WriteAllText(virtualAccountFile.FullName, virtualAccountJson);
+                    var data = new TradingAccountData
+                    {
+                        Balance = balance,
+                        TradingPairs = tradingPairs
+                    };
+
+                    var options = new JsonSerializerOptions { WriteIndented = true };
+                    string virtualAccountJson = JsonSerializer.Serialize(data, options);
+                    var virtualAccountFile = new FileInfo(virtualAccountFilePath);
+                    virtualAccountFile.Directory?.Create();
+
+                    // Atomic write: write to temp file first, then rename
+                    var tempPath = virtualAccountFile.FullName + ".tmp";
+                    File.WriteAllText(tempPath, virtualAccountJson);
+                    File.Move(tempPath, virtualAccountFile.FullName, overwrite: true);
+                }
+                catch (Exception ex)
+                {
+                    loggingService.Error("Unable to save virtual account data", ex);
+                }
             }
         }
 
@@ -121,11 +132,18 @@ namespace IntelliTrader.Trading
             var virtualAccountFile = new FileInfo(virtualAccountFilePath);
             virtualAccountFile.Directory?.Create();
 
+            // Atomic write: write to temp file first, then rename
+            var tempPath = virtualAccountFile.FullName + ".tmp";
 #if NETCOREAPP2_1
             // .NET Core 2.1 doesn't have WriteAllTextAsync
-            await Task.Run(() => File.WriteAllText(virtualAccountFile.FullName, virtualAccountJson), cancellationToken).ConfigureAwait(false);
+            await Task.Run(() =>
+            {
+                File.WriteAllText(tempPath, virtualAccountJson);
+                File.Move(tempPath, virtualAccountFile.FullName, overwrite: true);
+            }, cancellationToken).ConfigureAwait(false);
 #else
-            await File.WriteAllTextAsync(virtualAccountFile.FullName, virtualAccountJson, cancellationToken).ConfigureAwait(false);
+            await File.WriteAllTextAsync(tempPath, virtualAccountJson, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, virtualAccountFile.FullName, overwrite: true);
 #endif
         }
 

--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -1055,6 +1055,8 @@ namespace IntelliTrader.Trading
 
         private IOrderDetails PlaceBuyOrder(BuyOptions options)
         {
+            // Snapshot config at method entry to prevent mid-operation config changes
+            var config = Config;
             IOrderDetails orderDetails = null;
             TrailingManager.CancelTrailingBuy(options.Pair);
             TrailingManager.CancelTrailingSell(options.Pair);
@@ -1072,7 +1074,7 @@ namespace IntelliTrader.Trading
                     // Amount specified directly, calculate cost
                     effectiveMaxCost = options.Amount.Value * currentPrice;
                 }
-                else if (Config.PositionSizing?.Enabled == true && !options.ManualOrder && !options.Swap)
+                else if (config.PositionSizing?.Enabled == true && !options.ManualOrder && !options.Swap)
                 {
                     // Use position sizing for automated trades
                     decimal? calculatedSize = CalculatePositionSize(options.Pair, currentPrice);
@@ -1127,12 +1129,12 @@ namespace IntelliTrader.Trading
                         fees: orderDetails.Fees));
 
                     // Register position with portfolio risk manager
-                    if (portfolioRiskManager != null && Config.RiskManagement?.Enabled == true)
+                    if (portfolioRiskManager != null && config.RiskManagement?.Enabled == true)
                     {
-                        decimal positionRisk = Config.RiskManagement.DefaultPositionRiskPercent;
+                        decimal positionRisk = config.RiskManagement.DefaultPositionRiskPercent;
                         if (portfolioRiskManager is PortfolioRiskManager prm)
                         {
-                            positionRisk = prm.CalculatePositionRisk(orderDetails.AverageCost, Math.Abs(Config.SellStopLossMargin));
+                            positionRisk = prm.CalculatePositionRisk(orderDetails.AverageCost, Math.Abs(config.SellStopLossMargin));
                         }
                         portfolioRiskManager.RegisterPosition(options.Pair, positionRisk);
                     }
@@ -1153,6 +1155,8 @@ namespace IntelliTrader.Trading
 
         private IOrderDetails PlaceSellOrder(SellOptions options)
         {
+            // Snapshot config at method entry to prevent mid-operation config changes
+            var config = Config;
             IOrderDetails orderDetails = null;
             TrailingManager.CancelTrailingSell(options.Pair);
             TrailingManager.CancelTrailingBuy(options.Pair);
@@ -1209,7 +1213,7 @@ namespace IntelliTrader.Trading
                         fees: orderDetails.Fees));
 
                     // Update portfolio risk manager
-                    if (portfolioRiskManager != null && Config.RiskManagement?.Enabled == true)
+                    if (portfolioRiskManager != null && config.RiskManagement?.Enabled == true)
                     {
                         // Close the position in risk tracking
                         portfolioRiskManager.ClosePosition(options.Pair);
@@ -1245,6 +1249,8 @@ namespace IntelliTrader.Trading
 
         private async Task<IOrderDetails> PlaceBuyOrderAsync(BuyOptions options, CancellationToken cancellationToken = default)
         {
+            // Snapshot config at method entry to prevent mid-operation config changes
+            var config = Config;
             IOrderDetails orderDetails = null;
             TrailingManager.CancelTrailingBuy(options.Pair);
             TrailingManager.CancelTrailingSell(options.Pair);
@@ -1262,7 +1268,7 @@ namespace IntelliTrader.Trading
                     // Amount specified directly, calculate cost
                     effectiveMaxCost = options.Amount.Value * currentPrice;
                 }
-                else if (Config.PositionSizing?.Enabled == true && !options.ManualOrder && !options.Swap)
+                else if (config.PositionSizing?.Enabled == true && !options.ManualOrder && !options.Swap)
                 {
                     // Use position sizing for automated trades
                     decimal? calculatedSize = CalculatePositionSize(options.Pair, currentPrice);
@@ -1318,12 +1324,12 @@ namespace IntelliTrader.Trading
                         fees: orderDetails.Fees));
 
                     // Register position with portfolio risk manager
-                    if (portfolioRiskManager != null && Config.RiskManagement?.Enabled == true)
+                    if (portfolioRiskManager != null && config.RiskManagement?.Enabled == true)
                     {
-                        decimal positionRisk = Config.RiskManagement.DefaultPositionRiskPercent;
+                        decimal positionRisk = config.RiskManagement.DefaultPositionRiskPercent;
                         if (portfolioRiskManager is PortfolioRiskManager prm)
                         {
-                            positionRisk = prm.CalculatePositionRisk(orderDetails.AverageCost, Math.Abs(Config.SellStopLossMargin));
+                            positionRisk = prm.CalculatePositionRisk(orderDetails.AverageCost, Math.Abs(config.SellStopLossMargin));
                         }
                         portfolioRiskManager.RegisterPosition(options.Pair, positionRisk);
                     }
@@ -1344,6 +1350,8 @@ namespace IntelliTrader.Trading
 
         private async Task<IOrderDetails> PlaceSellOrderAsync(SellOptions options, CancellationToken cancellationToken = default)
         {
+            // Snapshot config at method entry to prevent mid-operation config changes
+            var config = Config;
             IOrderDetails orderDetails = null;
             TrailingManager.CancelTrailingSell(options.Pair);
             TrailingManager.CancelTrailingBuy(options.Pair);
@@ -1402,7 +1410,7 @@ namespace IntelliTrader.Trading
                         fees: orderDetails.Fees));
 
                     // Update portfolio risk manager
-                    if (portfolioRiskManager != null && Config.RiskManagement?.Enabled == true)
+                    if (portfolioRiskManager != null && config.RiskManagement?.Enabled == true)
                     {
                         // Close the position in risk tracking
                         portfolioRiskManager.ClosePosition(options.Pair);

--- a/tests/IntelliTrader.Core.Tests/ConstantsTests.cs
+++ b/tests/IntelliTrader.Core.Tests/ConstantsTests.cs
@@ -172,8 +172,8 @@ public class ConstantsTests
     [Fact]
     public void Resilience_OrderMaxRetryAttempts_IsMinimal()
     {
-        // Orders should have minimal retries to prevent duplicate orders
-        Constants.Resilience.DefaultOrderMaxRetryAttempts.Should().BeLessThanOrEqualTo(2);
+        // Orders must NOT be retried to prevent duplicate orders
+        Constants.Resilience.DefaultOrderMaxRetryAttempts.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Refs #100

- **Remove order retry**: Set `OrderMaxRetryAttempts` to 0 and stripped retry logic from the order pipeline entirely. Failed orders now log/notify instead of retrying, preventing duplicate orders on connection errors.
- **Config snapshots**: `PlaceBuyOrder`, `PlaceSellOrder`, and async variants now snapshot `Config` at method entry, preventing mid-operation config hot-reload from causing inconsistent trading parameters.
- **Atomic file writes**: `VirtualAccount.Save()` and `ExchangeAccount.Save()` (sync + async) now write to a `.tmp` file and atomically rename. Also added missing `try-catch` to `VirtualAccount.Save()`.
- **Stale price protection**: `GetLastPrice()` returns 0 when ticker data exceeds 60 seconds old. `CanBuy()` already blocks trades when `price <= 0`.
- **Startup resilience**: `ExchangeAccount.Refresh()` retries up to 3 times (10s delay) on initial startup. On final failure, trading is suspended instead of crashing the bot.

## Test plan

- [ ] Verify build succeeds (pre-existing CS0119 error in HomeController.cs is unrelated)
- [ ] Verify `ConstantsTests.Resilience_OrderMaxRetryAttempts_IsMinimal` passes with updated assertion (`== 0`)
- [ ] Manual: confirm order placement no longer retries on connection error
- [ ] Manual: confirm stale price (>60s) blocks buy orders with "invalid price" log
- [ ] Manual: confirm account file writes are atomic (check for `.tmp` files during save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)