### PR TITLE
fix(security): clean up decrypted temp files, redact sensitive config

### DIFF
--- a/IntelliTrader.Core/Interfaces/Configs/IConfigProvider.cs
+++ b/IntelliTrader.Core/Interfaces/Configs/IConfigProvider.cs
@@ -8,7 +8,7 @@ namespace IntelliTrader.Core
     /// <summary>
     /// Provides access to application configuration sections with support for hot-reload and change notifications.
     /// </summary>
-    public interface IConfigProvider
+    public interface IConfigProvider : IDisposable
     {
         /// <summary>
         /// Gets the raw JSON string for a configuration section.

--- a/IntelliTrader.Core/Models/Config/ConfigProvider.cs
+++ b/IntelliTrader.Core/Models/Config/ConfigProvider.cs
@@ -29,6 +29,11 @@ namespace IntelliTrader.Core
         // Tracks which config files were originally encrypted so we re-encrypt on save
         private readonly ConcurrentDictionary<string, bool> _encryptedFiles = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
+        // Tracks decrypted temp files so they can be cleaned up on disposal
+        private readonly List<string> _tempFiles = new List<string>();
+        private readonly object _tempFileLock = new object();
+        private bool _disposed;
+
         private const string MasterPasswordEnvVar = "INTELLITRADER_MASTER_PASSWORD";
 
         public ConfigProvider() : this(new ConfigValidationService())
@@ -38,6 +43,8 @@ namespace IntelliTrader.Core
         public ConfigProvider(IConfigValidationService validationService)
         {
             _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupTempFiles();
 
             IConfigurationRoot pathsConfig = GetConfig(PATHS_CONFIG_PATH, changedPathsConfig =>
             {
@@ -234,8 +241,10 @@ namespace IntelliTrader.Core
                             string decrypted = ConfigEncryption.Decrypt(raw, masterPassword);
                             // Write a decrypted temporary file that the JSON provider can read.
                             // Place it in the system temp directory so we don't pollute the config folder.
-                            string tempFile = Path.Combine(Path.GetTempPath(), $"intellitrader_cfg_{Path.GetFileName(configPath)}");
+                            // Use a random filename to avoid predictable temp file paths.
+                            string tempFile = Path.Combine(Path.GetTempPath(), $"intellitrader_{Path.GetRandomFileName()}.json");
                             File.WriteAllText(tempFile, decrypted);
+                            TrackTempFile(tempFile);
                             effectivePath = Path.GetFileName(tempFile);
                             effectiveBaseDir = Path.GetDirectoryName(tempFile);
                         }
@@ -310,6 +319,54 @@ namespace IntelliTrader.Core
                 LogError($"Failed to re-encrypt config file '{filePath}'. Saving as plaintext.", ex);
                 return content;
             }
+        }
+
+        /// <summary>
+        /// Tracks a temporary file for cleanup on disposal or process exit.
+        /// </summary>
+        private void TrackTempFile(string path)
+        {
+            lock (_tempFileLock)
+            {
+                _tempFiles.Add(path);
+            }
+        }
+
+        /// <summary>
+        /// Deletes all tracked temporary files containing decrypted configuration data.
+        /// </summary>
+        private void CleanupTempFiles()
+        {
+            string[] files;
+            lock (_tempFileLock)
+            {
+                files = _tempFiles.ToArray();
+                _tempFiles.Clear();
+            }
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    if (File.Exists(file))
+                    {
+                        File.Delete(file);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup; avoid throwing during disposal/process exit.
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            CleanupTempFiles();
         }
     }
 }

--- a/IntelliTrader.Web/Controllers/HomeController.cs
+++ b/IntelliTrader.Web/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.RateLimiting;
@@ -321,9 +322,29 @@ namespace IntelliTrader.Web.Controllers
             return View(model);
         }
 
+        // Keys whose values must be redacted before sending config JSON to the browser.
+        private static readonly HashSet<string> SensitiveKeyPatterns = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "password", "token", "secret", "key", "apikey", "privatekey"
+        };
+
+        private const string RedactedPlaceholder = "********";
+
         [Authorize(Policy = AuthPolicies.AdminOnly)]
         public IActionResult Settings()
         {
+            var rawConfigs = _configurableServices
+                .Where(s => !s.GetType().Name.Contains(Constants.ServiceNames.BacktestingService))
+                .OrderBy(s => s.ServiceName)
+                .ToDictionary(s => s.ServiceName, s => _configProvider.GetSectionJson(s.ServiceName));
+
+            // Redact sensitive values before sending to the browser
+            var redactedConfigs = new Dictionary<string, string>();
+            foreach (var kvp in rawConfigs)
+            {
+                redactedConfigs[kvp.Key] = RedactSensitiveJson(kvp.Value);
+            }
+
             var model = new SettingsViewModel()
             {
                 InstanceName = _coreService.Config.InstanceName,
@@ -333,10 +354,76 @@ namespace IntelliTrader.Web.Controllers
                 SellEnabled = _tradingService.Config.SellEnabled,
                 TradingSuspended = _tradingService.IsTradingSuspended,
                 HealthCheckEnabled = _coreService.Config.HealthCheckEnabled,
-                Configs = _configurableServices.Where(s => !s.GetType().Name.Contains(Constants.ServiceNames.BacktestingService)).OrderBy(s => s.ServiceName).ToDictionary(s => s.ServiceName, s => _configProvider.GetSectionJson(s.ServiceName))
+                Configs = redactedConfigs
             };
 
             return View(model);
+        }
+
+        /// <summary>
+        /// Parses a JSON string, replaces values of keys that match sensitive patterns
+        /// with a redacted placeholder, and returns the sanitised JSON.
+        /// Returns the original string unchanged if parsing fails.
+        /// </summary>
+        private static string RedactSensitiveJson(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                return json;
+
+            try
+            {
+                var node = JsonNode.Parse(json);
+                if (node != null)
+                {
+                    RedactNode(node);
+                    return node.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+                }
+            }
+            catch
+            {
+                // If JSON is unparseable, return it as-is rather than crashing.
+            }
+
+            return json;
+        }
+
+        private static void RedactNode(JsonNode node)
+        {
+            if (node is JsonObject obj)
+            {
+                var keys = obj.Select(p => p.Key).ToList();
+                foreach (var key in keys)
+                {
+                    if (IsSensitiveKey(key))
+                    {
+                        obj[key] = RedactedPlaceholder;
+                    }
+                    else if (obj[key] is JsonNode child)
+                    {
+                        RedactNode(child);
+                    }
+                }
+            }
+            else if (node is JsonArray arr)
+            {
+                foreach (var item in arr)
+                {
+                    if (item != null)
+                    {
+                        RedactNode(item);
+                    }
+                }
+            }
+        }
+
+        private static bool IsSensitiveKey(string key)
+        {
+            foreach (var pattern in SensitiveKeyPatterns)
+            {
+                if (key.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+            return false;
         }
 
         public IActionResult Log()

--- a/IntelliTrader.Web/Middleware/AuditMiddleware.cs
+++ b/IntelliTrader.Web/Middleware/AuditMiddleware.cs
@@ -40,6 +40,12 @@ namespace IntelliTrader.Web.Middleware
             "/Swap"
         };
 
+        // Config endpoints where we capture only the config section name (not the full definition).
+        private static readonly HashSet<string> ConfigPaths = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "/SaveConfig"
+        };
+
         // Form field names that must never appear in audit logs.
         private static readonly HashSet<string> SensitiveFields = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -104,7 +110,7 @@ namespace IntelliTrader.Web.Middleware
         /// </summary>
         private static async Task<string> BuildAuditDetailsAsync(HttpRequest request, string path)
         {
-            if (!IsTradingPath(path) || !request.HasFormContentType)
+            if ((!IsTradingPath(path) && !IsConfigPath(path)) || !request.HasFormContentType)
             {
                 return $"POST {path}";
             }
@@ -115,6 +121,20 @@ namespace IntelliTrader.Web.Middleware
                 request.EnableBuffering();
 
                 var form = await request.ReadFormAsync();
+
+                // For config endpoints, only log the config section name, never the definition (may contain secrets).
+                if (IsConfigPath(path))
+                {
+                    var configName = form.ContainsKey("name") ? form["name"].ToString() : "(unknown)";
+
+                    if (request.Body.CanSeek)
+                    {
+                        request.Body.Position = 0;
+                    }
+
+                    return $"POST {path} config={configName}";
+                }
+
                 var safeFields = new List<string>();
 
                 foreach (var field in form)
@@ -157,6 +177,11 @@ namespace IntelliTrader.Web.Middleware
         private static bool IsTradingPath(string path)
         {
             return path != null && TradingPaths.Contains(path);
+        }
+
+        private static bool IsConfigPath(string path)
+        {
+            return path != null && ConfigPaths.Contains(path);
         }
 
         private static string DeriveAction(string path)

--- a/IntelliTrader.Web/MinimalApiEndpoints.cs
+++ b/IntelliTrader.Web/MinimalApiEndpoints.cs
@@ -103,23 +103,44 @@ namespace IntelliTrader.Web
                 .RequireRateLimiting("status");
 
             // GET /api/status - Get current trading status
+            // Viewer role sees a reduced payload (no Balance or LogEntries) to limit financial data exposure.
             apiGroup.MapGet("/status", (
+                HttpContext httpContext,
                 ITradingService tradingService,
                 ISignalsService signalsService,
                 IHealthCheckService healthCheckService,
                 ILoggingService loggingService) =>
             {
-                var status = new
+                bool isViewer = httpContext.User.IsInRole(UserRoles.Viewer);
+
+                object status;
+                if (isViewer)
                 {
-                    Balance = tradingService.Account.GetBalance(),
-                    GlobalRating = signalsService.GetGlobalRating()?.ToString("0.000") ?? "N/A",
-                    TrailingBuys = tradingService.GetTrailingBuys(),
-                    TrailingSells = tradingService.GetTrailingSells(),
-                    TrailingSignals = signalsService.GetTrailingSignals(),
-                    TradingSuspended = tradingService.IsTradingSuspended,
-                    HealthChecks = healthCheckService.GetHealthChecks().OrderBy(c => c.Name),
-                    LogEntries = loggingService.GetLogEntries().Reverse().Take(5)
-                };
+                    status = new
+                    {
+                        GlobalRating = signalsService.GetGlobalRating()?.ToString("0.000") ?? "N/A",
+                        TrailingBuys = tradingService.GetTrailingBuys(),
+                        TrailingSells = tradingService.GetTrailingSells(),
+                        TrailingSignals = signalsService.GetTrailingSignals(),
+                        TradingSuspended = tradingService.IsTradingSuspended,
+                        HealthChecks = healthCheckService.GetHealthChecks().OrderBy(c => c.Name)
+                    };
+                }
+                else
+                {
+                    status = new
+                    {
+                        Balance = tradingService.Account.GetBalance(),
+                        GlobalRating = signalsService.GetGlobalRating()?.ToString("0.000") ?? "N/A",
+                        TrailingBuys = tradingService.GetTrailingBuys(),
+                        TrailingSells = tradingService.GetTrailingSells(),
+                        TrailingSignals = signalsService.GetTrailingSignals(),
+                        TradingSuspended = tradingService.IsTradingSuspended,
+                        HealthChecks = healthCheckService.GetHealthChecks().OrderBy(c => c.Name),
+                        LogEntries = loggingService.GetLogEntries().Reverse().Take(5)
+                    };
+                }
+
                 return Results.Json(status);
             })
             .WithName("GetStatus")
@@ -129,14 +150,41 @@ namespace IntelliTrader.Web
             .Produces(StatusCodes.Status401Unauthorized);
 
             // POST /api/trading-pairs - Get all trading pairs with their details
+            // Viewer role sees a reduced payload (no Cost, CurrentCost, BoughtPrice) to limit financial data exposure.
             apiGroup.MapPost("/trading-pairs", (
+                HttpContext httpContext,
                 ITradingService tradingService,
                 ISignalsService signalsService,
                 ICoreService coreService) =>
             {
+                bool isViewer = httpContext.User.IsInRole(UserRoles.Viewer);
+
                 var tradingPairs = from tradingPair in tradingService.Account.GetTradingPairs()
                                    let pairConfig = tradingService.GetPairConfig(tradingPair.Pair)
-                                   select new
+                                   select isViewer
+                                   ? (object)new
+                                   {
+                                       Name = tradingPair.Pair,
+                                       DCA = tradingPair.DCALevel,
+                                       TradingViewName = $"{tradingService.Config.Exchange.ToUpperInvariant()}:{tradingPair.Pair}",
+                                       Margin = tradingPair.CurrentMargin.ToString("0.00"),
+                                       Target = pairConfig.SellMargin.ToString("0.00"),
+                                       CurrentPrice = tradingPair.CurrentPrice.ToString("0.00000000"),
+                                       Amount = tradingPair.TotalAmount.ToString("0.########"),
+                                       OrderDates = tradingPair.OrderDates.Select(d => d.ToOffset(System.TimeSpan.FromHours(coreService.Config.TimezoneOffset)).ToString("yyyy-MM-dd HH:mm:ss")),
+                                       OrderIds = tradingPair.OrderIds,
+                                       Age = tradingPair.CurrentAge.ToString("0.00"),
+                                       CurrentRating = tradingPair.Metadata.CurrentRating?.ToString("0.000") ?? "N/A",
+                                       BoughtRating = tradingPair.Metadata.BoughtRating?.ToString("0.000") ?? "N/A",
+                                       SignalRule = tradingPair.Metadata.SignalRule ?? "N/A",
+                                       SwapPair = tradingPair.Metadata.SwapPair,
+                                       TradingRules = pairConfig.Rules,
+                                       IsTrailingSell = tradingService.GetTrailingSells().Contains(tradingPair.Pair),
+                                       IsTrailingBuy = tradingService.GetTrailingBuys().Contains(tradingPair.Pair),
+                                       LastBuyMargin = tradingPair.Metadata.LastBuyMargin?.ToString("0.00") ?? "N/A",
+                                       Config = pairConfig
+                                   }
+                                   : (object)new
                                    {
                                        Name = tradingPair.Pair,
                                        DCA = tradingPair.DCALevel,


### PR DESCRIPTION
## Summary
- **ConfigProvider temp file cleanup**: decrypted config temp files are now tracked and deleted on `Dispose()` and `ProcessExit`. File names use `Path.GetRandomFileName()` to prevent predictable paths.
- **Audit trail for /SaveConfig**: `AuditMiddleware.BuildAuditDetailsAsync` now captures the config section name for `/SaveConfig` requests without logging the full `definition` field (which may contain secrets).
- **Settings page redaction**: before sending config JSON to the browser, property values whose keys contain "password", "token", "secret", "key", "apikey", or "privatekey" are replaced with `********`.
- **Role-based API field filtering**: `/api/status` omits `Balance` and `LogEntries` for Viewer role; `/api/trading-pairs` omits `Cost`, `CurrentCost`, and `BoughtPrice` for Viewer role.

Closes #112

## Test plan
- [ ] Verify encrypted config files produce random temp file names and are cleaned up on shutdown
- [ ] Confirm `/SaveConfig` audit log entries show `config=<section>` without the full definition
- [ ] Check Settings page JSON in browser does not expose sensitive key values
- [ ] Log in as Viewer role and verify `/api/status` response lacks `Balance` and `LogEntries`
- [ ] Log in as Viewer role and verify `/api/trading-pairs` response lacks `Cost`, `CurrentCost`, `BoughtPrice`
- [ ] Verify build passes with zero new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)