### PR TITLE
fix: add missing DI bridges and async trading synchronization

### DIFF
--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -62,6 +62,8 @@ namespace IntelliTrader.Trading
         private readonly object _syncRoot = new object();
         public object SyncRoot => _syncRoot;
 
+        private readonly SemaphoreSlim _tradingSemaphore = new SemaphoreSlim(1, 1);
+
         public IModuleRules Rules { get; private set; }
         public TradingRulesConfig RulesConfig { get; private set; }
 
@@ -357,6 +359,19 @@ namespace IntelliTrader.Trading
         // Async trading methods (preferred for new code)
         public async Task BuyAsync(BuyOptions options, CancellationToken cancellationToken = default)
         {
+            await _tradingSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await BuyInternalAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tradingSemaphore.Release();
+            }
+        }
+
+        private async Task BuyInternalAsync(BuyOptions options, CancellationToken cancellationToken)
+        {
             IRule rule = signalsService.Value.Rules.Entries.FirstOrDefault(r => r.Name == options.Metadata.SignalRule);
 
             ITradingPair swappedPair = Account.GetTradingPairs().OrderBy(p => p.CurrentMargin).FirstOrDefault(tradingPair =>
@@ -369,7 +384,7 @@ namespace IntelliTrader.Trading
 
             if (swappedPair != null)
             {
-                await SwapAsync(new SwapOptions(swappedPair.Pair, options.Pair, options.Metadata), cancellationToken).ConfigureAwait(false);
+                await SwapInternalAsync(new SwapOptions(swappedPair.Pair, options.Pair, options.Metadata), cancellationToken).ConfigureAwait(false);
             }
             else if (rule?.Action != Constants.SignalRuleActions.Swap)
             {
@@ -401,6 +416,19 @@ namespace IntelliTrader.Trading
 
         public async Task SellAsync(SellOptions options, CancellationToken cancellationToken = default)
         {
+            await _tradingSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SellInternalAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tradingSemaphore.Release();
+            }
+        }
+
+        private async Task SellInternalAsync(SellOptions options, CancellationToken cancellationToken)
+        {
             if (CanSell(options, out string message))
             {
                 await InitiateSellAsync(options, cancellationToken).ConfigureAwait(false);
@@ -427,6 +455,19 @@ namespace IntelliTrader.Trading
         }
 
         public async Task SwapAsync(SwapOptions options, CancellationToken cancellationToken = default)
+        {
+            await _tradingSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SwapInternalAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tradingSemaphore.Release();
+            }
+        }
+
+        private async Task SwapInternalAsync(SwapOptions options, CancellationToken cancellationToken)
         {
             if (!CanSwap(options, out string message))
             {

--- a/IntelliTrader.Web/Startup.cs
+++ b/IntelliTrader.Web/Startup.cs
@@ -52,6 +52,12 @@ namespace IntelliTrader.Web
             services.AddSingleton(_ => Container.Resolve<IHealthCheckService>());
             services.AddSingleton(_ => Container.Resolve<IAuditService>());
             services.AddSingleton(_ => Container.Resolve<IEnumerable<IConfigurableService>>());
+            services.AddSingleton(_ => Container.Resolve<IConfigProvider>());
+            services.AddSingleton(_ =>
+            {
+                Container.TryResolve<IPortfolioRiskManager>(out var manager);
+                return manager;
+            });
 
             // Register password service for secure password hashing (BCrypt)
             services.AddSingleton<IPasswordService, PasswordService>();


### PR DESCRIPTION
## Summary
- **IConfigProvider DI bridge**: HomeController requires `IConfigProvider` but it was not bridged from Autofac to ASP.NET Core DI in `Startup.cs`. Added `services.AddSingleton(_ => Container.Resolve<IConfigProvider>())`.
- **IPortfolioRiskManager DI bridge**: HomeController accepts `IPortfolioRiskManager` as an optional parameter but it always resolved to null. Added with `TryResolve` to handle cases where the Trading module may not be loaded.
- **Async trading synchronization**: After PR #104 converted sync Buy/Sell/Swap to delegate to async methods, the old `lock(SyncRoot)` protection was lost. Added `SemaphoreSlim(1,1)` to `BuyAsync`, `SellAsync`, and `SwapAsync`. Extracted internal methods (`BuyInternalAsync`, `SellInternalAsync`, `SwapInternalAsync`) to avoid deadlock when `BuyAsync` calls `SwapAsync` within the same semaphore scope.
- **release.yml**: Verified test step matches CI (both run unfiltered `dotnet test`). No change needed.

Closes #106

## Test plan
- [ ] Verify HomeController resolves `IConfigProvider` correctly (no DI exception)
- [ ] Verify `IPortfolioRiskManager` resolves when Trading module is loaded, returns null gracefully otherwise
- [ ] Verify concurrent Buy/Sell operations are serialized by the semaphore
- [ ] Verify BuyAsync -> SwapAsync path does not deadlock (internal methods bypass semaphore)
- [ ] CI passes all existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced trading operations with improved execution consistency and reliability
  * Expanded service configuration and risk management infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->