### PR TITLE
fix(trading): correct financial calculation errors

### DIFF
--- a/IntelliTrader.Domain/Trading/Services/MarginCalculator.cs
+++ b/IntelliTrader.Domain/Trading/Services/MarginCalculator.cs
@@ -162,6 +162,12 @@ public sealed class MarginCalculator
         }
 
         var buyFees = position.TotalFees;
+        // TODO: This uses cost basis to estimate sell fees, but should ideally use
+        // current market value (currentPrice * quantity) for accurate estimation.
+        // Current value is not available in this context without adding a price parameter.
+        // Example: position cost=1000, current value=1500, fee=0.1% =>
+        //   current calc: 1000 * 0.001 = 1.00 (underestimates)
+        //   correct calc: 1500 * 0.001 = 1.50
         var estimatedSellFees = Money.Create(
             position.TotalCost.Amount * (sellFeePercentage / 100m),
             position.Currency);

--- a/IntelliTrader.Trading/Misc/Utils.cs
+++ b/IntelliTrader.Trading/Misc/Utils.cs
@@ -8,6 +8,9 @@ namespace IntelliTrader.Trading
     {
         public static decimal CalculateMargin(decimal oldValue, decimal newValue)
         {
+            // Guard against division by zero (e.g., zero cost basis).
+            // Example: CalculateMargin(0, 100) => 0 instead of DivideByZeroException
+            if (oldValue == 0m) return 0m;
             return (newValue - oldValue) / oldValue * 100;
         }
     }

--- a/IntelliTrader.Trading/Models/Accounts/TradingAccountBase.cs
+++ b/IntelliTrader.Trading/Models/Accounts/TradingAccountBase.cs
@@ -92,7 +92,11 @@ namespace IntelliTrader.Trading
                             tradingPair.OrderIds.Add(order.OrderId);
                             tradingPair.OrderDates.Add(order.Date);
                         }
-                        tradingPair.AveragePricePaid = (tradingPair.AverageCostPaid + order.AverageCost) / (tradingPair.TotalAmount + order.AmountFilled);
+                        // Fix: denominator must use amountAfterFees to match TotalAmount accumulation.
+                        // Example: existing 50 units at cost 100, new order 10 units with 0.1 fee =>
+                        //   amountAfterFees = 9.9, cost = 110 => avgPrice = 210 / 59.9 = 3.506
+                        //   Using order.AmountFilled (10) would give 210 / 60 = 3.500 (wrong)
+                        tradingPair.AveragePricePaid = (tradingPair.AverageCostPaid + order.AverageCost) / (tradingPair.TotalAmount + amountAfterFees);
                         tradingPair.FeesPairCurrency += feesPairCurrency;
                         tradingPair.FeesMarketCurrency += feesMarketCurrency;
                         tradingPair.TotalAmount += amountAfterFees;
@@ -130,21 +134,39 @@ namespace IntelliTrader.Trading
                     {
                         decimal balanceDifference = order.AverageCost;
 
+                        decimal sellFeesMarketCurrency = 0;
                         if (order.Fees != 0 && order.FeesCurrency != null)
                         {
                             if (order.FeesCurrency == tradingService.Config.Market)
                             {
+                                sellFeesMarketCurrency = order.Fees;
                                 tradingPair.FeesMarketCurrency += order.Fees;
                                 balanceDifference -= order.Fees;
                             }
                             else
                             {
                                 string feesPair = order.FeesCurrency + tradingService.Config.Market;
-                                tradingPair.FeesMarketCurrency += tradingService.GetCurrentPrice(feesPair) * order.Fees;
+                                if (feesPair == order.Pair)
+                                {
+                                    // Fees in pair currency reduce the effective sell proceeds
+                                    balanceDifference -= tradingService.GetCurrentPrice(feesPair) * order.Fees;
+                                }
+                                sellFeesMarketCurrency = tradingService.GetCurrentPrice(feesPair) * order.Fees;
+                                tradingPair.FeesMarketCurrency += sellFeesMarketCurrency;
                             }
                         }
                         balance += balanceDifference;
-                        decimal profit = (order.AverageCost - tradingPair.AverageCostPaid - (tradingPair.Metadata.AdditionalCosts ?? 0)) * (order.AmountFilled / tradingPair.TotalAmount);
+
+                        decimal additionalCosts = tradingPair.Metadata.AdditionalCosts ?? 0;
+                        decimal sellRatio = order.AmountFilled / tradingPair.TotalAmount;
+
+                        // Correct partial sell profit formula:
+                        // profit = sell proceeds - proportional cost basis - sell fees
+                        // Example: bought 100 units for 1000 total, additional costs 10, selling 25 units for 300:
+                        //   proportional cost = (1000 + 10) * (25 / 100) = 252.5
+                        //   profit = 300 - 252.5 - sellFees
+                        decimal proportionalCostBasis = (tradingPair.AverageCostPaid + additionalCosts) * sellRatio;
+                        decimal profit = order.AverageCost - proportionalCostBasis - sellFeesMarketCurrency;
 
                         var tradeResult = new TradeResult
                         {

--- a/IntelliTrader.Trading/Services/TradingService.cs
+++ b/IntelliTrader.Trading/Services/TradingService.cs
@@ -880,7 +880,8 @@ namespace IntelliTrader.Trading
                     effectiveMaxCost = options.MaxCost.Value;
                 }
 
-                decimal amount = options.Amount ?? Math.Round(effectiveMaxCost / currentPrice, 4);
+                // Use 8 decimal places (Binance max precision for most pairs) instead of hardcoded 4
+                decimal amount = options.Amount ?? Math.Round(effectiveMaxCost / currentPrice, 8);
 
                 var orderRequest = new BuyOrder
                 {


### PR DESCRIPTION
## Summary

Fixes critical financial calculation bugs that cause incorrect profit/loss reporting and order sizing.

- **Division by zero in `CalculateMargin`**: Returns 0 instead of throwing when `oldValue` is 0
- **Partial sell profit formula**: Old formula `(proceeds - totalCost - additionalCosts) * ratio` was mathematically wrong; fixed to `proceeds - (totalCost + additionalCosts) * ratio - sellFees` (proportional cost basis)
- **Sell fees in pair currency**: Added missing check (mirroring buy-side) to deduct pair-currency fees from balance
- **Sell profit ignores fees**: Profit now subtracts sell-side fees
- **DCA AveragePricePaid denominator**: Fixed to use `amountAfterFees` instead of `order.AmountFilled` to match how `TotalAmount` accumulates
- **Buy amount precision**: Changed from 4 to 8 decimal places (Binance max for most pairs)
- **AnalyzeFeeImpact**: Added TODO documenting that it uses cost basis instead of current value for sell fee estimation

Each formula change includes an inline example calculation verifying correctness.

Closes #111

## Test plan

- [ ] Verify `CalculateMargin(0, x)` returns 0 instead of throwing
- [ ] Verify partial sell profit: buy 100 units for 1000, sell 25 for 300 => profit ~47.5 (not -177.5)
- [ ] Verify sell fees in pair currency are deducted from balance
- [ ] Verify DCA average price accounts for fee-adjusted amounts
- [ ] Verify buy orders use 8 decimal precision
- [ ] Run existing unit tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential calculation error that could prevent margin analysis.
  * Corrected profit calculation logic for partial asset sales to improve accuracy.
  * Enhanced fee tracking consistency when fees are in different currencies.
  * Improved average price calculations for buy orders.

* **Improvements**
  * Adjusted buy order amount precision for better quantization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->