### PR TITLE
feat(cqrs): harden active order refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ Thumbs.db
 # Claude Code
 .claude/
 
+# Local agent tooling
+.agents/
+.dev-prompts/
+.claude-flow/
+AGENTS.md
+.gitmodules
+
 # Secrets/keys
 *.bin
 keys.bin

--- a/IntelliTrader.Application/Ports/Driven/IOrderRepository.cs
+++ b/IntelliTrader.Application/Ports/Driven/IOrderRepository.cs
@@ -1,0 +1,27 @@
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Repository port for persisted exchange order lifecycles.
+/// This keeps command-side order execution and query-side order inspection
+/// within the new Application/Domain stack.
+/// </summary>
+public interface IOrderRepository
+{
+    /// <summary>
+    /// Gets an order by its exchange-assigned identifier.
+    /// </summary>
+    Task<OrderLifecycle?> GetByIdAsync(OrderId id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all persisted orders.
+    /// </summary>
+    Task<IReadOnlyList<OrderLifecycle>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves an order lifecycle.
+    /// </summary>
+    Task SaveAsync(OrderLifecycle order, CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Application/Trading/Commands/RefreshOrderStatusCommand.cs
+++ b/IntelliTrader.Application/Trading/Commands/RefreshOrderStatusCommand.cs
@@ -1,0 +1,24 @@
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading.Commands;
+
+/// <summary>
+/// Command to refresh a persisted order lifecycle from the exchange.
+/// </summary>
+public sealed record RefreshOrderStatusCommand
+{
+    public required OrderId OrderId { get; init; }
+}
+
+/// <summary>
+/// Result of reconciling an existing order with the exchange.
+/// </summary>
+public sealed record RefreshOrderStatusResult
+{
+    public required OrderId OrderId { get; init; }
+    public required OrderLifecycleStatus PreviousStatus { get; init; }
+    public required OrderLifecycleStatus CurrentStatus { get; init; }
+    public required bool AppliedDomainEffects { get; init; }
+    public PositionId? PositionId { get; init; }
+}

--- a/IntelliTrader.Application/Trading/Commands/RefreshSubmittedOrdersCommand.cs
+++ b/IntelliTrader.Application/Trading/Commands/RefreshSubmittedOrdersCommand.cs
@@ -1,7 +1,28 @@
 namespace IntelliTrader.Application.Trading.Commands;
 
 /// <summary>
-/// Command to refresh a batch of submitted orders from the exchange.
+/// Command to refresh a batch of active, non-terminal orders from the exchange.
+/// </summary>
+public sealed record RefreshActiveOrdersCommand
+{
+    public int Limit { get; init; } = 50;
+}
+
+/// <summary>
+/// Aggregated result of refreshing active, non-terminal orders in batch.
+/// </summary>
+public sealed record RefreshActiveOrdersResult
+{
+    public required int TotalActive { get; init; }
+    public required int AttemptedCount { get; init; }
+    public required int RefreshedCount { get; init; }
+    public required int AppliedDomainEffectsCount { get; init; }
+    public required int FailedCount { get; init; }
+}
+
+/// <summary>
+/// Legacy command to refresh a batch of submitted orders from the exchange.
+/// Prefer <see cref="RefreshActiveOrdersCommand"/> because partially filled orders are refreshable too.
 /// </summary>
 public sealed record RefreshSubmittedOrdersCommand
 {
@@ -9,7 +30,8 @@ public sealed record RefreshSubmittedOrdersCommand
 }
 
 /// <summary>
-/// Aggregated result of refreshing submitted orders in batch.
+/// Legacy aggregated result of refreshing submitted orders in batch.
+/// Prefer <see cref="RefreshActiveOrdersResult"/>.
 /// </summary>
 public sealed record RefreshSubmittedOrdersResult
 {

--- a/IntelliTrader.Application/Trading/Commands/RefreshSubmittedOrdersCommand.cs
+++ b/IntelliTrader.Application/Trading/Commands/RefreshSubmittedOrdersCommand.cs
@@ -1,0 +1,21 @@
+namespace IntelliTrader.Application.Trading.Commands;
+
+/// <summary>
+/// Command to refresh a batch of submitted orders from the exchange.
+/// </summary>
+public sealed record RefreshSubmittedOrdersCommand
+{
+    public int Limit { get; init; } = 50;
+}
+
+/// <summary>
+/// Aggregated result of refreshing submitted orders in batch.
+/// </summary>
+public sealed record RefreshSubmittedOrdersResult
+{
+    public required int TotalSubmitted { get; init; }
+    public required int AttemptedCount { get; init; }
+    public required int RefreshedCount { get; init; }
+    public required int AppliedDomainEffectsCount { get; init; }
+    public required int FailedCount { get; init; }
+}

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -2,6 +2,7 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 
@@ -14,23 +15,26 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
 {
     private readonly IPortfolioRepository _portfolioRepository;
     private readonly IPositionRepository _positionRepository;
+    private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ITransactionalUnitOfWork _unitOfWork;
 
     public ClosePositionHandler(
         IPortfolioRepository portfolioRepository,
         IPositionRepository positionRepository,
+        IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
         TradingConstraintValidator constraintValidator,
-        IUnitOfWork unitOfWork,
+        ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
     {
         _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
         _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
@@ -123,21 +127,25 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             orderResult = marketOrderResult.Value;
         }
 
+        var orderLifecycle = ExchangeOrderLifecycleFactory.Create(
+            orderResult,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id);
+
         // 7. Check if order was filled
-        if (!orderResult.IsFullyFilled && !orderResult.IsPartiallyFilled)
+        if (!orderLifecycle.CanAffectPosition)
         {
-            return Result<ClosePositionResult>.Failure(
-                Error.ExchangeError($"Sell order was not filled. Status: {orderResult.Status}"));
+            return await PersistPendingOrderFailureAsync(orderLifecycle, orderResult.Status, cancellationToken);
         }
 
         // 8. Calculate proceeds and fees
-        var proceeds = orderResult.Cost; // For sell orders, cost represents the proceeds
-        var sellFees = orderResult.Fees;
+        var proceeds = orderLifecycle.Cost; // For sell orders, cost represents the proceeds
+        var sellFees = orderLifecycle.Fees;
 
         // 9. Close the position
         position.Close(
-            OrderId.From(orderResult.OrderId),
-            orderResult.AveragePrice,
+            orderLifecycle.Id,
+            orderLifecycle.AveragePrice,
             sellFees);
 
         // 10. Update portfolio - record position closed with proceeds
@@ -145,10 +153,13 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             position.Id,
             position.Pair,
             proceeds);
+        orderLifecycle.MarkCurrentFillApplied();
 
         // 11. Save changes
         try
         {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
 
@@ -166,7 +177,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         // 12. Dispatch domain events
-        await DispatchDomainEventsAsync(position, portfolio, cancellationToken);
+        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
 
         // 13. Calculate realized PnL
         var totalCost = position.TotalCost + position.TotalFees + sellFees;
@@ -183,9 +194,9 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         {
             PositionId = position.Id,
             Pair = position.Pair,
-            SellOrderId = OrderId.From(orderResult.OrderId),
-            SellPrice = orderResult.AveragePrice,
-            Quantity = orderResult.FilledQuantity,
+            SellOrderId = orderLifecycle.Id,
+            SellPrice = orderLifecycle.AveragePrice,
+            Quantity = orderLifecycle.FilledQuantity,
             Proceeds = proceeds,
             Fees = sellFees,
             TotalCost = totalCost,
@@ -209,18 +220,65 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         };
     }
 
+    private async Task<Result<ClosePositionResult>> PersistPendingOrderFailureAsync(
+        OrderLifecycle orderLifecycle,
+        OrderStatus exchangeStatus,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<ClosePositionResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<ClosePositionResult>.Failure(
+                Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
+        }
+
+        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+
+        return Result<ClosePositionResult>.Failure(
+            Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
+    }
+
+    private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
+    {
+        await _unitOfWork.BeginTransactionAsync(cancellationToken);
+    }
+
+    private async Task DispatchOrderEventsAsync(
+        OrderLifecycle orderLifecycle,
+        CancellationToken cancellationToken)
+    {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
+        orderLifecycle.ClearDomainEvents();
+
+        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+    }
+
     private async Task DispatchDomainEventsAsync(
+        OrderLifecycle orderLifecycle,
         Position position,
         Portfolio portfolio,
         CancellationToken cancellationToken)
     {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
         var positionEvents = position.DomainEvents.ToList();
         var portfolioEvents = portfolio.DomainEvents.ToList();
 
+        orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
 
-        var allEvents = positionEvents.Concat(portfolioEvents);
+        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
         await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -132,8 +132,8 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             intent: OrderIntent.ClosePosition,
             relatedPositionId: position.Id);
 
-        // 7. Check if order was filled
-        if (!orderLifecycle.CanAffectPosition)
+        // 7. Check if order was fully filled
+        if (orderLifecycle.Status != OrderLifecycleStatus.Filled)
         {
             return await PersistPendingOrderFailureAsync(orderLifecycle, orderResult.Status, cancellationToken);
         }

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -135,6 +135,16 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         // 7. Check if order was fully filled
         if (orderLifecycle.Status != OrderLifecycleStatus.Filled)
         {
+            if (orderLifecycle.HasUnappliedFill)
+            {
+                return await PersistPartialCloseOrderFailureAsync(
+                    position,
+                    portfolio,
+                    orderLifecycle,
+                    orderResult.Status,
+                    cancellationToken);
+            }
+
             return await PersistPendingOrderFailureAsync(orderLifecycle, orderResult.Status, cancellationToken);
         }
 
@@ -244,6 +254,60 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+
+        return Result<ClosePositionResult>.Failure(
+            Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
+    }
+
+    private async Task<Result<ClosePositionResult>> PersistPartialCloseOrderFailureAsync(
+        Position position,
+        Portfolio portfolio,
+        OrderLifecycle orderLifecycle,
+        OrderStatus exchangeStatus,
+        CancellationToken cancellationToken)
+    {
+        var closeDelta = position.ApplyCloseFillDelta(
+            orderLifecycle.Id,
+            orderLifecycle.AveragePrice,
+            orderLifecycle.UnappliedQuantity,
+            orderLifecycle.UnappliedFees);
+
+        if (closeDelta.PositionClosed)
+        {
+            portfolio.RecordPositionClosed(position.Id, position.Pair, closeDelta.Proceeds);
+        }
+        else
+        {
+            portfolio.RecordPositionCostReduced(
+                position.Id,
+                position.Pair,
+                closeDelta.ReleasedCost,
+                closeDelta.Proceeds);
+        }
+
+        orderLifecycle.MarkCurrentFillApplied();
+
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+            await _positionRepository.SaveAsync(position, cancellationToken);
+            await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<ClosePositionResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<ClosePositionResult>.Failure(
+                Error.ExchangeError($"Failed to save partial close effects: {ex.Message}"));
+        }
+
+        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
 
         return Result<ClosePositionResult>.Failure(
             Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));

--- a/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
@@ -1,0 +1,163 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using ExchangeOrderSide = IntelliTrader.Application.Ports.Driven.OrderSide;
+using ExchangeOrderStatus = IntelliTrader.Application.Ports.Driven.OrderStatus;
+using ExchangeOrderType = IntelliTrader.Application.Ports.Driven.OrderType;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Builds a domain order lifecycle from the exchange-facing result model.
+/// This keeps transport status translation out of individual command handlers.
+/// </summary>
+internal static class ExchangeOrderLifecycleFactory
+{
+    public static OrderLifecycle Create(
+        ExchangeOrderResult orderResult,
+        string? signalRule = null,
+        OrderIntent intent = OrderIntent.Unknown,
+        PositionId? relatedPositionId = null)
+    {
+        ArgumentNullException.ThrowIfNull(orderResult);
+
+        var lifecycle = OrderLifecycle.Submit(
+            OrderId.From(orderResult.OrderId),
+            orderResult.Pair,
+            MapSide(orderResult.Side),
+            MapType(orderResult.Type),
+            orderResult.RequestedQuantity,
+            orderResult.Price,
+            signalRule: signalRule,
+            timestamp: orderResult.Timestamp,
+            intent: intent,
+            relatedPositionId: relatedPositionId);
+
+        switch (MapStatus(orderResult.Status))
+        {
+            case OrderLifecycleStatus.Submitted:
+                break;
+
+            case OrderLifecycleStatus.PartiallyFilled:
+                lifecycle.MarkPartiallyFilled(
+                    orderResult.FilledQuantity,
+                    orderResult.AveragePrice,
+                    orderResult.Cost,
+                    orderResult.Fees);
+                break;
+
+            case OrderLifecycleStatus.Filled:
+                lifecycle.MarkFilled(
+                    orderResult.FilledQuantity,
+                    orderResult.AveragePrice,
+                    orderResult.Cost,
+                    orderResult.Fees);
+                break;
+
+            case OrderLifecycleStatus.Canceled:
+                lifecycle.Cancel();
+                break;
+
+            case OrderLifecycleStatus.Rejected:
+                lifecycle.Reject();
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(orderResult.Status), orderResult.Status, "Unsupported order status.");
+        }
+
+        return lifecycle;
+    }
+
+    public static bool Refresh(OrderLifecycle lifecycle, ExchangeOrderInfo orderInfo)
+    {
+        ArgumentNullException.ThrowIfNull(lifecycle);
+        ArgumentNullException.ThrowIfNull(orderInfo);
+
+        var targetStatus = MapStatus(orderInfo.Status);
+        if (targetStatus == lifecycle.Status)
+        {
+            return false;
+        }
+
+        switch (targetStatus)
+        {
+            case OrderLifecycleStatus.Submitted:
+                return false;
+
+            case OrderLifecycleStatus.PartiallyFilled:
+                lifecycle.MarkPartiallyFilled(
+                    orderInfo.FilledQuantity,
+                    orderInfo.AveragePrice,
+                    CalculateCost(orderInfo),
+                    orderInfo.Fees);
+                return true;
+
+            case OrderLifecycleStatus.Filled:
+                lifecycle.MarkFilled(
+                    orderInfo.FilledQuantity,
+                    orderInfo.AveragePrice,
+                    CalculateCost(orderInfo),
+                    orderInfo.Fees);
+                return true;
+
+            case OrderLifecycleStatus.Canceled:
+                lifecycle.Cancel();
+                return true;
+
+            case OrderLifecycleStatus.Rejected:
+                lifecycle.Reject();
+                return true;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(orderInfo.Status), orderInfo.Status, "Unsupported order status.");
+        }
+    }
+
+    private static Domain.Events.OrderSide MapSide(ExchangeOrderSide side)
+    {
+        return side switch
+        {
+            ExchangeOrderSide.Buy => Domain.Events.OrderSide.Buy,
+            ExchangeOrderSide.Sell => Domain.Events.OrderSide.Sell,
+            _ => throw new ArgumentOutOfRangeException(nameof(side), side, "Unsupported order side.")
+        };
+    }
+
+    private static Domain.Events.OrderType MapType(ExchangeOrderType type)
+    {
+        return type switch
+        {
+            ExchangeOrderType.Market => Domain.Events.OrderType.Market,
+            ExchangeOrderType.Limit => Domain.Events.OrderType.Limit,
+            ExchangeOrderType.StopLoss => Domain.Events.OrderType.StopLoss,
+            ExchangeOrderType.StopLossLimit => Domain.Events.OrderType.StopLoss,
+            ExchangeOrderType.TakeProfit => Domain.Events.OrderType.TakeProfit,
+            ExchangeOrderType.TakeProfitLimit => Domain.Events.OrderType.TakeProfit,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported order type.")
+        };
+    }
+
+    private static OrderLifecycleStatus MapStatus(ExchangeOrderStatus status)
+    {
+        return status switch
+        {
+            ExchangeOrderStatus.New => OrderLifecycleStatus.Submitted,
+            ExchangeOrderStatus.PartiallyFilled => OrderLifecycleStatus.PartiallyFilled,
+            ExchangeOrderStatus.Filled => OrderLifecycleStatus.Filled,
+            ExchangeOrderStatus.Canceled => OrderLifecycleStatus.Canceled,
+            ExchangeOrderStatus.PendingCancel => OrderLifecycleStatus.Canceled,
+            ExchangeOrderStatus.Rejected => OrderLifecycleStatus.Rejected,
+            ExchangeOrderStatus.Expired => OrderLifecycleStatus.Rejected,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unsupported order status.")
+        };
+    }
+
+    private static Money CalculateCost(ExchangeOrderInfo orderInfo)
+    {
+        return Money.Create(
+            orderInfo.AveragePrice.Value * orderInfo.FilledQuantity.Value,
+            orderInfo.Pair.QuoteCurrency);
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
@@ -78,6 +78,16 @@ internal static class ExchangeOrderLifecycleFactory
         var targetStatus = MapStatus(orderInfo.Status);
         if (targetStatus == lifecycle.Status)
         {
+            if (targetStatus == OrderLifecycleStatus.PartiallyFilled && HasFillChanged(lifecycle, orderInfo))
+            {
+                lifecycle.MarkPartiallyFilled(
+                    orderInfo.FilledQuantity,
+                    orderInfo.AveragePrice,
+                    CalculateCost(orderInfo),
+                    orderInfo.Fees);
+                return true;
+            }
+
             return false;
         }
 
@@ -159,5 +169,13 @@ internal static class ExchangeOrderLifecycleFactory
         return Money.Create(
             orderInfo.AveragePrice.Value * orderInfo.FilledQuantity.Value,
             orderInfo.Pair.QuoteCurrency);
+    }
+
+    private static bool HasFillChanged(OrderLifecycle lifecycle, ExchangeOrderInfo orderInfo)
+    {
+        return lifecycle.FilledQuantity != orderInfo.FilledQuantity ||
+               lifecycle.AveragePrice != orderInfo.AveragePrice ||
+               lifecycle.Cost != CalculateCost(orderInfo) ||
+               lifecycle.Fees != orderInfo.Fees;
     }
 }

--- a/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
@@ -56,6 +56,12 @@ internal static class ExchangeOrderLifecycleFactory
                 break;
 
             case OrderLifecycleStatus.Canceled:
+                ApplyCanceledFillIfPresent(
+                    lifecycle,
+                    orderResult.FilledQuantity,
+                    orderResult.AveragePrice,
+                    orderResult.Cost,
+                    orderResult.Fees);
                 lifecycle.Cancel();
                 break;
 
@@ -113,6 +119,12 @@ internal static class ExchangeOrderLifecycleFactory
                 return true;
 
             case OrderLifecycleStatus.Canceled:
+                ApplyCanceledFillIfPresent(
+                    lifecycle,
+                    orderInfo.FilledQuantity,
+                    orderInfo.AveragePrice,
+                    CalculateCost(orderInfo),
+                    orderInfo.Fees);
                 lifecycle.Cancel();
                 return true;
 
@@ -169,6 +181,21 @@ internal static class ExchangeOrderLifecycleFactory
         return Money.Create(
             orderInfo.AveragePrice.Value * orderInfo.FilledQuantity.Value,
             orderInfo.Pair.QuoteCurrency);
+    }
+
+    private static void ApplyCanceledFillIfPresent(
+        OrderLifecycle lifecycle,
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees)
+    {
+        if (filledQuantity.IsZero)
+        {
+            return;
+        }
+
+        lifecycle.MarkPartiallyFilled(filledQuantity, averagePrice, cost, fees);
     }
 
     private static bool HasFillChanged(OrderLifecycle lifecycle, ExchangeOrderInfo orderInfo)

--- a/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
@@ -2,6 +2,7 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 
@@ -14,23 +15,26 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
 {
     private readonly IPortfolioRepository _portfolioRepository;
     private readonly IPositionRepository _positionRepository;
+    private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ITransactionalUnitOfWork _unitOfWork;
 
     public ExecuteDCAHandler(
         IPortfolioRepository portfolioRepository,
         IPositionRepository positionRepository,
+        IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
         TradingConstraintValidator constraintValidator,
-        IUnitOfWork unitOfWork,
+        ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
     {
         _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
         _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
@@ -146,29 +150,36 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
             orderResult = marketOrderResult.Value;
         }
 
+        var orderLifecycle = ExchangeOrderLifecycleFactory.Create(
+            orderResult,
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: position.Id);
+
         // 9. Check if order was filled
-        if (!orderResult.IsFullyFilled && !orderResult.IsPartiallyFilled)
+        if (!orderLifecycle.CanAffectPosition)
         {
-            return Result<ExecuteDCAResult>.Failure(
-                Error.ExchangeError($"DCA order was not filled. Status: {orderResult.Status}"));
+            return await PersistPendingOrderFailureAsync(orderLifecycle, orderResult.Status, cancellationToken);
         }
 
         // 10. Add DCA entry to position
         position.AddDCAEntry(
-            OrderId.From(orderResult.OrderId),
-            orderResult.AveragePrice,
-            orderResult.FilledQuantity,
-            orderResult.Fees);
+            orderLifecycle.Id,
+            orderLifecycle.AveragePrice,
+            orderLifecycle.FilledQuantity,
+            orderLifecycle.Fees);
 
         // 11. Update portfolio - record the additional cost
         portfolio.RecordPositionCostIncreased(
             position.Id,
             position.Pair,
-            orderResult.Cost);
+            orderLifecycle.Cost);
+        orderLifecycle.MarkCurrentFillApplied();
 
         // 12. Save changes
         try
         {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
 
@@ -186,7 +197,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         }
 
         // 13. Dispatch domain events
-        await DispatchDomainEventsAsync(position, portfolio, cancellationToken);
+        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
 
         // 14. Send notification
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -196,11 +207,11 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         {
             PositionId = position.Id,
             Pair = position.Pair,
-            OrderId = OrderId.From(orderResult.OrderId),
-            EntryPrice = orderResult.AveragePrice,
-            Quantity = orderResult.FilledQuantity,
-            Cost = orderResult.Cost,
-            Fees = orderResult.Fees,
+            OrderId = orderLifecycle.Id,
+            EntryPrice = orderLifecycle.AveragePrice,
+            Quantity = orderLifecycle.FilledQuantity,
+            Cost = orderLifecycle.Cost,
+            Fees = orderLifecycle.Fees,
             NewDCALevel = position.DCALevel,
             NewAveragePrice = position.AveragePrice,
             NewTotalQuantity = position.TotalQuantity,
@@ -231,18 +242,65 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         return Quantity.Create(rawQuantity);
     }
 
+    private async Task<Result<ExecuteDCAResult>> PersistPendingOrderFailureAsync(
+        OrderLifecycle orderLifecycle,
+        OrderStatus exchangeStatus,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<ExecuteDCAResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<ExecuteDCAResult>.Failure(
+                Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
+        }
+
+        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+
+        return Result<ExecuteDCAResult>.Failure(
+            Error.ExchangeError($"DCA order was not filled. Status: {exchangeStatus}"));
+    }
+
+    private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
+    {
+        await _unitOfWork.BeginTransactionAsync(cancellationToken);
+    }
+
+    private async Task DispatchOrderEventsAsync(
+        OrderLifecycle orderLifecycle,
+        CancellationToken cancellationToken)
+    {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
+        orderLifecycle.ClearDomainEvents();
+
+        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+    }
+
     private async Task DispatchDomainEventsAsync(
+        OrderLifecycle orderLifecycle,
         Position position,
         Portfolio portfolio,
         CancellationToken cancellationToken)
     {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
         var positionEvents = position.DomainEvents.ToList();
         var portfolioEvents = portfolio.DomainEvents.ToList();
 
+        orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
 
-        var allEvents = positionEvents.Concat(portfolioEvents);
+        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
         await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 

--- a/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
@@ -2,6 +2,7 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 
@@ -14,23 +15,26 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
 {
     private readonly IPortfolioRepository _portfolioRepository;
     private readonly IPositionRepository _positionRepository;
+    private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly ITransactionalUnitOfWork _unitOfWork;
 
     public OpenPositionHandler(
         IPortfolioRepository portfolioRepository,
         IPositionRepository positionRepository,
+        IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
         TradingConstraintValidator constraintValidator,
-        IUnitOfWork unitOfWork,
+        ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
     {
         _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
         _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
@@ -130,31 +134,38 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             orderResult = marketOrderResult.Value;
         }
 
-        // 7. Check if order was filled
-        if (!orderResult.IsFullyFilled && !orderResult.IsPartiallyFilled)
+        var orderLifecycle = ExchangeOrderLifecycleFactory.Create(
+            orderResult,
+            command.SignalRule,
+            OrderIntent.OpenPosition);
+
+        // 7. Check if order was filled enough to open a position
+        if (!orderLifecycle.CanAffectPosition)
         {
-            return Result<OpenPositionResult>.Failure(
-                Error.ExchangeError($"Order was not filled. Status: {orderResult.Status}"));
+            return await PersistPendingOrderFailureAsync(orderLifecycle, orderResult.Status, cancellationToken);
         }
 
         // 8. Create the Position aggregate
         var position = Position.Open(
             command.Pair,
-            OrderId.From(orderResult.OrderId),
-            orderResult.AveragePrice,
-            orderResult.FilledQuantity,
-            orderResult.Fees,
+            orderLifecycle.Id,
+            orderLifecycle.AveragePrice,
+            orderLifecycle.FilledQuantity,
+            orderLifecycle.Fees,
             command.SignalRule);
 
         // 9. Update the Portfolio aggregate
         portfolio.RecordPositionOpened(
             position.Id,
             command.Pair,
-            orderResult.Cost);
+            orderLifecycle.Cost);
+        orderLifecycle.MarkCurrentFillApplied();
 
         // 10. Save changes
         try
         {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
 
@@ -172,7 +183,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         }
 
         // 11. Dispatch domain events
-        await DispatchDomainEventsAsync(position, portfolio, cancellationToken);
+        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
 
         // 12. Send notification (non-blocking)
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -182,11 +193,11 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         {
             PositionId = position.Id,
             Pair = command.Pair,
-            OrderId = OrderId.From(orderResult.OrderId),
-            EntryPrice = orderResult.AveragePrice,
-            Quantity = orderResult.FilledQuantity,
-            Cost = orderResult.Cost,
-            Fees = orderResult.Fees,
+            OrderId = orderLifecycle.Id,
+            EntryPrice = orderLifecycle.AveragePrice,
+            Quantity = orderLifecycle.FilledQuantity,
+            Cost = orderLifecycle.Cost,
+            Fees = orderLifecycle.Fees,
             OpenedAt = position.OpenedAt
         });
     }
@@ -224,18 +235,65 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         return Quantity.Create(rawQuantity);
     }
 
+    private async Task<Result<OpenPositionResult>> PersistPendingOrderFailureAsync(
+        OrderLifecycle orderLifecycle,
+        OrderStatus exchangeStatus,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<OpenPositionResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<OpenPositionResult>.Failure(
+                Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
+        }
+
+        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+
+        return Result<OpenPositionResult>.Failure(
+            Error.ExchangeError($"Order was not filled. Status: {exchangeStatus}"));
+    }
+
+    private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
+    {
+        await _unitOfWork.BeginTransactionAsync(cancellationToken);
+    }
+
+    private async Task DispatchOrderEventsAsync(
+        OrderLifecycle orderLifecycle,
+        CancellationToken cancellationToken)
+    {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
+        orderLifecycle.ClearDomainEvents();
+
+        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+    }
+
     private async Task DispatchDomainEventsAsync(
+        OrderLifecycle orderLifecycle,
         Position position,
         Portfolio portfolio,
         CancellationToken cancellationToken)
     {
+        var orderEvents = orderLifecycle.DomainEvents.ToList();
         var positionEvents = position.DomainEvents.ToList();
         var portfolioEvents = portfolio.DomainEvents.ToList();
 
+        orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
 
-        var allEvents = positionEvents.Concat(portfolioEvents);
+        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
         await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 

--- a/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
@@ -159,6 +159,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             position.Id,
             command.Pair,
             orderLifecycle.Cost);
+        orderLifecycle.LinkRelatedPosition(position.Id);
         orderLifecycle.MarkCurrentFillApplied();
 
         // 10. Save changes

--- a/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
@@ -1,0 +1,92 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Orders;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Query handler for a single persisted order lifecycle.
+/// </summary>
+public sealed class GetOrderHandler : IQueryHandler<GetOrderQuery, OrderView>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetOrderHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<Result<OrderView>> HandleAsync(
+        GetOrderQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var order = await _orderRepository.GetByIdAsync(query.OrderId, cancellationToken);
+        if (order is null)
+        {
+            return Result<OrderView>.Failure(Error.NotFound("Order", query.OrderId.Value));
+        }
+
+        return Result<OrderView>.Success(Map(order));
+    }
+
+    internal static OrderView Map(OrderLifecycle order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+
+        return new OrderView
+        {
+            Id = order.Id,
+            Pair = order.Pair,
+            Side = order.Side,
+            Type = order.Type,
+            Status = order.Status,
+            RequestedQuantity = order.RequestedQuantity,
+            FilledQuantity = order.FilledQuantity,
+            SubmittedPrice = order.SubmittedPrice,
+            AveragePrice = order.AveragePrice,
+            Cost = order.Cost,
+            Fees = order.Fees,
+            SignalRule = order.SignalRule,
+            SubmittedAt = order.SubmittedAt,
+            CanAffectPosition = order.CanAffectPosition,
+            IsTerminal = order.IsTerminal
+        };
+    }
+}
+
+/// <summary>
+/// Query handler for recent persisted orders.
+/// </summary>
+public sealed class GetRecentOrdersHandler : IQueryHandler<GetRecentOrdersQuery, IReadOnlyList<OrderView>>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetRecentOrdersHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<Result<IReadOnlyList<OrderView>>> HandleAsync(
+        GetRecentOrdersQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = query.Limit <= 0 ? 50 : query.Limit;
+        var orders = await _orderRepository.GetAllAsync(cancellationToken);
+
+        var filtered = orders
+            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
+            .Where(order => query.Status is null || order.Status == query.Status)
+            .Where(order => query.Side is null || order.Side == query.Side)
+            .OrderByDescending(order => order.SubmittedAt)
+            .Take(limit)
+            .Select(GetOrderHandler.Map)
+            .ToList();
+
+        return Result<IReadOnlyList<OrderView>>.Success(filtered);
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
@@ -90,3 +90,37 @@ public sealed class GetRecentOrdersHandler : IQueryHandler<GetRecentOrdersQuery,
         return Result<IReadOnlyList<OrderView>>.Success(filtered);
     }
 }
+
+/// <summary>
+/// Query handler for active, non-terminal persisted orders.
+/// </summary>
+public sealed class GetActiveOrdersHandler : IQueryHandler<GetActiveOrdersQuery, IReadOnlyList<OrderView>>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetActiveOrdersHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<Result<IReadOnlyList<OrderView>>> HandleAsync(
+        GetActiveOrdersQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = query.Limit <= 0 ? 50 : query.Limit;
+        var orders = await _orderRepository.GetAllAsync(cancellationToken);
+
+        var filtered = orders
+            .Where(order => !order.IsTerminal)
+            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
+            .Where(order => query.Side is null || order.Side == query.Side)
+            .OrderByDescending(order => order.SubmittedAt)
+            .Take(limit)
+            .Select(GetOrderHandler.Map)
+            .ToList();
+
+        return Result<IReadOnlyList<OrderView>>.Success(filtered);
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
@@ -124,3 +124,73 @@ public sealed class GetActiveOrdersHandler : IQueryHandler<GetActiveOrdersQuery,
         return Result<IReadOnlyList<OrderView>>.Success(filtered);
     }
 }
+
+/// <summary>
+/// Query handler for trade history projected from persisted filled order lifecycles.
+/// </summary>
+public sealed class GetTradingHistoryHandler : IQueryHandler<GetTradingHistoryQuery, IReadOnlyList<TradeHistoryEntry>>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetTradingHistoryHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<Result<IReadOnlyList<TradeHistoryEntry>>> HandleAsync(
+        GetTradingHistoryQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.From > query.To)
+        {
+            return Result<IReadOnlyList<TradeHistoryEntry>>.Failure(
+                Error.Validation("Trading history query range is invalid."));
+        }
+
+        var limit = query.Limit <= 0 ? 100 : query.Limit;
+        var offset = Math.Max(0, query.Offset);
+        var orders = await _orderRepository.GetAllAsync(cancellationToken);
+
+        var history = orders
+            .Where(order => order.Status == OrderLifecycleStatus.Filled)
+            .Where(order => order.RelatedPositionId is not null)
+            .Where(order => order.SubmittedAt >= query.From && order.SubmittedAt <= query.To)
+            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
+            .OrderByDescending(order => order.SubmittedAt)
+            .Skip(offset)
+            .Take(limit)
+            .Select(MapTradeHistoryEntry)
+            .ToList();
+
+        return Result<IReadOnlyList<TradeHistoryEntry>>.Success(history);
+    }
+
+    private static TradeHistoryEntry MapTradeHistoryEntry(OrderLifecycle order)
+    {
+        return new TradeHistoryEntry
+        {
+            PositionId = order.RelatedPositionId!,
+            Pair = order.Pair,
+            Type = ResolveTradeType(order),
+            Price = order.AveragePrice,
+            Quantity = order.FilledQuantity,
+            Cost = order.Cost,
+            Fees = order.Fees,
+            Timestamp = order.SubmittedAt,
+            OrderId = order.Id.Value,
+            Note = order.Intent.ToString()
+        };
+    }
+
+    private static TradeType ResolveTradeType(OrderLifecycle order)
+    {
+        if (order.Side == IntelliTrader.Domain.Events.OrderSide.Sell)
+        {
+            return TradeType.Sell;
+        }
+
+        return order.Intent == OrderIntent.ExecuteDca ? TradeType.DCA : TradeType.Buy;
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/PortfolioQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/PortfolioQueryHandlers.cs
@@ -1,0 +1,238 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Query handler for portfolio read models.
+/// </summary>
+public sealed class GetPortfolioHandler : IQueryHandler<GetPortfolioQuery, PortfolioView>
+{
+    private readonly IPortfolioRepository _portfolioRepository;
+
+    public GetPortfolioHandler(IPortfolioRepository portfolioRepository)
+    {
+        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
+    }
+
+    public async Task<Result<PortfolioView>> HandleAsync(
+        GetPortfolioQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var portfolio = await ResolvePortfolioAsync(query, cancellationToken);
+        if (portfolio is null)
+        {
+            var id = query.PortfolioId?.ToString() ?? query.Name ?? "default";
+            return Result<PortfolioView>.Failure(Error.NotFound("Portfolio", id));
+        }
+
+        return Result<PortfolioView>.Success(Map(portfolio));
+    }
+
+    private Task<Portfolio?> ResolvePortfolioAsync(
+        GetPortfolioQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (query.PortfolioId is not null)
+        {
+            return _portfolioRepository.GetByIdAsync(query.PortfolioId, cancellationToken);
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.Name))
+        {
+            return _portfolioRepository.GetByNameAsync(query.Name, cancellationToken);
+        }
+
+        return _portfolioRepository.GetDefaultAsync(cancellationToken);
+    }
+
+    internal static PortfolioView Map(Portfolio portfolio)
+    {
+        ArgumentNullException.ThrowIfNull(portfolio);
+
+        return new PortfolioView
+        {
+            Id = portfolio.Id,
+            Name = portfolio.Name,
+            Market = portfolio.Market,
+            TotalBalance = portfolio.Balance.Total,
+            AvailableBalance = portfolio.Balance.Available,
+            ReservedBalance = portfolio.Balance.Reserved,
+            ActivePositionCount = portfolio.ActivePositionCount,
+            MaxPositions = portfolio.MaxPositions,
+            MinPositionCost = portfolio.MinPositionCost,
+            CanOpenNewPosition = portfolio.CanOpenNewPosition,
+            AvailablePercentage = portfolio.Balance.AvailablePercentage,
+            ReservedPercentage = portfolio.Balance.ReservedPercentage,
+            CreatedAt = portfolio.CreatedAt,
+            LastUpdatedAt = null
+        };
+    }
+}
+
+/// <summary>
+/// Query handler for current portfolio statistics.
+/// </summary>
+public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioStatisticsQuery, PortfolioStatistics>
+{
+    private readonly IPortfolioRepository _portfolioRepository;
+    private readonly IPositionRepository _positionRepository;
+    private readonly IExchangePort _exchangePort;
+
+    public GetPortfolioStatisticsHandler(
+        IPortfolioRepository portfolioRepository,
+        IPositionRepository positionRepository,
+        IExchangePort exchangePort)
+    {
+        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+    }
+
+    public async Task<Result<PortfolioStatistics>> HandleAsync(
+        GetPortfolioStatisticsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var from = query.From ?? DateTimeOffset.MinValue;
+        var to = query.To ?? DateTimeOffset.UtcNow;
+        if (from > to)
+        {
+            return Result<PortfolioStatistics>.Failure(
+                Error.Validation("Portfolio statistics query range is invalid."));
+        }
+
+        var portfolio = query.PortfolioId is not null
+            ? await _portfolioRepository.GetByIdAsync(query.PortfolioId, cancellationToken)
+            : await _portfolioRepository.GetDefaultAsync(cancellationToken);
+
+        if (portfolio is null)
+        {
+            var id = query.PortfolioId?.ToString() ?? "default";
+            return Result<PortfolioStatistics>.Failure(Error.NotFound("Portfolio", id));
+        }
+
+        var activePositions = await _positionRepository.GetAllActiveAsync(cancellationToken);
+        var closedPositions = await _positionRepository.GetClosedPositionsAsync(from, to, cancellationToken);
+        var activeSnapshots = new List<PositionSnapshot>(activePositions.Count);
+
+        foreach (var position in activePositions)
+        {
+            var priceResult = await _exchangePort.GetCurrentPriceAsync(position.Pair, cancellationToken);
+            if (priceResult.IsFailure)
+            {
+                return Result<PortfolioStatistics>.Failure(priceResult.Error);
+            }
+
+            activeSnapshots.Add(PositionSnapshot.Create(position, priceResult.Value));
+        }
+
+        var currency = portfolio.Market;
+        var totalUnrealizedPnL = SumMoney(activeSnapshots.Select(snapshot => snapshot.UnrealizedPnL), currency);
+        var totalCurrentValue = SumMoney(activeSnapshots.Select(snapshot => snapshot.CurrentValue), currency);
+        var totalCostBasis = activeSnapshots.Sum(snapshot => snapshot.CostBasis.Amount);
+        var overallMargin = totalCostBasis == 0m
+            ? Margin.Zero
+            : Margin.Calculate(totalCostBasis, totalCurrentValue.Amount);
+        var winningSnapshots = activeSnapshots.Where(snapshot => snapshot.Margin.IsProfit).ToList();
+        var losingSnapshots = activeSnapshots.Where(snapshot => snapshot.Margin.IsLoss).ToList();
+        var totalTrades = activePositions.Sum(position => position.Entries.Count) + closedPositions.Count;
+        var averageHoldingPeriod = CalculateAverageHoldingPeriod(activePositions, closedPositions);
+
+        return Result<PortfolioStatistics>.Success(new PortfolioStatistics
+        {
+            PortfolioId = portfolio.Id,
+            TotalBalance = portfolio.Balance.Total,
+            AvailableBalance = portfolio.Balance.Available,
+            InvestedBalance = portfolio.GetTotalInvestedCost(),
+            ActivePositions = portfolio.ActivePositionCount,
+            MaxPositions = portfolio.MaxPositions,
+            PositionSlotsAvailable = Math.Max(0, portfolio.MaxPositions - portfolio.ActivePositionCount),
+            TotalUnrealizedPnL = totalUnrealizedPnL,
+            TotalRealizedPnL = Money.Zero(currency),
+            OverallMargin = overallMargin,
+            TotalTradesCount = totalTrades,
+            WinningTradesCount = winningSnapshots.Count,
+            LosingTradesCount = losingSnapshots.Count,
+            WinRate = CalculateWinRate(winningSnapshots.Count, losingSnapshots.Count),
+            AverageWin = AverageMoney(winningSnapshots.Select(snapshot => snapshot.UnrealizedPnL), currency),
+            AverageLoss = AverageMoney(losingSnapshots.Select(snapshot => snapshot.UnrealizedPnL), currency),
+            ProfitFactor = CalculateProfitFactor(winningSnapshots, losingSnapshots),
+            MaxDrawdown = Money.Zero(currency),
+            MaxDrawdownPercent = 0m,
+            Sharpe = 0m,
+            StatisticsAsOf = DateTimeOffset.UtcNow,
+            AverageHoldingPeriod = averageHoldingPeriod
+        });
+    }
+
+    private static decimal CalculateWinRate(int wins, int losses)
+    {
+        var completed = wins + losses;
+        return completed == 0 ? 0m : (decimal)wins / completed * 100m;
+    }
+
+    private static decimal CalculateProfitFactor(
+        IReadOnlyCollection<PositionSnapshot> winningSnapshots,
+        IReadOnlyCollection<PositionSnapshot> losingSnapshots)
+    {
+        var wins = winningSnapshots.Sum(snapshot => snapshot.UnrealizedPnL.Amount);
+        var losses = Math.Abs(losingSnapshots.Sum(snapshot => snapshot.UnrealizedPnL.Amount));
+        return losses == 0m ? 0m : wins / losses;
+    }
+
+    private static TimeSpan CalculateAverageHoldingPeriod(
+        IReadOnlyCollection<Position> activePositions,
+        IReadOnlyCollection<Position> closedPositions)
+    {
+        var periods = activePositions
+            .Select(position => DateTimeOffset.UtcNow - position.OpenedAt)
+            .Concat(closedPositions.Select(position => (position.ClosedAt ?? DateTimeOffset.UtcNow) - position.OpenedAt))
+            .ToList();
+
+        if (periods.Count == 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        return TimeSpan.FromTicks((long)periods.Average(period => period.Ticks));
+    }
+
+    private static Money SumMoney(IEnumerable<Money> values, string currency)
+    {
+        return values.Aggregate(Money.Zero(currency), (sum, value) => sum + value);
+    }
+
+    private static Money AverageMoney(IEnumerable<Money> values, string currency)
+    {
+        var list = values.ToList();
+        if (list.Count == 0)
+        {
+            return Money.Zero(currency);
+        }
+
+        return Money.Create(list.Average(value => value.Amount), currency);
+    }
+
+    private sealed record PositionSnapshot(
+        Money CurrentValue,
+        Money UnrealizedPnL,
+        Money CostBasis,
+        Margin Margin)
+    {
+        public static PositionSnapshot Create(Position position, Price currentPrice)
+        {
+            return new PositionSnapshot(
+                position.CalculateCurrentValue(currentPrice),
+                position.CalculateUnrealizedPnL(currentPrice),
+                position.TotalCost + position.TotalFees,
+                position.CalculateMargin(currentPrice));
+        }
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/PositionQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/PositionQueryHandlers.cs
@@ -1,0 +1,218 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Query handler for a single trading position.
+/// </summary>
+public sealed class GetPositionHandler : IQueryHandler<GetPositionQuery, PositionView>
+{
+    private readonly IPositionRepository _positionRepository;
+    private readonly IExchangePort _exchangePort;
+
+    public GetPositionHandler(IPositionRepository positionRepository, IExchangePort exchangePort)
+    {
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+    }
+
+    public async Task<Result<PositionView>> HandleAsync(
+        GetPositionQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.PositionId is null && query.Pair is null)
+        {
+            return Result<PositionView>.Failure(
+                Error.Validation("PositionId or Pair is required."));
+        }
+
+        var position = query.PositionId is not null
+            ? await _positionRepository.GetByIdAsync(query.PositionId, cancellationToken)
+            : await _positionRepository.GetByPairAsync(query.Pair!, cancellationToken);
+
+        if (position is null)
+        {
+            var id = query.PositionId?.ToString() ?? query.Pair!.Symbol;
+            return Result<PositionView>.Failure(Error.NotFound("Position", id));
+        }
+
+        var priceResult = await ResolveCurrentPriceAsync(position, cancellationToken);
+        if (priceResult.IsFailure)
+        {
+            return Result<PositionView>.Failure(priceResult.Error);
+        }
+
+        return Result<PositionView>.Success(PositionQueryMapper.Map(position, priceResult.Value));
+    }
+
+    private async Task<Result<Price>> ResolveCurrentPriceAsync(
+        Position position,
+        CancellationToken cancellationToken)
+    {
+        if (position.IsClosed)
+        {
+            return Result<Price>.Success(position.AveragePrice);
+        }
+
+        return await _exchangePort.GetCurrentPriceAsync(position.Pair, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Query handler for active trading positions.
+/// </summary>
+public sealed class GetActivePositionsHandler : IQueryHandler<GetActivePositionsQuery, IReadOnlyList<PositionView>>
+{
+    private readonly IPositionRepository _positionRepository;
+    private readonly IExchangePort _exchangePort;
+
+    public GetActivePositionsHandler(IPositionRepository positionRepository, IExchangePort exchangePort)
+    {
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+    }
+
+    public async Task<Result<IReadOnlyList<PositionView>>> HandleAsync(
+        GetActivePositionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var positions = await _positionRepository.GetAllActiveAsync(cancellationToken);
+        var filteredPositions = positions
+            .Where(position => query.Market is null || position.Pair.IsInMarket(query.Market))
+            .ToList();
+
+        var views = new List<PositionView>(filteredPositions.Count);
+        foreach (var position in filteredPositions)
+        {
+            var priceResult = await _exchangePort.GetCurrentPriceAsync(position.Pair, cancellationToken);
+            if (priceResult.IsFailure)
+            {
+                return Result<IReadOnlyList<PositionView>>.Failure(priceResult.Error);
+            }
+
+            views.Add(PositionQueryMapper.Map(position, priceResult.Value));
+        }
+
+        views = Sort(views, query.SortBy, query.Descending).ToList();
+
+        if (query.MinMargin.HasValue)
+        {
+            views = views
+                .Where(position => position.CurrentMargin.Percentage >= query.MinMargin.Value)
+                .ToList();
+        }
+
+        if (query.MaxMargin.HasValue)
+        {
+            views = views
+                .Where(position => position.CurrentMargin.Percentage <= query.MaxMargin.Value)
+                .ToList();
+        }
+
+        return Result<IReadOnlyList<PositionView>>.Success(views);
+    }
+
+    private static IEnumerable<PositionView> Sort(
+        IEnumerable<PositionView> positions,
+        PositionSortOrder sortBy,
+        bool descending)
+    {
+        return (sortBy, descending) switch
+        {
+            (PositionSortOrder.Pair, true) => positions.OrderByDescending(position => position.Pair.Symbol),
+            (PositionSortOrder.Pair, false) => positions.OrderBy(position => position.Pair.Symbol),
+            (PositionSortOrder.Cost, true) => positions.OrderByDescending(position => position.TotalCost.Amount),
+            (PositionSortOrder.Cost, false) => positions.OrderBy(position => position.TotalCost.Amount),
+            (PositionSortOrder.Margin, true) => positions.OrderByDescending(position => position.CurrentMargin.Percentage),
+            (PositionSortOrder.Margin, false) => positions.OrderBy(position => position.CurrentMargin.Percentage),
+            (PositionSortOrder.DCALevel, true) => positions.OrderByDescending(position => position.DCALevel),
+            (PositionSortOrder.DCALevel, false) => positions.OrderBy(position => position.DCALevel),
+            (_, true) => positions.OrderByDescending(position => position.OpenedAt),
+            (_, false) => positions.OrderBy(position => position.OpenedAt)
+        };
+    }
+}
+
+/// <summary>
+/// Query handler for closed trading positions.
+/// </summary>
+public sealed class GetClosedPositionsHandler : IQueryHandler<GetClosedPositionsQuery, IReadOnlyList<PositionView>>
+{
+    private readonly IPositionRepository _positionRepository;
+
+    public GetClosedPositionsHandler(IPositionRepository positionRepository)
+    {
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+    }
+
+    public async Task<Result<IReadOnlyList<PositionView>>> HandleAsync(
+        GetClosedPositionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.From > query.To)
+        {
+            return Result<IReadOnlyList<PositionView>>.Failure(
+                Error.Validation("Closed positions query range is invalid."));
+        }
+
+        if (query.ProfitableOnly.HasValue)
+        {
+            return Result<IReadOnlyList<PositionView>>.Failure(
+                Error.Validation("ProfitableOnly requires a closed-position PnL projection."));
+        }
+
+        var limit = query.Limit <= 0 ? 100 : query.Limit;
+        var positions = await _positionRepository.GetClosedPositionsAsync(query.From, query.To, cancellationToken);
+
+        var views = positions
+            .Where(position => position.IsClosed)
+            .Where(position => query.Pair is null || position.Pair.Equals(query.Pair))
+            .OrderByDescending(position => position.ClosedAt ?? position.OpenedAt)
+            .Take(limit)
+            .Select(position => PositionQueryMapper.Map(position, position.AveragePrice))
+            .ToList();
+
+        return Result<IReadOnlyList<PositionView>>.Success(views);
+    }
+}
+
+internal static class PositionQueryMapper
+{
+    public static PositionView Map(Position position, Price currentPrice)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        ArgumentNullException.ThrowIfNull(currentPrice);
+
+        return new PositionView
+        {
+            Id = position.Id,
+            Pair = position.Pair,
+            AveragePrice = position.AveragePrice,
+            CurrentPrice = currentPrice,
+            TotalQuantity = position.TotalQuantity,
+            TotalCost = position.TotalCost,
+            TotalFees = position.TotalFees,
+            CurrentValue = position.CalculateCurrentValue(currentPrice),
+            UnrealizedPnL = position.CalculateUnrealizedPnL(currentPrice),
+            CurrentMargin = position.CalculateMargin(currentPrice),
+            DCALevel = position.DCALevel,
+            EntryCount = position.Entries.Count,
+            OpenedAt = position.OpenedAt,
+            HoldingPeriod = (position.ClosedAt ?? DateTimeOffset.UtcNow) - position.OpenedAt,
+            SignalRule = position.SignalRule,
+            IsClosed = position.IsClosed,
+            ClosedAt = position.ClosedAt,
+            RealizedPnL = null
+        };
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -192,7 +192,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         DateTimeOffset occurredAt,
         CancellationToken cancellationToken)
     {
-        if (order.Status != OrderLifecycleStatus.Filled)
+        if (!order.HasUnappliedFill)
         {
             return await PersistOrderOnlyAsync(order, previousStatus, cancellationToken);
         }
@@ -217,8 +217,26 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
             return Result<RefreshOrderStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
         }
 
-        position.Close(order.Id, order.AveragePrice, order.Fees, occurredAt);
-        portfolio.RecordPositionClosed(position.Id, position.Pair, order.Cost);
+        var closeDelta = position.ApplyCloseFillDelta(
+            order.Id,
+            CalculateUnappliedAveragePrice(order),
+            order.UnappliedQuantity,
+            order.UnappliedFees,
+            occurredAt);
+
+        if (closeDelta.PositionClosed)
+        {
+            portfolio.RecordPositionClosed(position.Id, position.Pair, closeDelta.Proceeds);
+        }
+        else
+        {
+            portfolio.RecordPositionCostReduced(
+                position.Id,
+                position.Pair,
+                closeDelta.ReleasedCost,
+                closeDelta.Proceeds);
+        }
+
         order.MarkCurrentFillApplied();
 
         return await PersistOrderPositionPortfolioAsync(
@@ -410,5 +428,10 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
             AppliedDomainEffects = appliedDomainEffects,
             PositionId = positionId
         };
+    }
+
+    private static Price CalculateUnappliedAveragePrice(OrderLifecycle order)
+    {
+        return Price.Create(order.UnappliedCost.Amount / order.UnappliedQuantity.Value);
     }
 }

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -72,7 +72,20 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         }
 
         var previousStatus = order.Status;
-        var changed = ExchangeOrderLifecycleFactory.Refresh(order, exchangeResult.Value);
+        bool changed;
+        try
+        {
+            changed = ExchangeOrderLifecycleFactory.Refresh(order, exchangeResult.Value);
+        }
+        catch (ArgumentException ex)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(Error.Validation(ex.Message));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(Error.Validation(ex.Message));
+        }
+
         if (!changed && !order.HasUnappliedFill)
         {
             return Result<RefreshOrderStatusResult>.Success(CreateResult(

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -1,0 +1,354 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Reconciles a persisted order lifecycle against the exchange and applies
+/// the corresponding domain-side effects when a submitted order eventually fills.
+/// </summary>
+public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStatusCommand, RefreshOrderStatusResult>
+{
+    private readonly IPortfolioRepository _portfolioRepository;
+    private readonly IPositionRepository _positionRepository;
+    private readonly IOrderRepository _orderRepository;
+    private readonly IExchangePort _exchangePort;
+    private readonly IDomainEventDispatcher _eventDispatcher;
+    private readonly ITransactionalUnitOfWork _unitOfWork;
+
+    public RefreshOrderStatusHandler(
+        IPortfolioRepository portfolioRepository,
+        IPositionRepository positionRepository,
+        IOrderRepository orderRepository,
+        IExchangePort exchangePort,
+        IDomainEventDispatcher eventDispatcher,
+        ITransactionalUnitOfWork unitOfWork)
+    {
+        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+        _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Result<RefreshOrderStatusResult>> HandleAsync(
+        RefreshOrderStatusCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var order = await _orderRepository.GetByIdAsync(command.OrderId, cancellationToken);
+        if (order is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.NotFound("Order", command.OrderId.Value));
+        }
+
+        if (order.Intent == OrderIntent.Unknown)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.Validation($"Order {order.Id.Value} does not contain refreshable intent metadata."));
+        }
+
+        if (order.IsTerminal && !order.HasUnappliedFill)
+        {
+            return Result<RefreshOrderStatusResult>.Success(CreateResult(
+                order,
+                order.Status,
+                appliedDomainEffects: false,
+                positionId: order.RelatedPositionId));
+        }
+
+        var exchangeResult = await _exchangePort.GetOrderAsync(order.Pair, order.Id.Value, cancellationToken);
+        if (exchangeResult.IsFailure)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(exchangeResult.Error);
+        }
+
+        var previousStatus = order.Status;
+        var changed = ExchangeOrderLifecycleFactory.Refresh(order, exchangeResult.Value);
+        if (!changed && !order.HasUnappliedFill)
+        {
+            return Result<RefreshOrderStatusResult>.Success(CreateResult(
+                order,
+                previousStatus,
+                appliedDomainEffects: false,
+                positionId: order.RelatedPositionId));
+        }
+
+        if (!order.CanAffectPosition)
+        {
+            return await PersistOrderOnlyAsync(order, previousStatus, cancellationToken);
+        }
+
+        var occurredAt = exchangeResult.Value.UpdatedAt ?? exchangeResult.Value.CreatedAt;
+
+        return order.Intent switch
+        {
+            OrderIntent.OpenPosition => await ApplyOpenPositionAsync(order, previousStatus, occurredAt, cancellationToken),
+            OrderIntent.ClosePosition => await ApplyClosePositionAsync(order, previousStatus, occurredAt, cancellationToken),
+            OrderIntent.ExecuteDca => await ApplyDcaAsync(order, previousStatus, occurredAt, cancellationToken),
+            _ => Result<RefreshOrderStatusResult>.Failure(
+                Error.Validation($"Unsupported order intent {order.Intent} for order {order.Id.Value}."))
+        };
+    }
+
+    private async Task<Result<RefreshOrderStatusResult>> ApplyOpenPositionAsync(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        DateTimeOffset occurredAt,
+        CancellationToken cancellationToken)
+    {
+        var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
+        if (portfolio is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        var position = Position.Open(
+            order.Pair,
+            order.Id,
+            order.AveragePrice,
+            order.FilledQuantity,
+            order.Fees,
+            order.SignalRule,
+            occurredAt);
+
+        portfolio.RecordPositionOpened(position.Id, order.Pair, order.Cost);
+        order.MarkCurrentFillApplied();
+
+        return await PersistOrderPositionPortfolioAsync(
+            order,
+            previousStatus,
+            position,
+            portfolio,
+            cancellationToken);
+    }
+
+    private async Task<Result<RefreshOrderStatusResult>> ApplyClosePositionAsync(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        DateTimeOffset occurredAt,
+        CancellationToken cancellationToken)
+    {
+        var positionId = order.RelatedPositionId;
+        if (positionId is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.Validation($"Order {order.Id.Value} is missing related position metadata."));
+        }
+
+        var position = await _positionRepository.GetByIdAsync(positionId, cancellationToken);
+        if (position is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.NotFound("Position", positionId.Value.ToString()));
+        }
+
+        var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
+        if (portfolio is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        position.Close(order.Id, order.AveragePrice, order.Fees, occurredAt);
+        portfolio.RecordPositionClosed(position.Id, position.Pair, order.Cost);
+        order.MarkCurrentFillApplied();
+
+        return await PersistOrderPositionPortfolioAsync(
+            order,
+            previousStatus,
+            position,
+            portfolio,
+            cancellationToken);
+    }
+
+    private async Task<Result<RefreshOrderStatusResult>> ApplyDcaAsync(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        DateTimeOffset occurredAt,
+        CancellationToken cancellationToken)
+    {
+        var positionId = order.RelatedPositionId;
+        if (positionId is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.Validation($"Order {order.Id.Value} is missing related position metadata."));
+        }
+
+        var position = await _positionRepository.GetByIdAsync(positionId, cancellationToken);
+        if (position is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.NotFound("Position", positionId.Value.ToString()));
+        }
+
+        var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
+        if (portfolio is null)
+        {
+            return Result<RefreshOrderStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        if (!order.HasUnappliedFill)
+        {
+            return await PersistOrderOnlyAsync(order, previousStatus, cancellationToken);
+        }
+
+        if (position.Entries.Any(entry => entry.OrderId == order.Id))
+        {
+            position.ApplyDCAFillDelta(
+                order.Id,
+                order.AveragePrice,
+                order.FilledQuantity,
+                order.Fees,
+                occurredAt);
+        }
+        else
+        {
+            position.AddDCAEntry(
+                order.Id,
+                order.AveragePrice,
+                order.UnappliedQuantity,
+                order.UnappliedFees,
+                occurredAt);
+        }
+
+        portfolio.RecordPositionCostIncreased(position.Id, position.Pair, order.UnappliedCost);
+        order.MarkCurrentFillApplied();
+
+        return await PersistOrderPositionPortfolioAsync(
+            order,
+            previousStatus,
+            position,
+            portfolio,
+            cancellationToken);
+    }
+
+    private async Task<Result<RefreshOrderStatusResult>> PersistOrderOnlyAsync(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(order, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<RefreshOrderStatusResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.ExchangeError($"Failed to persist refreshed order: {ex.Message}"));
+        }
+
+        await DispatchDomainEventsAsync(order, cancellationToken);
+
+        return Result<RefreshOrderStatusResult>.Success(CreateResult(
+            order,
+            previousStatus,
+            appliedDomainEffects: false,
+            positionId: order.RelatedPositionId));
+    }
+
+    private async Task<Result<RefreshOrderStatusResult>> PersistOrderPositionPortfolioAsync(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        Position position,
+        Portfolio portfolio,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await BeginTransactionIfSupportedAsync(cancellationToken);
+            await _orderRepository.SaveAsync(order, cancellationToken);
+            await _positionRepository.SaveAsync(position, cancellationToken);
+            await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+
+            var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
+            if (commitResult.IsFailure)
+            {
+                return Result<RefreshOrderStatusResult>.Failure(commitResult.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            return Result<RefreshOrderStatusResult>.Failure(
+                Error.ExchangeError($"Failed to persist refreshed order effects: {ex.Message}"));
+        }
+
+        await DispatchDomainEventsAsync(order, position, portfolio, cancellationToken);
+
+        return Result<RefreshOrderStatusResult>.Success(CreateResult(
+            order,
+            previousStatus,
+            appliedDomainEffects: true,
+            positionId: position.Id));
+    }
+
+    private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
+    {
+        await _unitOfWork.BeginTransactionAsync(cancellationToken);
+    }
+
+    private async Task DispatchDomainEventsAsync(
+        OrderLifecycle order,
+        CancellationToken cancellationToken)
+    {
+        var events = order.DomainEvents.ToList();
+        order.ClearDomainEvents();
+
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+    }
+
+    private async Task DispatchDomainEventsAsync(
+        OrderLifecycle order,
+        Position position,
+        Portfolio portfolio,
+        CancellationToken cancellationToken)
+    {
+        var events = new List<IDomainEvent>();
+        events.AddRange(order.DomainEvents);
+        events.AddRange(position.DomainEvents);
+        events.AddRange(portfolio.DomainEvents);
+
+        order.ClearDomainEvents();
+        position.ClearDomainEvents();
+        portfolio.ClearDomainEvents();
+
+        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+    }
+
+    private static RefreshOrderStatusResult CreateResult(
+        OrderLifecycle order,
+        OrderLifecycleStatus previousStatus,
+        bool appliedDomainEffects,
+        PositionId? positionId)
+    {
+        return new RefreshOrderStatusResult
+        {
+            OrderId = order.Id,
+            PreviousStatus = previousStatus,
+            CurrentStatus = order.Status,
+            AppliedDomainEffects = appliedDomainEffects,
+            PositionId = positionId
+        };
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -179,6 +179,11 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         DateTimeOffset occurredAt,
         CancellationToken cancellationToken)
     {
+        if (order.Status != OrderLifecycleStatus.Filled)
+        {
+            return await PersistOrderOnlyAsync(order, previousStatus, cancellationToken);
+        }
+
         var positionId = order.RelatedPositionId;
         if (positionId is null)
         {

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -105,22 +105,64 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         DateTimeOffset occurredAt,
         CancellationToken cancellationToken)
     {
+        if (!order.HasUnappliedFill)
+        {
+            return await PersistOrderOnlyAsync(order, previousStatus, cancellationToken);
+        }
+
         var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
         if (portfolio is null)
         {
             return Result<RefreshOrderStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
         }
 
-        var position = Position.Open(
-            order.Pair,
-            order.Id,
-            order.AveragePrice,
-            order.FilledQuantity,
-            order.Fees,
-            order.SignalRule,
-            occurredAt);
+        Position position;
+        var relatedPositionId = order.RelatedPositionId ?? portfolio.GetPositionId(order.Pair);
+        if (relatedPositionId is null)
+        {
+            position = Position.Open(
+                order.Pair,
+                order.Id,
+                order.AveragePrice,
+                order.FilledQuantity,
+                order.Fees,
+                order.SignalRule,
+                occurredAt);
 
-        portfolio.RecordPositionOpened(position.Id, order.Pair, order.Cost);
+            portfolio.RecordPositionOpened(position.Id, order.Pair, order.UnappliedCost);
+            order.LinkRelatedPosition(position.Id);
+        }
+        else
+        {
+            var existingPosition = await _positionRepository.GetByIdAsync(relatedPositionId, cancellationToken);
+            if (existingPosition is null)
+            {
+                return Result<RefreshOrderStatusResult>.Failure(
+                    Error.NotFound("Position", relatedPositionId.Value.ToString()));
+            }
+
+            position = existingPosition;
+            if (!position.Entries.Any(entry => entry.OrderId == order.Id))
+            {
+                return Result<RefreshOrderStatusResult>.Failure(
+                    Error.Validation($"Position {position.Id.Value} does not contain opening order {order.Id.Value}."));
+            }
+
+            if (order.RelatedPositionId is null)
+            {
+                order.LinkRelatedPosition(position.Id);
+            }
+
+            position.ApplyOpeningFillDelta(
+                order.Id,
+                order.AveragePrice,
+                order.FilledQuantity,
+                order.Fees,
+                occurredAt);
+
+            portfolio.RecordPositionCostIncreased(position.Id, position.Pair, order.UnappliedCost);
+        }
+
         order.MarkCurrentFillApplied();
 
         return await PersistOrderPositionPortfolioAsync(

--- a/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
@@ -7,7 +7,7 @@ using IntelliTrader.Domain.Trading.Orders;
 namespace IntelliTrader.Application.Trading.Handlers;
 
 /// <summary>
-/// Refreshes a batch of persisted submitted orders by delegating to the
+/// Refreshes a batch of persisted non-terminal orders by delegating to the
 /// single-order reconciliation use case.
 /// </summary>
 public sealed class RefreshSubmittedOrdersHandler
@@ -31,13 +31,13 @@ public sealed class RefreshSubmittedOrdersHandler
         ArgumentNullException.ThrowIfNull(command);
 
         var allOrders = await _orderRepository.GetAllAsync(cancellationToken);
-        var submittedOrders = allOrders
-            .Where(order => order.Status == OrderLifecycleStatus.Submitted)
+        var refreshableOrders = allOrders
+            .Where(order => !order.IsTerminal)
             .OrderBy(order => order.SubmittedAt)
             .ToList();
 
         var limit = command.Limit <= 0 ? 50 : command.Limit;
-        var batch = submittedOrders
+        var batch = refreshableOrders
             .Take(limit)
             .ToList();
 
@@ -69,7 +69,7 @@ public sealed class RefreshSubmittedOrdersHandler
 
         return Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
         {
-            TotalSubmitted = submittedOrders.Count,
+            TotalSubmitted = refreshableOrders.Count,
             AttemptedCount = batch.Count,
             RefreshedCount = refreshedCount,
             AppliedDomainEffectsCount = appliedDomainEffectsCount,

--- a/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
@@ -1,0 +1,79 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Domain.Trading.Orders;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Refreshes a batch of persisted submitted orders by delegating to the
+/// single-order reconciliation use case.
+/// </summary>
+public sealed class RefreshSubmittedOrdersHandler
+    : ICommandHandler<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ICommandDispatcher _commandDispatcher;
+
+    public RefreshSubmittedOrdersHandler(
+        IOrderRepository orderRepository,
+        ICommandDispatcher commandDispatcher)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _commandDispatcher = commandDispatcher ?? throw new ArgumentNullException(nameof(commandDispatcher));
+    }
+
+    public async Task<Result<RefreshSubmittedOrdersResult>> HandleAsync(
+        RefreshSubmittedOrdersCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var allOrders = await _orderRepository.GetAllAsync(cancellationToken);
+        var submittedOrders = allOrders
+            .Where(order => order.Status == OrderLifecycleStatus.Submitted)
+            .OrderBy(order => order.SubmittedAt)
+            .ToList();
+
+        var limit = command.Limit <= 0 ? 50 : command.Limit;
+        var batch = submittedOrders
+            .Take(limit)
+            .ToList();
+
+        var refreshedCount = 0;
+        var appliedDomainEffectsCount = 0;
+        var failedCount = 0;
+
+        foreach (var order in batch)
+        {
+            var refreshResult = await _commandDispatcher.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                new RefreshOrderStatusCommand
+                {
+                    OrderId = order.Id
+                },
+                cancellationToken);
+
+            if (refreshResult.IsFailure)
+            {
+                failedCount++;
+                continue;
+            }
+
+            refreshedCount++;
+            if (refreshResult.Value.AppliedDomainEffects)
+            {
+                appliedDomainEffectsCount++;
+            }
+        }
+
+        return Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
+        {
+            TotalSubmitted = submittedOrders.Count,
+            AttemptedCount = batch.Count,
+            RefreshedCount = refreshedCount,
+            AppliedDomainEffectsCount = appliedDomainEffectsCount,
+            FailedCount = failedCount
+        });
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshSubmittedOrdersHandler.cs
@@ -11,7 +11,8 @@ namespace IntelliTrader.Application.Trading.Handlers;
 /// single-order reconciliation use case.
 /// </summary>
 public sealed class RefreshSubmittedOrdersHandler
-    : ICommandHandler<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>
+    : ICommandHandler<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>,
+      ICommandHandler<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>
 {
     private readonly IOrderRepository _orderRepository;
     private readonly ICommandDispatcher _commandDispatcher;
@@ -30,13 +31,42 @@ public sealed class RefreshSubmittedOrdersHandler
     {
         ArgumentNullException.ThrowIfNull(command);
 
+        var result = await HandleActiveOrdersAsync(command.Limit, cancellationToken);
+        if (result.IsFailure)
+        {
+            return Result<RefreshSubmittedOrdersResult>.Failure(result.Error);
+        }
+
+        return Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
+        {
+            TotalSubmitted = result.Value.TotalActive,
+            AttemptedCount = result.Value.AttemptedCount,
+            RefreshedCount = result.Value.RefreshedCount,
+            AppliedDomainEffectsCount = result.Value.AppliedDomainEffectsCount,
+            FailedCount = result.Value.FailedCount
+        });
+    }
+
+    public async Task<Result<RefreshActiveOrdersResult>> HandleAsync(
+        RefreshActiveOrdersCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        return await HandleActiveOrdersAsync(command.Limit, cancellationToken);
+    }
+
+    private async Task<Result<RefreshActiveOrdersResult>> HandleActiveOrdersAsync(
+        int requestedLimit,
+        CancellationToken cancellationToken)
+    {
         var allOrders = await _orderRepository.GetAllAsync(cancellationToken);
         var refreshableOrders = allOrders
             .Where(order => !order.IsTerminal)
             .OrderBy(order => order.SubmittedAt)
             .ToList();
 
-        var limit = command.Limit <= 0 ? 50 : command.Limit;
+        var limit = requestedLimit <= 0 ? 50 : requestedLimit;
         var batch = refreshableOrders
             .Take(limit)
             .ToList();
@@ -67,9 +97,9 @@ public sealed class RefreshSubmittedOrdersHandler
             }
         }
 
-        return Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
+        return Result<RefreshActiveOrdersResult>.Success(new RefreshActiveOrdersResult
         {
-            TotalSubmitted = refreshableOrders.Count,
+            TotalActive = refreshableOrders.Count,
             AttemptedCount = batch.Count,
             RefreshedCount = refreshedCount,
             AppliedDomainEffectsCount = appliedDomainEffectsCount,

--- a/IntelliTrader.Application/Trading/Queries/OrderQueries.cs
+++ b/IntelliTrader.Application/Trading/Queries/OrderQueries.cs
@@ -1,0 +1,45 @@
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading.Queries;
+
+/// <summary>
+/// Query to get a single persisted order lifecycle.
+/// </summary>
+public sealed record GetOrderQuery
+{
+    public required OrderId OrderId { get; init; }
+}
+
+/// <summary>
+/// Query to get recent persisted orders with optional filters.
+/// </summary>
+public sealed record GetRecentOrdersQuery
+{
+    public TradingPair? Pair { get; init; }
+    public OrderLifecycleStatus? Status { get; init; }
+    public IntelliTrader.Domain.Events.OrderSide? Side { get; init; }
+    public int Limit { get; init; } = 50;
+}
+
+/// <summary>
+/// Read model for an order lifecycle.
+/// </summary>
+public sealed record OrderView
+{
+    public required OrderId Id { get; init; }
+    public required TradingPair Pair { get; init; }
+    public required IntelliTrader.Domain.Events.OrderSide Side { get; init; }
+    public required IntelliTrader.Domain.Events.OrderType Type { get; init; }
+    public required OrderLifecycleStatus Status { get; init; }
+    public required Quantity RequestedQuantity { get; init; }
+    public required Quantity FilledQuantity { get; init; }
+    public required Price SubmittedPrice { get; init; }
+    public required Price AveragePrice { get; init; }
+    public required Money Cost { get; init; }
+    public required Money Fees { get; init; }
+    public string? SignalRule { get; init; }
+    public required DateTimeOffset SubmittedAt { get; init; }
+    public required bool CanAffectPosition { get; init; }
+    public required bool IsTerminal { get; init; }
+}

--- a/IntelliTrader.Application/Trading/Queries/OrderQueries.cs
+++ b/IntelliTrader.Application/Trading/Queries/OrderQueries.cs
@@ -23,6 +23,16 @@ public sealed record GetRecentOrdersQuery
 }
 
 /// <summary>
+/// Query to get active, non-terminal persisted orders with optional filters.
+/// </summary>
+public sealed record GetActiveOrdersQuery
+{
+    public TradingPair? Pair { get; init; }
+    public IntelliTrader.Domain.Events.OrderSide? Side { get; init; }
+    public int Limit { get; init; } = 50;
+}
+
+/// <summary>
 /// Read model for an order lifecycle.
 /// </summary>
 public sealed record OrderView

--- a/IntelliTrader.Application/Trading/TradingUseCase.cs
+++ b/IntelliTrader.Application/Trading/TradingUseCase.cs
@@ -1,0 +1,340 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Trading;
+
+/// <summary>
+/// Application service implementing the primary trading port.
+/// Primary adapters should depend on this use case instead of individual dispatchers.
+/// </summary>
+public sealed class TradingUseCase : ITradingUseCase
+{
+    private const int UnboundedDcaLevels = int.MaxValue;
+
+    private readonly ICommandDispatcher _commandDispatcher;
+    private readonly IQueryDispatcher _queryDispatcher;
+    private readonly IPortfolioRepository _portfolioRepository;
+    private readonly IPositionRepository _positionRepository;
+    private readonly IExchangePort _exchangePort;
+
+    public TradingUseCase(
+        ICommandDispatcher commandDispatcher,
+        IQueryDispatcher queryDispatcher,
+        IPortfolioRepository portfolioRepository,
+        IPositionRepository positionRepository,
+        IExchangePort exchangePort)
+    {
+        _commandDispatcher = commandDispatcher ?? throw new ArgumentNullException(nameof(commandDispatcher));
+        _queryDispatcher = queryDispatcher ?? throw new ArgumentNullException(nameof(queryDispatcher));
+        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
+        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+    }
+
+    public Task<Result<OpenPositionResult>> OpenPositionAsync(
+        OpenPositionCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        return _commandDispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(
+            command,
+            cancellationToken);
+    }
+
+    public Task<Result<ClosePositionResult>> ClosePositionAsync(
+        ClosePositionCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        return _commandDispatcher.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+            command,
+            cancellationToken);
+    }
+
+    public Task<Result<ClosePositionResult>> ClosePositionByPairAsync(
+        ClosePositionByPairCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        return _commandDispatcher.DispatchAsync<ClosePositionByPairCommand, ClosePositionResult>(
+            command,
+            cancellationToken);
+    }
+
+    public Task<Result<ExecuteDCAResult>> ExecuteDCAAsync(
+        ExecuteDCACommand command,
+        CancellationToken cancellationToken = default)
+    {
+        return _commandDispatcher.DispatchAsync<ExecuteDCACommand, ExecuteDCAResult>(
+            command,
+            cancellationToken);
+    }
+
+    public Task<Result<ExecuteDCAResult>> ExecuteDCAByPairAsync(
+        ExecuteDCAByPairCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        return _commandDispatcher.DispatchAsync<ExecuteDCAByPairCommand, ExecuteDCAResult>(
+            command,
+            cancellationToken);
+    }
+
+    public async Task<Result<IReadOnlyList<ClosePositionResult>>> CloseAllPositionsAsync(
+        CloseReason reason = CloseReason.Manual,
+        CancellationToken cancellationToken = default)
+    {
+        var positions = await _positionRepository.GetAllActiveAsync(cancellationToken);
+        var results = new List<ClosePositionResult>(positions.Count);
+
+        foreach (var position in positions)
+        {
+            var result = await ClosePositionAsync(
+                new ClosePositionCommand
+                {
+                    PositionId = position.Id,
+                    Reason = reason
+                },
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                return Result<IReadOnlyList<ClosePositionResult>>.Failure(result.Error);
+            }
+
+            results.Add(result.Value);
+        }
+
+        return Result<IReadOnlyList<ClosePositionResult>>.Success(results);
+    }
+
+    public Task<Result<PositionView>> GetPositionAsync(
+        GetPositionQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetPositionQuery, PositionView>(query, cancellationToken);
+    }
+
+    public Task<Result<IReadOnlyList<PositionView>>> GetActivePositionsAsync(
+        GetActivePositionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetActivePositionsQuery, IReadOnlyList<PositionView>>(
+            query,
+            cancellationToken);
+    }
+
+    public Task<Result<IReadOnlyList<PositionView>>> GetClosedPositionsAsync(
+        GetClosedPositionsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetClosedPositionsQuery, IReadOnlyList<PositionView>>(
+            query,
+            cancellationToken);
+    }
+
+    public async Task<Result<PositionsSummary>> GetPositionsSummaryAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var positionsResult = await GetActivePositionsAsync(new GetActivePositionsQuery(), cancellationToken);
+        if (positionsResult.IsFailure)
+        {
+            return Result<PositionsSummary>.Failure(positionsResult.Error);
+        }
+
+        var positions = positionsResult.Value;
+        var currency = ResolveSummaryCurrency(positions);
+
+        if (positions.Count == 0)
+        {
+            return Result<PositionsSummary>.Success(CreateEmptySummary(currency));
+        }
+
+        var totalInvested = SumMoney(positions.Select(position => position.TotalCost), currency);
+        var totalCurrentValue = SumMoney(positions.Select(position => position.CurrentValue), currency);
+        var totalUnrealizedPnL = SumMoney(positions.Select(position => position.UnrealizedPnL), currency);
+        var averageMargin = Margin.FromPercentage(positions.Average(position => position.CurrentMargin.Percentage));
+        var best = positions.MaxBy(position => position.CurrentMargin.Percentage);
+        var worst = positions.MinBy(position => position.CurrentMargin.Percentage);
+
+        return Result<PositionsSummary>.Success(new PositionsSummary
+        {
+            TotalPositions = positions.Count,
+            ProfitablePositions = positions.Count(position => position.CurrentMargin.IsProfit),
+            LosingPositions = positions.Count(position => position.CurrentMargin.IsLoss),
+            TotalInvested = totalInvested,
+            TotalCurrentValue = totalCurrentValue,
+            TotalUnrealizedPnL = totalUnrealizedPnL,
+            AverageMargin = averageMargin,
+            BestMargin = best?.CurrentMargin ?? Margin.Zero,
+            WorstMargin = worst?.CurrentMargin ?? Margin.Zero,
+            BestPerformer = best?.Pair,
+            WorstPerformer = worst?.Pair
+        });
+    }
+
+    public Task<Result<PortfolioView>> GetPortfolioAsync(
+        GetPortfolioQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetPortfolioQuery, PortfolioView>(query, cancellationToken);
+    }
+
+    public Task<Result<PortfolioStatistics>> GetPortfolioStatisticsAsync(
+        GetPortfolioStatisticsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetPortfolioStatisticsQuery, PortfolioStatistics>(
+            query,
+            cancellationToken);
+    }
+
+    public Task<Result<IReadOnlyList<TradeHistoryEntry>>> GetTradingHistoryAsync(
+        GetTradingHistoryQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        return _queryDispatcher.DispatchAsync<GetTradingHistoryQuery, IReadOnlyList<TradeHistoryEntry>>(
+            query,
+            cancellationToken);
+    }
+
+    public async Task<Result<CanOpenPositionResult>> CanOpenPositionAsync(
+        TradingPair pair,
+        Money cost,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        ArgumentNullException.ThrowIfNull(cost);
+
+        var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
+        if (portfolio is null)
+        {
+            return Result<CanOpenPositionResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        var validationErrors = new List<string>();
+        if (!cost.Currency.Equals(portfolio.Market, StringComparison.Ordinal))
+        {
+            validationErrors.Add($"Cost currency {cost.Currency} does not match portfolio market {portfolio.Market}.");
+        }
+        else
+        {
+            if (cost < portfolio.MinPositionCost)
+            {
+                validationErrors.Add($"Requested cost {cost} is below minimum position cost {portfolio.MinPositionCost}.");
+            }
+
+            if (!portfolio.CanAfford(cost))
+            {
+                validationErrors.Add($"Insufficient funds. Available: {portfolio.Balance.Available}, Required: {cost}.");
+            }
+        }
+
+        if (portfolio.HasPositionFor(pair))
+        {
+            validationErrors.Add($"Position already exists for {pair.Symbol}.");
+        }
+
+        if (portfolio.IsAtMaxPositions)
+        {
+            validationErrors.Add($"Maximum positions ({portfolio.MaxPositions}) reached.");
+        }
+
+        return Result<CanOpenPositionResult>.Success(new CanOpenPositionResult
+        {
+            CanOpen = validationErrors.Count == 0,
+            Pair = pair,
+            RequestedCost = cost,
+            AvailableBalance = portfolio.Balance.Available,
+            CurrentPositionCount = portfolio.ActivePositionCount,
+            MaxPositions = portfolio.MaxPositions,
+            ValidationErrors = validationErrors
+        });
+    }
+
+    public async Task<Result<CanDCAResult>> CanExecuteDCAAsync(
+        PositionId positionId,
+        Money cost,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(positionId);
+        ArgumentNullException.ThrowIfNull(cost);
+
+        var position = await _positionRepository.GetByIdAsync(positionId, cancellationToken);
+        if (position is null)
+        {
+            return Result<CanDCAResult>.Failure(Error.NotFound("Position", positionId.ToString()));
+        }
+
+        var portfolio = await _portfolioRepository.GetDefaultAsync(cancellationToken);
+        if (portfolio is null)
+        {
+            return Result<CanDCAResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        var priceResult = await _exchangePort.GetCurrentPriceAsync(position.Pair, cancellationToken);
+        if (priceResult.IsFailure)
+        {
+            return Result<CanDCAResult>.Failure(priceResult.Error);
+        }
+
+        var validationErrors = new List<string>();
+        if (position.IsClosed)
+        {
+            validationErrors.Add($"Position {positionId} is closed.");
+        }
+
+        if (!portfolio.HasPositionFor(position.Pair))
+        {
+            validationErrors.Add($"Portfolio does not contain active position for {position.Pair.Symbol}.");
+        }
+
+        if (!cost.Currency.Equals(portfolio.Market, StringComparison.Ordinal))
+        {
+            validationErrors.Add($"Cost currency {cost.Currency} does not match portfolio market {portfolio.Market}.");
+        }
+        else if (!portfolio.CanAfford(cost))
+        {
+            validationErrors.Add($"Insufficient funds. Available: {portfolio.Balance.Available}, Required: {cost}.");
+        }
+
+        return Result<CanDCAResult>.Success(new CanDCAResult
+        {
+            CanDCA = validationErrors.Count == 0,
+            PositionId = position.Id,
+            Pair = position.Pair,
+            CurrentDCALevel = position.DCALevel,
+            MaxDCALevels = UnboundedDcaLevels,
+            RequestedCost = cost,
+            AvailableBalance = portfolio.Balance.Available,
+            CurrentMargin = position.CalculateMargin(priceResult.Value),
+            ValidationErrors = validationErrors
+        });
+    }
+
+    private static string ResolveSummaryCurrency(IReadOnlyList<PositionView> positions)
+    {
+        return positions.FirstOrDefault()?.TotalCost.Currency ?? "USDT";
+    }
+
+    private static PositionsSummary CreateEmptySummary(string currency)
+    {
+        return new PositionsSummary
+        {
+            TotalPositions = 0,
+            ProfitablePositions = 0,
+            LosingPositions = 0,
+            TotalInvested = Money.Zero(currency),
+            TotalCurrentValue = Money.Zero(currency),
+            TotalUnrealizedPnL = Money.Zero(currency),
+            AverageMargin = Margin.Zero,
+            BestMargin = Margin.Zero,
+            WorstMargin = Margin.Zero
+        };
+    }
+
+    private static Money SumMoney(IEnumerable<Money> values, string currency)
+    {
+        return values.Aggregate(Money.Zero(currency), (sum, value) => sum + value);
+    }
+}

--- a/IntelliTrader.Core/Interfaces/Services/IActiveOrderRefreshService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/IActiveOrderRefreshService.cs
@@ -1,0 +1,18 @@
+namespace IntelliTrader.Core
+{
+    /// <summary>
+    /// Manages the lifecycle of background active-order reconciliation.
+    /// </summary>
+    public interface IActiveOrderRefreshService
+    {
+        /// <summary>
+        /// Starts background refresh of active, non-terminal orders.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops background refresh of active, non-terminal orders.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/IntelliTrader.Core/Interfaces/Services/ISubmittedOrderRefreshService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ISubmittedOrderRefreshService.cs
@@ -1,18 +1,10 @@
 namespace IntelliTrader.Core
 {
     /// <summary>
-    /// Manages the lifecycle of background submitted-order reconciliation.
+    /// Compatibility alias for the legacy submitted-order refresh contract.
+    /// Prefer <see cref="IActiveOrderRefreshService"/>.
     /// </summary>
-    public interface ISubmittedOrderRefreshService
+    public interface ISubmittedOrderRefreshService : IActiveOrderRefreshService
     {
-        /// <summary>
-        /// Starts background refresh of submitted orders.
-        /// </summary>
-        void Start();
-
-        /// <summary>
-        /// Stops background refresh of submitted orders.
-        /// </summary>
-        void Stop();
     }
 }

--- a/IntelliTrader.Core/Interfaces/Services/ISubmittedOrderRefreshService.cs
+++ b/IntelliTrader.Core/Interfaces/Services/ISubmittedOrderRefreshService.cs
@@ -1,0 +1,18 @@
+namespace IntelliTrader.Core
+{
+    /// <summary>
+    /// Manages the lifecycle of background submitted-order reconciliation.
+    /// </summary>
+    public interface ISubmittedOrderRefreshService
+    {
+        /// <summary>
+        /// Starts background refresh of submitted orders.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops background refresh of submitted orders.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -19,6 +19,7 @@ namespace IntelliTrader.Core
         IWebService webService,
         IBacktestingService backtestingService,
         IAlertingService alertingService,
+        ISubmittedOrderRefreshService submittedOrderRefreshService,
         IApplicationContext applicationContext,
         IConfigProvider configProvider,
         Lazy<ISecretRotationService> secretRotationService) : ConfigurableServiceBase<CoreConfig>(configProvider), ICoreService
@@ -67,6 +68,7 @@ namespace IntelliTrader.Core
             if (tradingService.Config.Enabled)
             {
                 tradingService.Start();
+                submittedOrderRefreshService.Start();
             }
             if (notificationService.Config.Enabled)
             {
@@ -116,6 +118,7 @@ namespace IntelliTrader.Core
             loggingService.Info("Stop Core service...");
             if (tradingService.Config.Enabled)
             {
+                submittedOrderRefreshService.Stop();
                 tradingService.Stop();
             }
             if (notificationService.Config.Enabled)

--- a/IntelliTrader.Core/Services/CoreService.cs
+++ b/IntelliTrader.Core/Services/CoreService.cs
@@ -19,7 +19,7 @@ namespace IntelliTrader.Core
         IWebService webService,
         IBacktestingService backtestingService,
         IAlertingService alertingService,
-        ISubmittedOrderRefreshService submittedOrderRefreshService,
+        IActiveOrderRefreshService activeOrderRefreshService,
         IApplicationContext applicationContext,
         IConfigProvider configProvider,
         Lazy<ISecretRotationService> secretRotationService) : ConfigurableServiceBase<CoreConfig>(configProvider), ICoreService
@@ -68,7 +68,7 @@ namespace IntelliTrader.Core
             if (tradingService.Config.Enabled)
             {
                 tradingService.Start();
-                submittedOrderRefreshService.Start();
+                activeOrderRefreshService.Start();
             }
             if (notificationService.Config.Enabled)
             {
@@ -118,7 +118,7 @@ namespace IntelliTrader.Core
             loggingService.Info("Stop Core service...");
             if (tradingService.Config.Enabled)
             {
-                submittedOrderRefreshService.Stop();
+                activeOrderRefreshService.Stop();
                 tradingService.Stop();
             }
             if (notificationService.Config.Enabled)

--- a/IntelliTrader.Domain/Trading/Aggregates/Portfolio/Portfolio.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Portfolio/Portfolio.cs
@@ -260,6 +260,47 @@ public sealed class Portfolio : AggregateRoot<PortfolioId>
         }
     }
 
+    public void RecordPositionCostReduced(
+        PositionId positionId,
+        TradingPair pair,
+        Money releasedCost,
+        Money proceeds)
+    {
+        ArgumentNullException.ThrowIfNull(positionId);
+        ArgumentNullException.ThrowIfNull(pair);
+        ArgumentNullException.ThrowIfNull(releasedCost);
+        ArgumentNullException.ThrowIfNull(proceeds);
+        EnsureSameCurrency(releasedCost);
+        EnsureSameCurrency(proceeds);
+
+        lock (_positionLock)
+        {
+            if (!HasPositionFor(pair))
+                throw new InvalidOperationException($"No position exists for {pair}");
+
+            if (_activePositions[pair] != positionId)
+                throw new InvalidOperationException($"Position ID mismatch for {pair}");
+
+            var currentCost = _positionCosts[positionId];
+            if (releasedCost > currentCost)
+                throw new InvalidOperationException("Cannot reduce more than tracked position cost.");
+
+            var pnl = proceeds - releasedCost;
+            var previousBalance = Balance;
+            Balance = Balance.Release(releasedCost);
+            Balance = Balance.RecordPnL(pnl);
+            _positionCosts[positionId] = currentCost - releasedCost;
+
+            AddDomainEvent(new PortfolioBalanceChanged(
+                Id,
+                previousBalance.Total,
+                Balance.Total,
+                previousBalance.Available,
+                Balance.Available,
+                $"Position partially closed for {pair}, PnL: {pnl}"));
+        }
+    }
+
     /// <summary>
     /// Updates the portfolio configuration.
     /// </summary>

--- a/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
@@ -203,6 +203,70 @@ public sealed class Position : AggregateRoot<PositionId>
             TotalCost));
     }
 
+    public void ApplyDCAFillDelta(
+        OrderId orderId,
+        Price averagePrice,
+        Quantity cumulativeQuantity,
+        Money cumulativeFees,
+        DateTimeOffset? timestamp = null)
+    {
+        EnsureNotClosed();
+
+        ArgumentNullException.ThrowIfNull(orderId);
+        ArgumentNullException.ThrowIfNull(averagePrice);
+        ArgumentNullException.ThrowIfNull(cumulativeQuantity);
+        ArgumentNullException.ThrowIfNull(cumulativeFees);
+
+        if (averagePrice.IsZero)
+            throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
+
+        if (cumulativeQuantity.IsZero)
+            throw new ArgumentException("Cumulative quantity cannot be zero", nameof(cumulativeQuantity));
+
+        if (cumulativeFees.Currency != Currency)
+            throw new InvalidOperationException($"Fee currency mismatch. Expected {Currency}, got {cumulativeFees.Currency}");
+
+        var entryIndex = _entries.FindIndex(entry => entry.OrderId == orderId);
+        if (entryIndex < 0)
+            throw new InvalidOperationException($"No DCA entry exists for order {orderId.Value}");
+
+        var existingEntry = _entries[entryIndex];
+        if (cumulativeQuantity < existingEntry.Quantity)
+            throw new InvalidOperationException("Cumulative quantity cannot be lower than the already applied quantity");
+
+        if (cumulativeQuantity == existingEntry.Quantity)
+            return;
+
+        var now = timestamp ?? DateTimeOffset.UtcNow;
+        var updatedEntry = PositionEntry.Create(
+            orderId,
+            averagePrice,
+            cumulativeQuantity,
+            cumulativeFees,
+            existingEntry.Timestamp,
+            existingEntry.IsMigrated);
+
+        var deltaQuantity = cumulativeQuantity - existingEntry.Quantity;
+        var deltaCost = updatedEntry.Cost - existingEntry.Cost;
+        var deltaFees = cumulativeFees - existingEntry.Fees;
+
+        _entries[entryIndex] = updatedEntry;
+        LastBuyAt = now;
+
+        AddDomainEvent(new DCAExecuted(
+            Id,
+            Pair,
+            orderId,
+            DCALevel,
+            averagePrice,
+            deltaQuantity,
+            deltaCost,
+            deltaFees,
+            AveragePrice,
+            TotalQuantity,
+            TotalCost));
+    }
+
     /// <summary>
     /// Closes the position with a sell order.
     /// </summary>

--- a/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
@@ -357,6 +357,54 @@ public sealed class Position : AggregateRoot<PositionId>
             now - OpenedAt));
     }
 
+    public PositionCloseFillDelta ApplyCloseFillDelta(
+        OrderId sellOrderId,
+        Price sellPrice,
+        Quantity soldQuantity,
+        Money sellFees,
+        DateTimeOffset? timestamp = null)
+    {
+        EnsureNotClosed();
+
+        ArgumentNullException.ThrowIfNull(sellOrderId);
+        ArgumentNullException.ThrowIfNull(sellPrice);
+        ArgumentNullException.ThrowIfNull(soldQuantity);
+        ArgumentNullException.ThrowIfNull(sellFees);
+
+        if (sellPrice.IsZero)
+            throw new ArgumentException("Sell price cannot be zero", nameof(sellPrice));
+
+        if (soldQuantity.IsZero)
+            throw new ArgumentException("Sold quantity cannot be zero", nameof(soldQuantity));
+
+        if (soldQuantity > TotalQuantity)
+            throw new InvalidOperationException("Sold quantity cannot exceed position quantity.");
+
+        var proceeds = Money.Create(sellPrice.Value * soldQuantity.Value, Currency);
+        var releasedCost = CalculateReleasedCost(soldQuantity);
+
+        if (soldQuantity.Value == TotalQuantity.Value)
+        {
+            Close(sellOrderId, sellPrice, sellFees, timestamp);
+            return new PositionCloseFillDelta(soldQuantity, proceeds, releasedCost, sellFees, PositionClosed: true);
+        }
+
+        ReduceEntries(soldQuantity);
+
+        AddDomainEvent(new PositionPartiallyClosed(
+            Id,
+            Pair,
+            sellOrderId,
+            sellPrice,
+            soldQuantity,
+            TotalQuantity,
+            proceeds,
+            releasedCost,
+            sellFees));
+
+        return new PositionCloseFillDelta(soldQuantity, proceeds, releasedCost, sellFees, PositionClosed: false);
+    }
+
     /// <summary>
     /// Calculates the current margin (profit/loss percentage) at the given price.
     /// </summary>
@@ -456,4 +504,61 @@ public sealed class Position : AggregateRoot<PositionId>
         if (IsClosed)
             throw new InvalidOperationException("Cannot modify a closed position");
     }
+
+    private Money CalculateReleasedCost(Quantity soldQuantity)
+    {
+        var remainingToSell = soldQuantity.Value;
+        var releasedCost = Money.Zero(Currency);
+
+        foreach (var entry in _entries)
+        {
+            if (remainingToSell <= 0m)
+                break;
+
+            var quantityToSell = Math.Min(entry.Quantity.Value, remainingToSell);
+            releasedCost += Money.Create(entry.Price.Value * quantityToSell, Currency);
+            remainingToSell -= quantityToSell;
+        }
+
+        return releasedCost;
+    }
+
+    private void ReduceEntries(Quantity soldQuantity)
+    {
+        var remainingToSell = soldQuantity.Value;
+
+        for (var index = 0; index < _entries.Count && remainingToSell > 0m;)
+        {
+            var entry = _entries[index];
+            var quantityToSell = Math.Min(entry.Quantity.Value, remainingToSell);
+            var remainingEntryQuantity = entry.Quantity.Value - quantityToSell;
+            var ratio = quantityToSell / entry.Quantity.Value;
+            var releasedFees = entry.Fees * ratio;
+
+            if (remainingEntryQuantity == 0m)
+            {
+                _entries.RemoveAt(index);
+            }
+            else
+            {
+                _entries[index] = PositionEntry.Create(
+                    entry.OrderId,
+                    entry.Price,
+                    Quantity.Create(remainingEntryQuantity),
+                    entry.Fees - releasedFees,
+                    entry.Timestamp,
+                    entry.IsMigrated);
+                index++;
+            }
+
+            remainingToSell -= quantityToSell;
+        }
+    }
 }
+
+public sealed record PositionCloseFillDelta(
+    Quantity SoldQuantity,
+    Money Proceeds,
+    Money ReleasedCost,
+    Money SellFees,
+    bool PositionClosed);

--- a/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
@@ -268,6 +268,56 @@ public sealed class Position : AggregateRoot<PositionId>
     }
 
     /// <summary>
+    /// Reconciles the cumulative fill for the opening order without creating a DCA entry.
+    /// </summary>
+    public void ApplyOpeningFillDelta(
+        OrderId orderId,
+        Price averagePrice,
+        Quantity cumulativeQuantity,
+        Money cumulativeFees,
+        DateTimeOffset? timestamp = null)
+    {
+        EnsureNotClosed();
+
+        ArgumentNullException.ThrowIfNull(orderId);
+        ArgumentNullException.ThrowIfNull(averagePrice);
+        ArgumentNullException.ThrowIfNull(cumulativeQuantity);
+        ArgumentNullException.ThrowIfNull(cumulativeFees);
+
+        if (averagePrice.IsZero)
+            throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
+
+        if (cumulativeQuantity.IsZero)
+            throw new ArgumentException("Cumulative quantity cannot be zero", nameof(cumulativeQuantity));
+
+        if (cumulativeFees.Currency != Currency)
+            throw new InvalidOperationException($"Fee currency mismatch. Expected {Currency}, got {cumulativeFees.Currency}");
+
+        var entryIndex = _entries.FindIndex(entry => entry.OrderId == orderId);
+        if (entryIndex != 0)
+            throw new InvalidOperationException($"No opening entry exists for order {orderId.Value}");
+
+        var existingEntry = _entries[entryIndex];
+        if (cumulativeQuantity < existingEntry.Quantity)
+            throw new InvalidOperationException("Cumulative quantity cannot be lower than the already applied quantity");
+
+        if (cumulativeQuantity == existingEntry.Quantity)
+            return;
+
+        var now = timestamp ?? DateTimeOffset.UtcNow;
+        var updatedEntry = PositionEntry.Create(
+            orderId,
+            averagePrice,
+            cumulativeQuantity,
+            cumulativeFees,
+            existingEntry.Timestamp,
+            existingEntry.IsMigrated);
+
+        _entries[entryIndex] = updatedEntry;
+        LastBuyAt = now;
+    }
+
+    /// <summary>
     /// Closes the position with a sell order.
     /// </summary>
     public void Close(

--- a/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
@@ -1,0 +1,47 @@
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Domain.Trading.Events;
+
+/// <summary>
+/// Domain event raised when a sell order partially reduces an open position.
+/// </summary>
+public sealed record PositionPartiallyClosed : IDomainEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+    public string? CorrelationId { get; }
+    public PositionId PositionId { get; }
+    public TradingPair Pair { get; }
+    public OrderId SellOrderId { get; }
+    public Price SellPrice { get; }
+    public Quantity SoldQuantity { get; }
+    public Quantity RemainingQuantity { get; }
+    public Money Proceeds { get; }
+    public Money ReleasedCost { get; }
+    public Money SellFees { get; }
+
+    public PositionPartiallyClosed(
+        PositionId positionId,
+        TradingPair pair,
+        OrderId sellOrderId,
+        Price sellPrice,
+        Quantity soldQuantity,
+        Quantity remainingQuantity,
+        Money proceeds,
+        Money releasedCost,
+        Money sellFees,
+        string? correlationId = null)
+    {
+        PositionId = positionId;
+        Pair = pair;
+        SellOrderId = sellOrderId;
+        SellPrice = sellPrice;
+        SoldQuantity = soldQuantity;
+        RemainingQuantity = remainingQuantity;
+        Proceeds = proceeds;
+        ReleasedCost = releasedCost;
+        SellFees = sellFees;
+        CorrelationId = correlationId;
+    }
+}

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -187,6 +187,9 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
         if (filledQuantity.IsZero)
             throw new ArgumentException("Filled quantity cannot be zero", nameof(filledQuantity));
 
+        if (filledQuantity > RequestedQuantity)
+            throw new ArgumentException("Filled quantity cannot exceed requested quantity.", nameof(filledQuantity));
+
         if (averagePrice.IsZero)
             throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
 

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -33,7 +33,7 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
 
     public bool CanAffectPosition =>
         Status is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled ||
-        Status == OrderLifecycleStatus.Canceled && Side == OrderSide.Buy && !FilledQuantity.IsZero;
+        Status == OrderLifecycleStatus.Canceled && !FilledQuantity.IsZero;
 
     public bool HasUnappliedFill =>
         CanAffectPosition && FilledQuantity > AppliedQuantity;

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -1,0 +1,237 @@
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Domain.Trading.Orders;
+
+/// <summary>
+/// Domain state machine for an order submitted to the exchange.
+/// Tracks the lifecycle needed by the new Application handlers without
+/// depending on transport-specific exchange statuses.
+/// </summary>
+public sealed class OrderLifecycle : AggregateRoot<OrderId>
+{
+    private OrderLifecycle() { }
+
+    public TradingPair Pair { get; private set; } = null!;
+    public OrderSide Side { get; private set; }
+    public OrderType Type { get; private set; }
+    public Quantity RequestedQuantity { get; private set; } = Quantity.Zero;
+    public Quantity FilledQuantity { get; private set; } = Quantity.Zero;
+    public Price SubmittedPrice { get; private set; } = Price.Zero;
+    public Price AveragePrice { get; private set; } = Price.Zero;
+    public Money Cost { get; private set; } = null!;
+    public Money Fees { get; private set; } = null!;
+    public Quantity AppliedQuantity { get; private set; } = Quantity.Zero;
+    public Money AppliedCost { get; private set; } = null!;
+    public Money AppliedFees { get; private set; } = null!;
+    public string? SignalRule { get; private set; }
+    public OrderIntent Intent { get; private set; }
+    public PositionId? RelatedPositionId { get; private set; }
+    public DateTimeOffset SubmittedAt { get; private set; }
+    public OrderLifecycleStatus Status { get; private set; }
+
+    public bool CanAffectPosition =>
+        Status is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled;
+
+    public bool HasUnappliedFill =>
+        CanAffectPosition && FilledQuantity > AppliedQuantity;
+
+    public Quantity UnappliedQuantity => FilledQuantity - AppliedQuantity;
+
+    public Money UnappliedCost => Cost - AppliedCost;
+
+    public Money UnappliedFees => Fees - AppliedFees;
+
+    public bool IsTerminal =>
+        Status is OrderLifecycleStatus.Filled or OrderLifecycleStatus.Canceled or OrderLifecycleStatus.Rejected;
+
+    public static OrderLifecycle Submit(
+        OrderId orderId,
+        TradingPair pair,
+        OrderSide side,
+        OrderType type,
+        Quantity requestedQuantity,
+        Price submittedPrice,
+        string? signalRule = null,
+        DateTimeOffset? timestamp = null,
+        OrderIntent intent = OrderIntent.Unknown,
+        PositionId? relatedPositionId = null)
+    {
+        ArgumentNullException.ThrowIfNull(orderId);
+        ArgumentNullException.ThrowIfNull(pair);
+        ArgumentNullException.ThrowIfNull(requestedQuantity);
+        ArgumentNullException.ThrowIfNull(submittedPrice);
+
+        if (requestedQuantity.IsZero)
+            throw new ArgumentException("Requested quantity cannot be zero", nameof(requestedQuantity));
+
+        if (intent is OrderIntent.ClosePosition or OrderIntent.ExecuteDca && relatedPositionId is null)
+            throw new ArgumentException("Related position ID is required for close and DCA orders.", nameof(relatedPositionId));
+
+        if (intent == OrderIntent.OpenPosition && relatedPositionId is not null)
+            throw new ArgumentException("Open position orders cannot reference an existing position.", nameof(relatedPositionId));
+
+        var submittedAt = timestamp ?? DateTimeOffset.UtcNow;
+        var order = new OrderLifecycle
+        {
+            Id = orderId,
+            Pair = pair,
+            Side = side,
+            Type = type,
+            RequestedQuantity = requestedQuantity,
+            SubmittedPrice = submittedPrice,
+            AveragePrice = Price.Zero,
+            FilledQuantity = Quantity.Zero,
+            Cost = Money.Zero(pair.QuoteCurrency),
+            Fees = Money.Zero(pair.QuoteCurrency),
+            AppliedQuantity = Quantity.Zero,
+            AppliedCost = Money.Zero(pair.QuoteCurrency),
+            AppliedFees = Money.Zero(pair.QuoteCurrency),
+            SignalRule = signalRule,
+            Intent = intent,
+            RelatedPositionId = relatedPositionId,
+            SubmittedAt = submittedAt,
+            Status = OrderLifecycleStatus.Submitted
+        };
+
+        order.AddDomainEvent(new OrderPlacedEvent(
+            orderId.Value,
+            pair.Symbol,
+            side,
+            requestedQuantity.Value,
+            submittedPrice.Value,
+            type,
+            isManual: false,
+            signalRule: signalRule));
+
+        return order;
+    }
+
+    public void MarkPartiallyFilled(
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees)
+    {
+        ApplyFill(OrderLifecycleStatus.PartiallyFilled, filledQuantity, averagePrice, cost, fees, isPartialFill: true);
+    }
+
+    public void MarkFilled(
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees)
+    {
+        ApplyFill(OrderLifecycleStatus.Filled, filledQuantity, averagePrice, cost, fees, isPartialFill: false);
+    }
+
+    public void Cancel()
+    {
+        TransitionTo(OrderLifecycleStatus.Canceled);
+    }
+
+    public void Reject()
+    {
+        TransitionTo(OrderLifecycleStatus.Rejected);
+    }
+
+    public void MarkCurrentFillApplied()
+    {
+        if (!CanAffectPosition)
+        {
+            throw new InvalidOperationException(
+                $"Cannot mark order {Id.Value} as applied because status {Status} has no fill.");
+        }
+
+        AppliedQuantity = FilledQuantity;
+        AppliedCost = Cost;
+        AppliedFees = Fees;
+    }
+
+    private void ApplyFill(
+        OrderLifecycleStatus targetStatus,
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees,
+        bool isPartialFill)
+    {
+        ArgumentNullException.ThrowIfNull(filledQuantity);
+        ArgumentNullException.ThrowIfNull(averagePrice);
+        ArgumentNullException.ThrowIfNull(cost);
+        ArgumentNullException.ThrowIfNull(fees);
+
+        if (filledQuantity.IsZero)
+            throw new ArgumentException("Filled quantity cannot be zero", nameof(filledQuantity));
+
+        if (averagePrice.IsZero)
+            throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
+
+        TransitionTo(targetStatus);
+
+        FilledQuantity = filledQuantity;
+        AveragePrice = averagePrice;
+        Cost = cost;
+        Fees = fees;
+
+        AddDomainEvent(new OrderFilledEvent(
+            Id.Value,
+            Pair.Symbol,
+            Side,
+            filledQuantity.Value,
+            averagePrice.Value,
+            cost.Amount,
+            fees.Amount,
+            isPartialFill));
+    }
+
+    private void TransitionTo(OrderLifecycleStatus nextStatus)
+    {
+        if (!CanTransitionTo(nextStatus))
+        {
+            throw new InvalidOperationException(
+                $"Cannot transition order {Id.Value} from {Status} to {nextStatus}.");
+        }
+
+        Status = nextStatus;
+    }
+
+    private bool CanTransitionTo(OrderLifecycleStatus nextStatus)
+    {
+        return Status switch
+        {
+            OrderLifecycleStatus.Submitted => nextStatus is
+                OrderLifecycleStatus.PartiallyFilled or
+                OrderLifecycleStatus.Filled or
+                OrderLifecycleStatus.Canceled or
+                OrderLifecycleStatus.Rejected,
+
+            OrderLifecycleStatus.PartiallyFilled => nextStatus is
+                OrderLifecycleStatus.Filled or
+                OrderLifecycleStatus.Canceled,
+
+            OrderLifecycleStatus.Filled => false,
+            OrderLifecycleStatus.Canceled => false,
+            OrderLifecycleStatus.Rejected => false,
+            _ => false
+        };
+    }
+}
+
+public enum OrderLifecycleStatus
+{
+    Submitted,
+    PartiallyFilled,
+    Filled,
+    Canceled,
+    Rejected
+}
+
+public enum OrderIntent
+{
+    Unknown,
+    OpenPosition,
+    ClosePosition,
+    ExecuteDca
+}

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -149,6 +149,28 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
         AppliedFees = Fees;
     }
 
+    /// <summary>
+    /// Links an open-position order to the position created from its first applied fill.
+    /// </summary>
+    public void LinkRelatedPosition(PositionId positionId)
+    {
+        ArgumentNullException.ThrowIfNull(positionId);
+
+        if (Intent != OrderIntent.OpenPosition)
+        {
+            throw new InvalidOperationException(
+                $"Only open position orders can be linked after submission. Order {Id.Value} has intent {Intent}.");
+        }
+
+        if (RelatedPositionId is not null && RelatedPositionId != positionId)
+        {
+            throw new InvalidOperationException(
+                $"Order {Id.Value} is already linked to position {RelatedPositionId.Value}.");
+        }
+
+        RelatedPositionId = positionId;
+    }
+
     private void ApplyFill(
         OrderLifecycleStatus targetStatus,
         Quantity filledQuantity,

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -32,7 +32,8 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
     public OrderLifecycleStatus Status { get; private set; }
 
     public bool CanAffectPosition =>
-        Status is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled;
+        Status is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled ||
+        Status == OrderLifecycleStatus.Canceled && Side == OrderSide.Buy && !FilledQuantity.IsZero;
 
     public bool HasUnappliedFill =>
         CanAffectPosition && FilledQuantity > AppliedQuantity;
@@ -138,7 +139,7 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
 
     public void MarkCurrentFillApplied()
     {
-        if (!CanAffectPosition)
+        if (FilledQuantity.IsZero)
         {
             throw new InvalidOperationException(
                 $"Cannot mark order {Id.Value} as applied because status {Status} has no fill.");

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -190,7 +190,22 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
         if (averagePrice.IsZero)
             throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
 
-        TransitionTo(targetStatus);
+        if (Status == OrderLifecycleStatus.PartiallyFilled &&
+            targetStatus is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled &&
+            filledQuantity < FilledQuantity)
+        {
+            throw new InvalidOperationException("Cumulative filled quantity cannot be lower than the current filled quantity.");
+        }
+
+        if (Status == targetStatus && targetStatus == OrderLifecycleStatus.PartiallyFilled)
+        {
+            if (filledQuantity == FilledQuantity && averagePrice == AveragePrice && cost == Cost && fees == Fees)
+                return;
+        }
+        else
+        {
+            TransitionTo(targetStatus);
+        }
 
         FilledQuantity = filledQuantity;
         AveragePrice = averagePrice;

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonOrderRepository.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonOrderRepository.cs
@@ -1,0 +1,240 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Transactions;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// JSON file-based repository for persisted order lifecycles.
+/// </summary>
+public sealed class JsonOrderRepository : IOrderRepository, IJsonTransactionalResource, IDisposable
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonTransactionCoordinator _transactionCoordinator;
+    private ConcurrentDictionary<string, OrderLifecycleDto> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonOrderRepository(string filePath, JsonTransactionCoordinator? transactionCoordinator = null)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
+
+        _filePath = filePath;
+        _transactionCoordinator = transactionCoordinator ?? JsonTransactionCoordinator.Shared;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<OrderLifecycle?> GetByIdAsync(OrderId id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = GetReadCache();
+        return cache.TryGetValue(id.Value, out var dto) ? OrderLifecycleMapper.FromDto(dto) : null;
+    }
+
+    public async Task<IReadOnlyList<OrderLifecycle>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return GetReadCache().Values
+            .OrderByDescending(dto => dto.SubmittedAt)
+            .Select(OrderLifecycleMapper.FromDto)
+            .ToList();
+    }
+
+    public async Task SaveAsync(OrderLifecycle order, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = GetWriteCache();
+        cache[order.Id.Value] = OrderLifecycleMapper.ToDto(order);
+
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+            return;
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            _cache = new ConcurrentDictionary<string, OrderLifecycleDto>(StringComparer.OrdinalIgnoreCase);
+            _cacheLoaded = true;
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _cache = new ConcurrentDictionary<string, OrderLifecycleDto>(StringComparer.OrdinalIgnoreCase);
+            _cacheLoaded = true;
+            return;
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<OrderLifecycleDto>>(json, _jsonOptions)
+                   ?? new List<OrderLifecycleDto>();
+
+        _cache = new ConcurrentDictionary<string, OrderLifecycleDto>(
+            dtos.ToDictionary(dto => dto.Id, StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+
+        _cacheLoaded = true;
+    }
+
+    private ConcurrentDictionary<string, OrderLifecycleDto> GetReadCache()
+    {
+        if (_transactionCoordinator.TryGetState(this, out ConcurrentDictionary<string, OrderLifecycleDto>? stagedCache))
+        {
+            return stagedCache;
+        }
+
+        return _cache;
+    }
+
+    private ConcurrentDictionary<string, OrderLifecycleDto> GetWriteCache()
+    {
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            return _cache;
+        }
+
+        return _transactionCoordinator.GetOrCreateState(this, CloneCache);
+    }
+
+    private ConcurrentDictionary<string, OrderLifecycleDto> CloneCache()
+    {
+        var json = JsonSerializer.Serialize(_cache.Values.ToList(), _jsonOptions);
+        var dtos = JsonSerializer.Deserialize<List<OrderLifecycleDto>>(json, _jsonOptions)
+                   ?? new List<OrderLifecycleDto>();
+
+        return new ConcurrentDictionary<string, OrderLifecycleDto>(
+            dtos.ToDictionary(dto => dto.Id, StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task PersistCacheAsync(
+        ConcurrentDictionary<string, OrderLifecycleDto> cache,
+        CancellationToken cancellationToken)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var dtos = cache.Values
+                .OrderByDescending(dto => dto.SubmittedAt)
+                .ToList();
+
+            var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+            await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task<JsonPreparedWrite?> IJsonTransactionalResource.PrepareCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<string, OrderLifecycleDto>? stagedCache))
+        {
+            return Task.FromResult<JsonPreparedWrite?>(null);
+        }
+
+        var dtos = stagedCache.Values
+            .OrderByDescending(dto => dto.SubmittedAt)
+            .ToList();
+
+        var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+        return Task.FromResult<JsonPreparedWrite?>(new JsonPreparedWrite(_filePath, json));
+    }
+
+    async Task IJsonTransactionalResource.AcceptCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<string, OrderLifecycleDto>? stagedCache))
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cache = stagedCache;
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task IJsonTransactionalResource.RollbackAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonOrderRepository.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonOrderRepository.cs
@@ -226,7 +226,12 @@ public sealed class JsonOrderRepository : IOrderRepository, IJsonTransactionalRe
         JsonTransaction transaction,
         CancellationToken cancellationToken)
     {
-        return Task.CompletedTask;
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<string, OrderLifecycleDto>? _))
+        {
+            return Task.CompletedTask;
+        }
+
+        return ReloadAsync(cancellationToken);
     }
 
     public void Dispose()

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPortfolioRepository.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPortfolioRepository.cs
@@ -1,0 +1,341 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Transactions;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// JSON file-based repository for Portfolio aggregates.
+/// Supports a single default portfolio while allowing additional named portfolios.
+/// </summary>
+public sealed class JsonPortfolioRepository : IPortfolioRepository, IJsonTransactionalResource, IDisposable
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonTransactionCoordinator _transactionCoordinator;
+    private ConcurrentDictionary<Guid, PortfolioDto> _cache = new();
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonPortfolioRepository(string filePath, JsonTransactionCoordinator? transactionCoordinator = null)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
+
+        _filePath = filePath;
+        _transactionCoordinator = transactionCoordinator ?? JsonTransactionCoordinator.Shared;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<Portfolio?> GetByIdAsync(PortfolioId id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = GetReadCache();
+        return cache.TryGetValue(id.Value, out var dto) ? PortfolioMapper.FromDto(dto) : null;
+    }
+
+    public async Task<Portfolio?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be null or empty", nameof(name));
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var dto = GetReadCache().Values.FirstOrDefault(p =>
+            p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        return dto is null ? null : PortfolioMapper.FromDto(dto);
+    }
+
+    public async Task<Portfolio?> GetDefaultAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var dto = GetReadCache().Values
+            .OrderByDescending(p => p.IsDefault)
+            .ThenBy(p => p.CreatedAt)
+            .FirstOrDefault();
+
+        return dto is null ? null : PortfolioMapper.FromDto(dto);
+    }
+
+    public async Task<IReadOnlyList<Portfolio>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return GetReadCache().Values
+            .OrderByDescending(p => p.IsDefault)
+            .ThenBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(PortfolioMapper.FromDto)
+            .ToList();
+    }
+
+    public async Task SaveAsync(Portfolio portfolio, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(portfolio);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = GetWriteCache();
+        var isDefault = ResolveDefaultFlag(cache, portfolio.Id.Value);
+        var dto = PortfolioMapper.ToDto(portfolio, isDefault);
+        cache[portfolio.Id.Value] = dto;
+
+        if (isDefault)
+        {
+            PromoteDefaultPortfolio(cache, portfolio.Id.Value);
+        }
+
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task DeleteAsync(PortfolioId id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = GetWriteCache();
+        var removedWasDefault = cache.TryGetValue(id.Value, out var existing) && existing.IsDefault;
+        if (!cache.TryRemove(id.Value, out _))
+        {
+            return;
+        }
+
+        if (removedWasDefault)
+        {
+            PromoteOldestPortfolioAsDefault(cache);
+        }
+
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<bool> ExistsWithNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be null or empty", nameof(name));
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+        return GetReadCache().Values.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private bool ResolveDefaultFlag(
+        ConcurrentDictionary<Guid, PortfolioDto> cache,
+        Guid portfolioId)
+    {
+        if (cache.TryGetValue(portfolioId, out var existing))
+        {
+            return existing.IsDefault || !cache.Values.Any(p => p.IsDefault);
+        }
+
+        return cache.IsEmpty || !cache.Values.Any(p => p.IsDefault);
+    }
+
+    private static void PromoteDefaultPortfolio(
+        ConcurrentDictionary<Guid, PortfolioDto> cache,
+        Guid defaultPortfolioId)
+    {
+        foreach (var dto in cache.Values)
+        {
+            dto.IsDefault = dto.Id == defaultPortfolioId;
+        }
+    }
+
+    private static void PromoteOldestPortfolioAsDefault(ConcurrentDictionary<Guid, PortfolioDto> cache)
+    {
+        var nextDefault = cache.Values.OrderBy(p => p.CreatedAt).FirstOrDefault();
+        if (nextDefault is null)
+            return;
+
+        PromoteDefaultPortfolio(cache, nextDefault.Id);
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded) return;
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            _cache = new ConcurrentDictionary<Guid, PortfolioDto>();
+            _cacheLoaded = true;
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _cache = new ConcurrentDictionary<Guid, PortfolioDto>();
+            _cacheLoaded = true;
+            return;
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<PortfolioDto>>(json, _jsonOptions) ?? new List<PortfolioDto>();
+        _cache = new ConcurrentDictionary<Guid, PortfolioDto>(dtos.ToDictionary(d => d.Id));
+
+        if (_cache.Count > 0 && !_cache.Values.Any(p => p.IsDefault))
+        {
+            PromoteOldestPortfolioAsDefault(_cache);
+        }
+
+        _cacheLoaded = true;
+    }
+
+    private ConcurrentDictionary<Guid, PortfolioDto> GetReadCache()
+    {
+        if (_transactionCoordinator.TryGetState(this, out ConcurrentDictionary<Guid, PortfolioDto>? stagedCache))
+        {
+            return stagedCache;
+        }
+
+        return _cache;
+    }
+
+    private ConcurrentDictionary<Guid, PortfolioDto> GetWriteCache()
+    {
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            return _cache;
+        }
+
+        return _transactionCoordinator.GetOrCreateState(this, CloneCache);
+    }
+
+    private ConcurrentDictionary<Guid, PortfolioDto> CloneCache()
+    {
+        var json = JsonSerializer.Serialize(_cache.Values.ToList(), _jsonOptions);
+        var dtos = JsonSerializer.Deserialize<List<PortfolioDto>>(json, _jsonOptions) ?? new List<PortfolioDto>();
+        var clone = new ConcurrentDictionary<Guid, PortfolioDto>(dtos.ToDictionary(d => d.Id));
+
+        if (clone.Count > 0 && !clone.Values.Any(p => p.IsDefault))
+        {
+            PromoteOldestPortfolioAsDefault(clone);
+        }
+
+        return clone;
+    }
+
+    private async Task PersistCacheAsync(
+        ConcurrentDictionary<Guid, PortfolioDto> cache,
+        CancellationToken cancellationToken)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var dtos = cache.Values
+                .OrderByDescending(p => p.IsDefault)
+                .ThenBy(p => p.CreatedAt)
+                .ToList();
+
+            var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+            await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task<JsonPreparedWrite?> IJsonTransactionalResource.PrepareCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, PortfolioDto>? stagedCache))
+        {
+            return Task.FromResult<JsonPreparedWrite?>(null);
+        }
+
+        var dtos = stagedCache.Values
+            .OrderByDescending(p => p.IsDefault)
+            .ThenBy(p => p.CreatedAt)
+            .ToList();
+
+        var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+        return Task.FromResult<JsonPreparedWrite?>(new JsonPreparedWrite(_filePath, json));
+    }
+
+    async Task IJsonTransactionalResource.AcceptCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, PortfolioDto>? stagedCache))
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cache = stagedCache;
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task IJsonTransactionalResource.RollbackAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPortfolioRepository.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPortfolioRepository.cs
@@ -328,7 +328,12 @@ public sealed class JsonPortfolioRepository : IPortfolioRepository, IJsonTransac
         JsonTransaction transaction,
         CancellationToken cancellationToken)
     {
-        return Task.CompletedTask;
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, PortfolioDto>? _))
+        {
+            return Task.CompletedTask;
+        }
+
+        return ReloadAsync(cancellationToken);
     }
 
     public void Dispose()

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPositionRepository.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonPositionRepository.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Transactions;
 
 namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
 
@@ -10,11 +11,12 @@ namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
 /// JSON file-based repository for Position aggregates.
 /// Thread-safe implementation using file locking and in-memory cache.
 /// </summary>
-public sealed class JsonPositionRepository : IPositionRepository, IDisposable
+public sealed class JsonPositionRepository : IPositionRepository, IJsonTransactionalResource, IDisposable
 {
     private readonly string _filePath;
     private readonly SemaphoreSlim _fileLock = new(1, 1);
     private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonTransactionCoordinator _transactionCoordinator;
     private ConcurrentDictionary<Guid, PositionDto> _cache = new();
     private bool _cacheLoaded;
     private bool _disposed;
@@ -23,12 +25,13 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
     /// Creates a new JsonPositionRepository.
     /// </summary>
     /// <param name="filePath">The path to the JSON file for position storage.</param>
-    public JsonPositionRepository(string filePath)
+    public JsonPositionRepository(string filePath, JsonTransactionCoordinator? transactionCoordinator = null)
     {
         if (string.IsNullOrWhiteSpace(filePath))
             throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
 
         _filePath = filePath;
+        _transactionCoordinator = transactionCoordinator ?? JsonTransactionCoordinator.Shared;
         _jsonOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -42,7 +45,8 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(id);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        return _cache.TryGetValue(id.Value, out var dto) ? PositionMapper.FromDto(dto) : null;
+        var cache = GetReadCache();
+        return cache.TryGetValue(id.Value, out var dto) ? PositionMapper.FromDto(dto) : null;
     }
 
     /// <inheritdoc />
@@ -51,7 +55,7 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(pair);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        var dto = _cache.Values
+        var dto = GetReadCache().Values
             .FirstOrDefault(p => !p.IsClosed &&
                                  p.Pair.Symbol.Equals(pair.Symbol, StringComparison.OrdinalIgnoreCase));
 
@@ -63,7 +67,7 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
     {
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        return _cache.Values
+        return GetReadCache().Values
             .Where(p => !p.IsClosed)
             .Select(PositionMapper.FromDto)
             .ToList();
@@ -77,7 +81,7 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(portfolioId);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        return _cache.Values
+        return GetReadCache().Values
             .Where(p => p.PortfolioId == portfolioId.Value)
             .Select(PositionMapper.FromDto)
             .ToList();
@@ -91,7 +95,7 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
     {
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        return _cache.Values
+        return GetReadCache().Values
             .Where(p => p.IsClosed &&
                         p.ClosedAt.HasValue &&
                         p.ClosedAt.Value >= from &&
@@ -106,17 +110,22 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(position);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
+        var cache = GetWriteCache();
+
         // Preserve existing portfolio association if present
         PortfolioId? portfolioId = null;
-        if (_cache.TryGetValue(position.Id.Value, out var existingDto))
+        if (cache.TryGetValue(position.Id.Value, out var existingDto))
         {
             portfolioId = PositionMapper.GetPortfolioId(existingDto);
         }
 
         var dto = PositionMapper.ToDto(position, portfolioId);
-        _cache[position.Id.Value] = dto;
+        cache[position.Id.Value] = dto;
 
-        await PersistCacheAsync(cancellationToken).ConfigureAwait(false);
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
@@ -125,19 +134,23 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(positions);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
+        var cache = GetWriteCache();
         foreach (var position in positions)
         {
             PortfolioId? portfolioId = null;
-            if (_cache.TryGetValue(position.Id.Value, out var existingDto))
+            if (cache.TryGetValue(position.Id.Value, out var existingDto))
             {
                 portfolioId = PositionMapper.GetPortfolioId(existingDto);
             }
 
             var dto = PositionMapper.ToDto(position, portfolioId);
-            _cache[position.Id.Value] = dto;
+            cache[position.Id.Value] = dto;
         }
 
-        await PersistCacheAsync(cancellationToken).ConfigureAwait(false);
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
@@ -146,9 +159,10 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(id);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_cache.TryRemove(id.Value, out _))
+        var cache = GetWriteCache();
+        if (cache.TryRemove(id.Value, out _) && !_transactionCoordinator.HasActiveTransaction)
         {
-            await PersistCacheAsync(cancellationToken).ConfigureAwait(false);
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -158,15 +172,15 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(pair);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        return _cache.Values.Any(p => !p.IsClosed &&
-                                      p.Pair.Symbol.Equals(pair.Symbol, StringComparison.OrdinalIgnoreCase));
+        return GetReadCache().Values.Any(p => !p.IsClosed &&
+                                              p.Pair.Symbol.Equals(pair.Symbol, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <inheritdoc />
     public async Task<int> GetActiveCountAsync(CancellationToken cancellationToken = default)
     {
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
-        return _cache.Values.Count(p => !p.IsClosed);
+        return GetReadCache().Values.Count(p => !p.IsClosed);
     }
 
     /// <summary>
@@ -181,10 +195,15 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         ArgumentNullException.ThrowIfNull(portfolioId);
         await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_cache.TryGetValue(positionId.Value, out var dto))
+        var cache = GetWriteCache();
+        if (cache.TryGetValue(positionId.Value, out var dto))
         {
             dto.PortfolioId = portfolioId.Value;
-            await PersistCacheAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!_transactionCoordinator.HasActiveTransaction)
+            {
+                await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 
@@ -246,7 +265,37 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         _cacheLoaded = true;
     }
 
-    private async Task PersistCacheAsync(CancellationToken cancellationToken)
+    private ConcurrentDictionary<Guid, PositionDto> GetReadCache()
+    {
+        if (_transactionCoordinator.TryGetState(this, out ConcurrentDictionary<Guid, PositionDto>? stagedCache))
+        {
+            return stagedCache;
+        }
+
+        return _cache;
+    }
+
+    private ConcurrentDictionary<Guid, PositionDto> GetWriteCache()
+    {
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            return _cache;
+        }
+
+        return _transactionCoordinator.GetOrCreateState(this, CloneCache);
+    }
+
+    private ConcurrentDictionary<Guid, PositionDto> CloneCache()
+    {
+        var json = JsonSerializer.Serialize(_cache.Values.ToList(), _jsonOptions);
+        var dtos = JsonSerializer.Deserialize<List<PositionDto>>(json, _jsonOptions) ?? new List<PositionDto>();
+
+        return new ConcurrentDictionary<Guid, PositionDto>(dtos.ToDictionary(d => d.Id));
+    }
+
+    private async Task PersistCacheAsync(
+        ConcurrentDictionary<Guid, PositionDto> cache,
+        CancellationToken cancellationToken)
     {
         await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -257,7 +306,7 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
                 Directory.CreateDirectory(directory);
             }
 
-            var dtos = _cache.Values.ToList();
+            var dtos = cache.Values.ToList();
             var json = JsonSerializer.Serialize(dtos, _jsonOptions);
             await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
         }
@@ -265,6 +314,47 @@ public sealed class JsonPositionRepository : IPositionRepository, IDisposable
         {
             _fileLock.Release();
         }
+    }
+
+    Task<JsonPreparedWrite?> IJsonTransactionalResource.PrepareCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, PositionDto>? stagedCache))
+        {
+            return Task.FromResult<JsonPreparedWrite?>(null);
+        }
+
+        var json = JsonSerializer.Serialize(stagedCache.Values.ToList(), _jsonOptions);
+        return Task.FromResult<JsonPreparedWrite?>(new JsonPreparedWrite(_filePath, json));
+    }
+
+    async Task IJsonTransactionalResource.AcceptCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, PositionDto>? stagedCache))
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cache = stagedCache;
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task IJsonTransactionalResource.RollbackAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
     }
 
     public void Dispose()

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/OrderLifecycleDto.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/OrderLifecycleDto.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// Data transfer object for OrderLifecycle persistence.
+/// </summary>
+internal sealed class OrderLifecycleDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
+
+    [JsonPropertyName("pair")]
+    public TradingPairDto Pair { get; set; } = null!;
+
+    [JsonPropertyName("side")]
+    public string Side { get; set; } = null!;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = null!;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = null!;
+
+    [JsonPropertyName("requestedQuantity")]
+    public decimal RequestedQuantity { get; set; }
+
+    [JsonPropertyName("filledQuantity")]
+    public decimal FilledQuantity { get; set; }
+
+    [JsonPropertyName("submittedPrice")]
+    public decimal SubmittedPrice { get; set; }
+
+    [JsonPropertyName("averagePrice")]
+    public decimal AveragePrice { get; set; }
+
+    [JsonPropertyName("costAmount")]
+    public decimal CostAmount { get; set; }
+
+    [JsonPropertyName("costCurrency")]
+    public string CostCurrency { get; set; } = null!;
+
+    [JsonPropertyName("feesAmount")]
+    public decimal FeesAmount { get; set; }
+
+    [JsonPropertyName("feesCurrency")]
+    public string FeesCurrency { get; set; } = null!;
+
+    [JsonPropertyName("appliedQuantity")]
+    public decimal AppliedQuantity { get; set; }
+
+    [JsonPropertyName("appliedCostAmount")]
+    public decimal AppliedCostAmount { get; set; }
+
+    [JsonPropertyName("appliedCostCurrency")]
+    public string? AppliedCostCurrency { get; set; }
+
+    [JsonPropertyName("appliedFeesAmount")]
+    public decimal AppliedFeesAmount { get; set; }
+
+    [JsonPropertyName("appliedFeesCurrency")]
+    public string? AppliedFeesCurrency { get; set; }
+
+    [JsonPropertyName("signalRule")]
+    public string? SignalRule { get; set; }
+
+    [JsonPropertyName("intent")]
+    public string? Intent { get; set; }
+
+    [JsonPropertyName("relatedPositionId")]
+    public string? RelatedPositionId { get; set; }
+
+    [JsonPropertyName("submittedAt")]
+    public DateTimeOffset SubmittedAt { get; set; }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/OrderLifecycleMapper.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/OrderLifecycleMapper.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// Maps between OrderLifecycle aggregates and DTOs for JSON persistence.
+/// </summary>
+internal static class OrderLifecycleMapper
+{
+    public static OrderLifecycleDto ToDto(OrderLifecycle order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+
+        return new OrderLifecycleDto
+        {
+            Id = order.Id.Value,
+            Pair = new TradingPairDto
+            {
+                Symbol = order.Pair.Symbol,
+                QuoteCurrency = order.Pair.QuoteCurrency
+            },
+            Side = order.Side.ToString(),
+            Type = order.Type.ToString(),
+            Status = order.Status.ToString(),
+            RequestedQuantity = order.RequestedQuantity.Value,
+            FilledQuantity = order.FilledQuantity.Value,
+            SubmittedPrice = order.SubmittedPrice.Value,
+            AveragePrice = order.AveragePrice.Value,
+            CostAmount = order.Cost.Amount,
+            CostCurrency = order.Cost.Currency,
+            FeesAmount = order.Fees.Amount,
+            FeesCurrency = order.Fees.Currency,
+            AppliedQuantity = order.AppliedQuantity.Value,
+            AppliedCostAmount = order.AppliedCost.Amount,
+            AppliedCostCurrency = order.AppliedCost.Currency,
+            AppliedFeesAmount = order.AppliedFees.Amount,
+            AppliedFeesCurrency = order.AppliedFees.Currency,
+            SignalRule = order.SignalRule,
+            Intent = order.Intent.ToString(),
+            RelatedPositionId = order.RelatedPositionId?.Value.ToString(),
+            SubmittedAt = order.SubmittedAt
+        };
+    }
+
+    public static OrderLifecycle FromDto(OrderLifecycleDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var order = (OrderLifecycle?)Activator.CreateInstance(
+            typeof(OrderLifecycle),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: null,
+            culture: null);
+
+        if (order is null)
+            throw new InvalidOperationException("Failed to create OrderLifecycle instance.");
+
+        SetPrivateProperty(order, "Id", OrderId.From(dto.Id));
+        SetPrivateProperty(order, "Pair", TradingPair.Create(dto.Pair.Symbol, dto.Pair.QuoteCurrency));
+        SetPrivateProperty(order, "Side", Enum.Parse<DomainOrderSide>(dto.Side, ignoreCase: true));
+        SetPrivateProperty(order, "Type", Enum.Parse<DomainOrderType>(dto.Type, ignoreCase: true));
+        SetPrivateProperty(order, "Status", Enum.Parse<OrderLifecycleStatus>(dto.Status, ignoreCase: true));
+        SetPrivateProperty(order, "RequestedQuantity", Quantity.Create(dto.RequestedQuantity));
+        SetPrivateProperty(order, "FilledQuantity", Quantity.Create(dto.FilledQuantity));
+        SetPrivateProperty(order, "SubmittedPrice", Price.Create(dto.SubmittedPrice));
+        SetPrivateProperty(order, "AveragePrice", Price.Create(dto.AveragePrice));
+        SetPrivateProperty(order, "Cost", Money.Create(dto.CostAmount, dto.CostCurrency));
+        SetPrivateProperty(order, "Fees", Money.Create(dto.FeesAmount, dto.FeesCurrency));
+        SetPrivateProperty(order, "AppliedQuantity", Quantity.Create(dto.AppliedQuantity));
+        SetPrivateProperty(order, "AppliedCost", Money.Create(
+            dto.AppliedCostAmount,
+            string.IsNullOrWhiteSpace(dto.AppliedCostCurrency) ? dto.CostCurrency : dto.AppliedCostCurrency));
+        SetPrivateProperty(order, "AppliedFees", Money.Create(
+            dto.AppliedFeesAmount,
+            string.IsNullOrWhiteSpace(dto.AppliedFeesCurrency) ? dto.FeesCurrency : dto.AppliedFeesCurrency));
+        SetPrivateProperty(order, "SignalRule", dto.SignalRule);
+        SetPrivateProperty(order, "Intent", ParseIntent(dto.Intent));
+        SetPrivateProperty(
+            order,
+            "RelatedPositionId",
+            string.IsNullOrWhiteSpace(dto.RelatedPositionId) ? null : PositionId.From(dto.RelatedPositionId));
+        SetPrivateProperty(order, "SubmittedAt", dto.SubmittedAt);
+
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static OrderIntent ParseIntent(string? intent)
+    {
+        return string.IsNullOrWhiteSpace(intent)
+            ? OrderIntent.Unknown
+            : Enum.Parse<OrderIntent>(intent, ignoreCase: true);
+    }
+
+    private static void SetPrivateProperty(object obj, string propertyName, object? value)
+    {
+        var type = obj.GetType();
+        while (type != null)
+        {
+            var backingField = type.GetField(
+                $"<{propertyName}>k__BackingField",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (backingField != null)
+            {
+                backingField.SetValue(obj, value);
+                return;
+            }
+
+            type = type.BaseType;
+        }
+
+        throw new InvalidOperationException($"Backing field for property '{propertyName}' was not found.");
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/PortfolioDto.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/PortfolioDto.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// Data transfer object for Portfolio aggregate persistence.
+/// </summary>
+internal sealed class PortfolioDto
+{
+    [JsonPropertyName("id")]
+    public Guid Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = null!;
+
+    [JsonPropertyName("market")]
+    public string Market { get; set; } = null!;
+
+    [JsonPropertyName("balance")]
+    public PortfolioBalanceDto Balance { get; set; } = null!;
+
+    [JsonPropertyName("maxPositions")]
+    public int MaxPositions { get; set; }
+
+    [JsonPropertyName("minPositionCost")]
+    public decimal MinPositionCost { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonPropertyName("isDefault")]
+    public bool IsDefault { get; set; }
+
+    [JsonPropertyName("activePositions")]
+    public List<ActivePositionDto> ActivePositions { get; set; } = new();
+
+    [JsonPropertyName("positionCosts")]
+    public List<PositionCostDto> PositionCosts { get; set; } = new();
+}
+
+internal sealed class PortfolioBalanceDto
+{
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = null!;
+
+    [JsonPropertyName("total")]
+    public decimal Total { get; set; }
+
+    [JsonPropertyName("available")]
+    public decimal Available { get; set; }
+
+    [JsonPropertyName("reserved")]
+    public decimal Reserved { get; set; }
+}
+
+internal sealed class ActivePositionDto
+{
+    [JsonPropertyName("pair")]
+    public TradingPairDto Pair { get; set; } = null!;
+
+    [JsonPropertyName("positionId")]
+    public Guid PositionId { get; set; }
+}
+
+internal sealed class PositionCostDto
+{
+    [JsonPropertyName("positionId")]
+    public Guid PositionId { get; set; }
+
+    [JsonPropertyName("amount")]
+    public decimal Amount { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = null!;
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/PortfolioMapper.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/PortfolioMapper.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// Maps between Portfolio domain aggregates and DTOs for JSON persistence.
+/// Uses reflection to rehydrate aggregate internals without exposing mutation APIs.
+/// </summary>
+internal static class PortfolioMapper
+{
+    public static PortfolioDto ToDto(Portfolio portfolio, bool isDefault)
+    {
+        ArgumentNullException.ThrowIfNull(portfolio);
+
+        return new PortfolioDto
+        {
+            Id = portfolio.Id.Value,
+            Name = portfolio.Name,
+            Market = portfolio.Market,
+            Balance = new PortfolioBalanceDto
+            {
+                Currency = portfolio.Balance.Currency,
+                Total = portfolio.Balance.Total.Amount,
+                Available = portfolio.Balance.Available.Amount,
+                Reserved = portfolio.Balance.Reserved.Amount
+            },
+            MaxPositions = portfolio.MaxPositions,
+            MinPositionCost = portfolio.MinPositionCost.Amount,
+            CreatedAt = portfolio.CreatedAt,
+            IsDefault = isDefault,
+            ActivePositions = portfolio.ActivePositions
+                .Select(kvp => new ActivePositionDto
+                {
+                    Pair = new TradingPairDto
+                    {
+                        Symbol = kvp.Key.Symbol,
+                        QuoteCurrency = kvp.Key.QuoteCurrency
+                    },
+                    PositionId = kvp.Value.Value
+                })
+                .ToList(),
+            PositionCosts = portfolio.ActivePositions.Values
+                .Select(positionId => new PositionCostDto
+                {
+                    PositionId = positionId.Value,
+                    Amount = portfolio.GetPositionCost(positionId)?.Amount ?? 0m,
+                    Currency = portfolio.GetPositionCost(positionId)?.Currency ?? portfolio.Market
+                })
+                .ToList()
+        };
+    }
+
+    public static Portfolio FromDto(PortfolioDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var portfolio = Portfolio.Create(
+            dto.Name,
+            dto.Market,
+            dto.Balance.Total,
+            dto.MaxPositions,
+            dto.MinPositionCost);
+
+        SetPrivateProperty(portfolio, "Id", PortfolioId.From(dto.Id));
+        SetPrivateProperty(portfolio, "Name", dto.Name);
+        SetPrivateProperty(portfolio, "Market", dto.Market);
+        SetPrivateProperty(portfolio, "Balance", CreateBalance(dto.Balance));
+        SetPrivateProperty(portfolio, "MaxPositions", dto.MaxPositions);
+        SetPrivateProperty(portfolio, "MinPositionCost", Money.Create(dto.MinPositionCost, dto.Market));
+        SetPrivateProperty(portfolio, "CreatedAt", dto.CreatedAt);
+
+        var activePositionsField = GetPrivateField(portfolio, "_activePositions");
+        if (activePositionsField?.GetValue(portfolio) is Dictionary<TradingPair, PositionId> activePositions)
+        {
+            activePositions.Clear();
+
+            foreach (var activePosition in dto.ActivePositions)
+            {
+                activePositions[TradingPair.Create(activePosition.Pair.Symbol, activePosition.Pair.QuoteCurrency)] =
+                    PositionId.From(activePosition.PositionId);
+            }
+        }
+
+        var positionCostsField = GetPrivateField(portfolio, "_positionCosts");
+        if (positionCostsField?.GetValue(portfolio) is Dictionary<PositionId, Money> positionCosts)
+        {
+            positionCosts.Clear();
+
+            foreach (var positionCost in dto.PositionCosts)
+            {
+                positionCosts[PositionId.From(positionCost.PositionId)] =
+                    Money.Create(positionCost.Amount, positionCost.Currency);
+            }
+        }
+
+        portfolio.ClearDomainEvents();
+        return portfolio;
+    }
+
+    private static PortfolioBalance CreateBalance(PortfolioBalanceDto dto)
+    {
+        var balance = PortfolioBalance.Create(dto.Total, dto.Currency);
+        SetPrivateProperty(balance, "Total", Money.Create(dto.Total, dto.Currency));
+        SetPrivateProperty(balance, "Available", Money.Create(dto.Available, dto.Currency));
+        SetPrivateProperty(balance, "Reserved", Money.Create(dto.Reserved, dto.Currency));
+        return balance;
+    }
+
+    private static void SetPrivateProperty(object obj, string propertyName, object? value)
+    {
+        var type = obj.GetType();
+        while (type != null)
+        {
+            var backingField = type.GetField(
+                $"<{propertyName}>k__BackingField",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (backingField != null)
+            {
+                backingField.SetValue(obj, value);
+                return;
+            }
+
+            type = type.BaseType;
+        }
+    }
+
+    private static FieldInfo? GetPrivateField(object obj, string fieldName)
+    {
+        return obj.GetType().GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance);
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -2,11 +2,16 @@ using Autofac;
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Ports.Driving;
-using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Services;
+using IntelliTrader.Infrastructure.Adapters.Exchange;
 using IntelliTrader.Infrastructure.Adapters.Legacy;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.BackgroundServices;
 using IntelliTrader.Infrastructure.Dispatching;
 using IntelliTrader.Infrastructure.Events;
+using IntelliTrader.Infrastructure.Transactions;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IntelliTrader.Infrastructure;
@@ -19,34 +24,44 @@ public class AppModule : Module
 {
     protected override void Load(ContainerBuilder builder)
     {
+        builder.RegisterType<JsonTransactionCoordinator>()
+            .SingleInstance();
+
+        RegisterServiceProviderAdapter(builder);
         // Register domain event dispatcher
         RegisterDomainEventDispatcher(builder);
 
         // Register CQRS dispatchers
         RegisterDispatchers(builder);
 
+        // Register infrastructure adapters required by Application handlers
+        RegisterPersistence(builder);
+        RegisterPorts(builder);
+
         // Register legacy service adapters
         RegisterLegacyAdapters(builder);
 
-        // Register command handlers
-        RegisterCommandHandlers(builder);
+        // Register application services and handlers
+        RegisterApplicationServices(builder);
+    }
+
+    private static void RegisterServiceProviderAdapter(ContainerBuilder builder)
+    {
+        builder.Register(c =>
+            {
+                var scope = c.Resolve<ILifetimeScope>();
+                return (IServiceProvider)new AutofacServiceProviderAdapter(scope);
+            })
+            .As<IServiceProvider>()
+            .SingleInstance();
     }
 
     private static void RegisterDomainEventDispatcher(ContainerBuilder builder)
     {
-        // InMemoryDomainEventDispatcher's constructor expects Microsoft DI
-        // primitives (System.IServiceProvider, ILogger<T>) that are not
-        // part of the Autofac root container. We adapt them manually here:
-        //   * IServiceProvider is satisfied by a tiny adapter wrapping the
-        //     active Autofac lifetime scope (no extra package required).
-        //   * ILogger<InMemoryDomainEventDispatcher> falls back to
-        //     NullLogger because IntelliTrader uses its own ILoggingService
-        //     and does not configure Microsoft.Extensions.Logging.
         builder.Register(c =>
             {
-                var scope = c.Resolve<ILifetimeScope>();
                 return new InMemoryDomainEventDispatcher(
-                    new AutofacServiceProviderAdapter(scope),
+                    c.Resolve<IServiceProvider>(),
                     NullLogger<InMemoryDomainEventDispatcher>.Instance);
             })
             .As<IDomainEventDispatcher>()
@@ -75,14 +90,63 @@ public class AppModule : Module
 
     private static void RegisterDispatchers(ContainerBuilder builder)
     {
-        // Command dispatcher - singleton, stateless
-        builder.RegisterType<InMemoryCommandDispatcher>()
+        builder.Register(c =>
+            new InMemoryCommandDispatcher(
+                c.Resolve<IServiceProvider>(),
+                NullLogger<InMemoryCommandDispatcher>.Instance))
             .As<ICommandDispatcher>()
             .SingleInstance();
 
-        // Query dispatcher - singleton, stateless
-        builder.RegisterType<InMemoryQueryDispatcher>()
+        builder.Register(c =>
+            new InMemoryQueryDispatcher(
+                c.Resolve<IServiceProvider>(),
+                NullLogger<InMemoryQueryDispatcher>.Instance))
             .As<IQueryDispatcher>()
+            .SingleInstance();
+    }
+
+    private static void RegisterPersistence(ContainerBuilder builder)
+    {
+        builder.Register(_ =>
+            new JsonPositionRepository(CreateDataFilePath("positions.json"), _.Resolve<JsonTransactionCoordinator>()))
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
+            new JsonPortfolioRepository(CreateDataFilePath("portfolios.json"), _.Resolve<JsonTransactionCoordinator>()))
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
+            new JsonOrderRepository(CreateDataFilePath("orders.json"), _.Resolve<JsonTransactionCoordinator>()))
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonTransactionalUnitOfWork(c.Resolve<JsonTransactionCoordinator>()))
+            .As<IUnitOfWork>()
+            .As<ITransactionalUnitOfWork>()
+            .SingleInstance();
+    }
+
+    private static void RegisterPorts(ContainerBuilder builder)
+    {
+        builder.Register(c =>
+            {
+                var exchange =
+                    c.ResolveOptionalNamed<IExchangeService>("Binance") ??
+                    c.ResolveOptional<IExchangeService>() ??
+                    throw new InvalidOperationException("No exchange service is registered for IExchangePort.");
+
+                return new BinanceExchangeAdapter(exchange);
+            })
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        builder.RegisterType<SubmittedOrderRefreshService>()
+            .As<ISubmittedOrderRefreshService>()
             .SingleInstance();
     }
 
@@ -94,21 +158,37 @@ public class AppModule : Module
             .SingleInstance();
     }
 
-    private static void RegisterCommandHandlers(ContainerBuilder builder)
+    private static void RegisterApplicationServices(ContainerBuilder builder)
     {
-        // PlaceBuyOrderHandler
-        builder.RegisterType<PlaceBuyOrderHandler>()
-            .As<ICommandHandler<PlaceBuyOrderCommand, PlaceBuyOrderResult>>()
+        var applicationAssembly = typeof(OpenPositionHandler).Assembly;
+
+        builder.RegisterType<TradingConstraintValidator>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterAssemblyTypes(applicationAssembly)
+            .AsClosedTypesOf(typeof(ICommandHandler<,>))
+            .AsImplementedInterfaces()
             .InstancePerDependency();
 
-        // PlaceSellOrderHandler
-        builder.RegisterType<PlaceSellOrderHandler>()
-            .As<ICommandHandler<PlaceSellOrderCommand, PlaceSellOrderResult>>()
+        builder.RegisterAssemblyTypes(applicationAssembly)
+            .AsClosedTypesOf(typeof(ICommandHandler<>))
+            .AsImplementedInterfaces()
             .InstancePerDependency();
 
-        // PlaceSwapOrderHandler
-        builder.RegisterType<PlaceSwapOrderHandler>()
-            .As<ICommandHandler<PlaceSwapOrderCommand, PlaceSwapOrderResult>>()
+        builder.RegisterAssemblyTypes(applicationAssembly)
+            .AsClosedTypesOf(typeof(IQueryHandler<,>))
+            .AsImplementedInterfaces()
             .InstancePerDependency();
+
+        builder.RegisterAssemblyTypes(typeof(AppModule).Assembly)
+            .AsClosedTypesOf(typeof(IDomainEventHandler<>))
+            .AsImplementedInterfaces()
+            .SingleInstance();
+    }
+
+    private static string CreateDataFilePath(string fileName)
+    {
+        return Path.Combine(Directory.GetCurrentDirectory(), "data", fileName);
     }
 }

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -145,7 +145,8 @@ public class AppModule : Module
             .As<IExchangePort>()
             .SingleInstance();
 
-        builder.RegisterType<SubmittedOrderRefreshService>()
+        builder.RegisterType<ActiveOrderRefreshService>()
+            .As<IActiveOrderRefreshService>()
             .As<ISubmittedOrderRefreshService>()
             .SingleInstance();
     }

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -2,6 +2,7 @@ using Autofac;
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Core;
 using IntelliTrader.Domain.Trading.Services;
@@ -165,6 +166,10 @@ public class AppModule : Module
 
         builder.RegisterType<TradingConstraintValidator>()
             .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterType<TradingUseCase>()
+            .As<ITradingUseCase>()
             .SingleInstance();
 
         builder.RegisterAssemblyTypes(applicationAssembly)

--- a/IntelliTrader.Infrastructure/BackgroundServices/ActiveOrderRefreshService.cs
+++ b/IntelliTrader.Infrastructure/BackgroundServices/ActiveOrderRefreshService.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace IntelliTrader.Infrastructure.BackgroundServices;
 
 /// <summary>
-/// Core-facing lifecycle manager for submitted-order refresh background work.
+/// Core-facing lifecycle manager for active-order refresh background work.
 /// Creates a fresh <see cref="OrderStatusRefreshService"/> instance on each start
 /// because <see cref="Microsoft.Extensions.Hosting.BackgroundService"/> instances are
 /// not intended to be restarted after stop.
 /// </summary>
-public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
+public sealed class ActiveOrderRefreshService : IActiveOrderRefreshService, ISubmittedOrderRefreshService
 {
     private readonly ILoggingService _loggingService;
     private readonly ICommandDispatcher _commandDispatcher;
@@ -18,14 +18,14 @@ public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
     private CancellationTokenSource? _cts;
     private OrderStatusRefreshService? _backgroundService;
 
-    public SubmittedOrderRefreshService(
+    public ActiveOrderRefreshService(
         ILoggingService loggingService,
         ICommandDispatcher commandDispatcher)
         : this(loggingService, commandDispatcher, new OrderStatusRefreshOptions())
     {
     }
 
-    public SubmittedOrderRefreshService(
+    public ActiveOrderRefreshService(
         ILoggingService loggingService,
         ICommandDispatcher commandDispatcher,
         OrderStatusRefreshOptions options)
@@ -42,7 +42,7 @@ public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
             return;
         }
 
-        _loggingService.Info("Start submitted order refresh service...");
+        _loggingService.Info("Start active order refresh service...");
 
         _cts = new CancellationTokenSource();
         _backgroundService = new OrderStatusRefreshService(
@@ -52,7 +52,7 @@ public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
 
         _backgroundService.StartAsync(_cts.Token).GetAwaiter().GetResult();
 
-        _loggingService.Info("Submitted order refresh service started");
+        _loggingService.Info("Active order refresh service started");
     }
 
     public void Stop()
@@ -62,7 +62,7 @@ public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
             return;
         }
 
-        _loggingService.Info("Stop submitted order refresh service...");
+        _loggingService.Info("Stop active order refresh service...");
 
         _cts.Cancel();
         _backgroundService?.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
@@ -72,6 +72,6 @@ public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
         _cts = null;
         _backgroundService = null;
 
-        _loggingService.Info("Submitted order refresh service stopped");
+        _loggingService.Info("Active order refresh service stopped");
     }
 }

--- a/IntelliTrader.Infrastructure/BackgroundServices/OrderStatusRefreshService.cs
+++ b/IntelliTrader.Infrastructure/BackgroundServices/OrderStatusRefreshService.cs
@@ -20,13 +20,13 @@ public sealed class OrderStatusRefreshOptions
     public TimeSpan StartDelay { get; set; } = TimeSpan.Zero;
 
     /// <summary>
-    /// Maximum number of submitted orders to refresh per cycle.
+    /// Maximum number of active orders to refresh per cycle.
     /// </summary>
     public int MaxOrdersPerCycle { get; set; } = 50;
 }
 
 /// <summary>
-/// Background service that periodically refreshes submitted orders.
+/// Background service that periodically refreshes active, non-terminal orders.
 /// </summary>
 public sealed class OrderStatusRefreshService : TimedBackgroundService
 {
@@ -47,8 +47,8 @@ public sealed class OrderStatusRefreshService : TimedBackgroundService
 
     protected override async Task ExecuteWorkAsync(CancellationToken stoppingToken)
     {
-        var result = await _commandDispatcher.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
-            new RefreshSubmittedOrdersCommand
+        var result = await _commandDispatcher.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+            new RefreshActiveOrdersCommand
             {
                 Limit = _options.MaxOrdersPerCycle
             },
@@ -57,15 +57,15 @@ public sealed class OrderStatusRefreshService : TimedBackgroundService
         if (result.IsFailure)
         {
             _logger.LogWarning(
-                "Failed to refresh submitted orders: {ErrorCode} {ErrorMessage}",
+                "Failed to refresh active orders: {ErrorCode} {ErrorMessage}",
                 result.Error.Code,
                 result.Error.Message);
             return;
         }
 
         _logger.LogDebug(
-            "Refreshed submitted orders. Submitted={TotalSubmitted}, Attempted={Attempted}, Refreshed={Refreshed}, Applied={Applied}, Failed={Failed}",
-            result.Value.TotalSubmitted,
+            "Refreshed active orders. Active={TotalActive}, Attempted={Attempted}, Refreshed={Refreshed}, Applied={Applied}, Failed={Failed}",
+            result.Value.TotalActive,
             result.Value.AttemptedCount,
             result.Value.RefreshedCount,
             result.Value.AppliedDomainEffectsCount,

--- a/IntelliTrader.Infrastructure/BackgroundServices/OrderStatusRefreshService.cs
+++ b/IntelliTrader.Infrastructure/BackgroundServices/OrderStatusRefreshService.cs
@@ -1,0 +1,74 @@
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace IntelliTrader.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Configuration for the OrderStatusRefreshService.
+/// </summary>
+public sealed class OrderStatusRefreshOptions
+{
+    /// <summary>
+    /// Interval between refresh cycles. Default: 5 seconds.
+    /// </summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Delay before the first refresh cycle. Default: 0 seconds.
+    /// </summary>
+    public TimeSpan StartDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum number of submitted orders to refresh per cycle.
+    /// </summary>
+    public int MaxOrdersPerCycle { get; set; } = 50;
+}
+
+/// <summary>
+/// Background service that periodically refreshes submitted orders.
+/// </summary>
+public sealed class OrderStatusRefreshService : TimedBackgroundService
+{
+    private readonly ILogger<OrderStatusRefreshService> _logger;
+    private readonly ICommandDispatcher _commandDispatcher;
+    private readonly OrderStatusRefreshOptions _options;
+
+    public OrderStatusRefreshService(
+        ILogger<OrderStatusRefreshService> logger,
+        ICommandDispatcher commandDispatcher,
+        OrderStatusRefreshOptions? options = null)
+        : base(logger, options?.Interval ?? TimeSpan.FromSeconds(5), options?.StartDelay)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _commandDispatcher = commandDispatcher ?? throw new ArgumentNullException(nameof(commandDispatcher));
+        _options = options ?? new OrderStatusRefreshOptions();
+    }
+
+    protected override async Task ExecuteWorkAsync(CancellationToken stoppingToken)
+    {
+        var result = await _commandDispatcher.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
+            new RefreshSubmittedOrdersCommand
+            {
+                Limit = _options.MaxOrdersPerCycle
+            },
+            stoppingToken);
+
+        if (result.IsFailure)
+        {
+            _logger.LogWarning(
+                "Failed to refresh submitted orders: {ErrorCode} {ErrorMessage}",
+                result.Error.Code,
+                result.Error.Message);
+            return;
+        }
+
+        _logger.LogDebug(
+            "Refreshed submitted orders. Submitted={TotalSubmitted}, Attempted={Attempted}, Refreshed={Refreshed}, Applied={Applied}, Failed={Failed}",
+            result.Value.TotalSubmitted,
+            result.Value.AttemptedCount,
+            result.Value.RefreshedCount,
+            result.Value.AppliedDomainEffectsCount,
+            result.Value.FailedCount);
+    }
+}

--- a/IntelliTrader.Infrastructure/BackgroundServices/SubmittedOrderRefreshService.cs
+++ b/IntelliTrader.Infrastructure/BackgroundServices/SubmittedOrderRefreshService.cs
@@ -1,0 +1,77 @@
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace IntelliTrader.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Core-facing lifecycle manager for submitted-order refresh background work.
+/// Creates a fresh <see cref="OrderStatusRefreshService"/> instance on each start
+/// because <see cref="Microsoft.Extensions.Hosting.BackgroundService"/> instances are
+/// not intended to be restarted after stop.
+/// </summary>
+public sealed class SubmittedOrderRefreshService : ISubmittedOrderRefreshService
+{
+    private readonly ILoggingService _loggingService;
+    private readonly ICommandDispatcher _commandDispatcher;
+    private readonly OrderStatusRefreshOptions _options;
+    private CancellationTokenSource? _cts;
+    private OrderStatusRefreshService? _backgroundService;
+
+    public SubmittedOrderRefreshService(
+        ILoggingService loggingService,
+        ICommandDispatcher commandDispatcher)
+        : this(loggingService, commandDispatcher, new OrderStatusRefreshOptions())
+    {
+    }
+
+    public SubmittedOrderRefreshService(
+        ILoggingService loggingService,
+        ICommandDispatcher commandDispatcher,
+        OrderStatusRefreshOptions options)
+    {
+        _loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+        _commandDispatcher = commandDispatcher ?? throw new ArgumentNullException(nameof(commandDispatcher));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public void Start()
+    {
+        if (_cts is not null)
+        {
+            return;
+        }
+
+        _loggingService.Info("Start submitted order refresh service...");
+
+        _cts = new CancellationTokenSource();
+        _backgroundService = new OrderStatusRefreshService(
+            NullLogger<OrderStatusRefreshService>.Instance,
+            _commandDispatcher,
+            _options);
+
+        _backgroundService.StartAsync(_cts.Token).GetAwaiter().GetResult();
+
+        _loggingService.Info("Submitted order refresh service started");
+    }
+
+    public void Stop()
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        _loggingService.Info("Stop submitted order refresh service...");
+
+        _cts.Cancel();
+        _backgroundService?.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+        _cts.Dispose();
+        _backgroundService?.Dispose();
+
+        _cts = null;
+        _backgroundService = null;
+
+        _loggingService.Info("Submitted order refresh service stopped");
+    }
+}

--- a/IntelliTrader.Infrastructure/Dispatching/InMemoryCommandDispatcher.cs
+++ b/IntelliTrader.Infrastructure/Dispatching/InMemoryCommandDispatcher.cs
@@ -1,6 +1,7 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driving;
 using Microsoft.Extensions.Logging;
+using System.Reflection;
 
 namespace IntelliTrader.Infrastructure.Dispatching;
 
@@ -61,6 +62,7 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
                     "No handler registered for command {CommandType}",
                     commandType.Name);
 
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result<TResult>.Failure(
                     Error.NotFound("CommandHandler", commandType.Name));
             }
@@ -69,6 +71,7 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
             var handleMethod = handlerType.GetMethod("HandleAsync");
             if (handleMethod is null)
             {
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result<TResult>.Failure(
                     new Error("MethodNotFound", "HandleAsync method not found on handler"));
             }
@@ -79,16 +82,14 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
 
             if (task is null)
             {
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result<TResult>.Failure(
                     new Error("InvocationFailed", "Handler returned null"));
             }
 
             var result = await task.ConfigureAwait(false);
 
-            if (transactionalUnitOfWork?.HasActiveTransaction == true)
-            {
-                await transactionalUnitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            }
+            await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
 
             _logger.LogDebug(
                 "Command {CommandType} handled with success={IsSuccess}",
@@ -99,13 +100,20 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
         }
         catch (Exception ex)
         {
+            var dispatchException = ex is TargetInvocationException { InnerException: not null }
+                ? ex.InnerException
+                : ex;
+
+            var transactionalUnitOfWork = _serviceProvider.GetService(typeof(ITransactionalUnitOfWork)) as ITransactionalUnitOfWork;
+            await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
+
             _logger.LogError(
-                ex,
+                dispatchException,
                 "Exception while dispatching command {CommandType}",
                 commandType.Name);
 
             return Result<TResult>.Failure(
-                new Error("DispatchError", ex.Message));
+                new Error("DispatchError", dispatchException.Message));
         }
     }
 
@@ -138,6 +146,7 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
                     "No handler registered for command {CommandType}",
                     commandType.Name);
 
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result.Failure(
                     Error.NotFound("CommandHandler", commandType.Name));
             }
@@ -146,6 +155,7 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
             var handleMethod = handlerType.GetMethod("HandleAsync");
             if (handleMethod is null)
             {
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result.Failure(
                     new Error("MethodNotFound", "HandleAsync method not found on handler"));
             }
@@ -156,16 +166,14 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
 
             if (task is null)
             {
+                await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
                 return Result.Failure(
                     new Error("InvocationFailed", "Handler returned null"));
             }
 
             var result = await task.ConfigureAwait(false);
 
-            if (transactionalUnitOfWork?.HasActiveTransaction == true)
-            {
-                await transactionalUnitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            }
+            await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
 
             _logger.LogDebug(
                 "Void command {CommandType} handled with success={IsSuccess}",
@@ -176,13 +184,30 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
         }
         catch (Exception ex)
         {
+            var dispatchException = ex is TargetInvocationException { InnerException: not null }
+                ? ex.InnerException
+                : ex;
+
+            var transactionalUnitOfWork = _serviceProvider.GetService(typeof(ITransactionalUnitOfWork)) as ITransactionalUnitOfWork;
+            await RollbackIfActiveAsync(transactionalUnitOfWork, cancellationToken).ConfigureAwait(false);
+
             _logger.LogError(
-                ex,
+                dispatchException,
                 "Exception while dispatching void command {CommandType}",
                 commandType.Name);
 
             return Result.Failure(
-                new Error("DispatchError", ex.Message));
+                new Error("DispatchError", dispatchException.Message));
+        }
+    }
+
+    private static async Task RollbackIfActiveAsync(
+        ITransactionalUnitOfWork? transactionalUnitOfWork,
+        CancellationToken cancellationToken)
+    {
+        if (transactionalUnitOfWork?.HasActiveTransaction == true)
+        {
+            await transactionalUnitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/IntelliTrader.Infrastructure/Dispatching/InMemoryCommandDispatcher.cs
+++ b/IntelliTrader.Infrastructure/Dispatching/InMemoryCommandDispatcher.cs
@@ -45,6 +45,12 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
 
         try
         {
+            var transactionalUnitOfWork = _serviceProvider.GetService(typeof(ITransactionalUnitOfWork)) as ITransactionalUnitOfWork;
+            if (transactionalUnitOfWork is not null)
+            {
+                await transactionalUnitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             // Resolve the handler from DI
             var handlerType = typeof(ICommandHandler<,>).MakeGenericType(commandType, resultType);
             var handler = _serviceProvider.GetService(handlerType);
@@ -79,6 +85,11 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
 
             var result = await task.ConfigureAwait(false);
 
+            if (transactionalUnitOfWork?.HasActiveTransaction == true)
+            {
+                await transactionalUnitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             _logger.LogDebug(
                 "Command {CommandType} handled with success={IsSuccess}",
                 commandType.Name,
@@ -111,6 +122,12 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
 
         try
         {
+            var transactionalUnitOfWork = _serviceProvider.GetService(typeof(ITransactionalUnitOfWork)) as ITransactionalUnitOfWork;
+            if (transactionalUnitOfWork is not null)
+            {
+                await transactionalUnitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             // Resolve the handler from DI
             var handlerType = typeof(ICommandHandler<>).MakeGenericType(commandType);
             var handler = _serviceProvider.GetService(handlerType);
@@ -144,6 +161,11 @@ public sealed class InMemoryCommandDispatcher : ICommandDispatcher
             }
 
             var result = await task.ConfigureAwait(false);
+
+            if (transactionalUnitOfWork?.HasActiveTransaction == true)
+            {
+                await transactionalUnitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             _logger.LogDebug(
                 "Void command {CommandType} handled with success={IsSuccess}",

--- a/IntelliTrader.Infrastructure/Events/OrderFilledAuditHandler.cs
+++ b/IntelliTrader.Infrastructure/Events/OrderFilledAuditHandler.cs
@@ -1,0 +1,31 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Infrastructure.Events;
+
+/// <summary>
+/// Emits audit entries for fully or partially filled exchange orders.
+/// </summary>
+public sealed class OrderFilledAuditHandler : IDomainEventHandler<OrderFilledEvent>
+{
+    private readonly IAuditService _auditService;
+
+    public OrderFilledAuditHandler(IAuditService auditService)
+    {
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+    }
+
+    public Task HandleAsync(OrderFilledEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        var details =
+            $"Order {domainEvent.OrderId} filled for {domainEvent.Pair}. " +
+            $"Side={domainEvent.Side}, FilledAmount={domainEvent.FilledAmount}, AveragePrice={domainEvent.AveragePrice}, " +
+            $"Cost={domainEvent.Cost}, Fees={domainEvent.Fees}, Partial={domainEvent.IsPartialFill}.";
+
+        _auditService.LogAudit("OrderFilled", details);
+        return Task.CompletedTask;
+    }
+}

--- a/IntelliTrader.Infrastructure/Events/OrderPlacedAuditHandler.cs
+++ b/IntelliTrader.Infrastructure/Events/OrderPlacedAuditHandler.cs
@@ -1,0 +1,30 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Infrastructure.Events;
+
+/// <summary>
+/// Emits audit entries for submitted exchange orders.
+/// </summary>
+public sealed class OrderPlacedAuditHandler : IDomainEventHandler<OrderPlacedEvent>
+{
+    private readonly IAuditService _auditService;
+
+    public OrderPlacedAuditHandler(IAuditService auditService)
+    {
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+    }
+
+    public Task HandleAsync(OrderPlacedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        var details =
+            $"Order {domainEvent.OrderId} placed for {domainEvent.Pair}. " +
+            $"Side={domainEvent.Side}, Type={domainEvent.OrderType}, Amount={domainEvent.Amount}, Price={domainEvent.Price}.";
+
+        _auditService.LogAudit("OrderPlaced", details);
+        return Task.CompletedTask;
+    }
+}

--- a/IntelliTrader.Infrastructure/Events/PositionOpenedAuditHandler.cs
+++ b/IntelliTrader.Infrastructure/Events/PositionOpenedAuditHandler.cs
@@ -1,0 +1,32 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Events;
+
+namespace IntelliTrader.Infrastructure.Events;
+
+/// <summary>
+/// Emits audit entries for newly opened positions.
+/// This is the first concrete consumer of domain events in the new pipeline.
+/// </summary>
+public sealed class PositionOpenedAuditHandler : IDomainEventHandler<PositionOpened>
+{
+    private readonly IAuditService _auditService;
+
+    public PositionOpenedAuditHandler(IAuditService auditService)
+    {
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+    }
+
+    public Task HandleAsync(PositionOpened domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        var details =
+            $"Position {domainEvent.PositionId.Value} opened for {domainEvent.Pair.Symbol}. " +
+            $"OrderId={domainEvent.OrderId.Value}, Price={domainEvent.Price.Value}, " +
+            $"Quantity={domainEvent.Quantity.Value}, Cost={domainEvent.Cost.Amount} {domainEvent.Cost.Currency}.";
+
+        _auditService.LogAudit("PositionOpened", details);
+        return Task.CompletedTask;
+    }
+}

--- a/IntelliTrader.Infrastructure/Transactions/JsonTransactionalUnitOfWork.cs
+++ b/IntelliTrader.Infrastructure/Transactions/JsonTransactionalUnitOfWork.cs
@@ -1,0 +1,296 @@
+using System.Collections.Concurrent;
+using System.Text;
+using IntelliTrader.Application.Common;
+
+namespace IntelliTrader.Infrastructure.Transactions;
+
+/// <summary>
+/// Transactional unit of work for JSON-backed repositories.
+/// Repositories stage writes in-memory while a transaction is active,
+/// and the unit of work commits them together.
+/// </summary>
+public sealed class JsonTransactionalUnitOfWork : ITransactionalUnitOfWork
+{
+    private readonly JsonTransactionCoordinator _coordinator;
+
+    public JsonTransactionalUnitOfWork(JsonTransactionCoordinator? coordinator = null)
+    {
+        _coordinator = coordinator ?? JsonTransactionCoordinator.Shared;
+    }
+
+    public bool HasActiveTransaction => _coordinator.HasActiveTransaction;
+
+    public Task BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        _coordinator.BeginTransaction();
+        return Task.CompletedTask;
+    }
+
+    public Task<Result> CommitAsync(CancellationToken cancellationToken = default)
+        => _coordinator.CommitAsync(cancellationToken);
+
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+        => _coordinator.RollbackAsync(cancellationToken);
+}
+
+public sealed class JsonTransactionCoordinator
+{
+    public static JsonTransactionCoordinator Shared { get; } = new();
+
+    private readonly AsyncLocal<JsonTransaction?> _currentTransaction = new();
+    private readonly SemaphoreSlim _commitLock = new(1, 1);
+
+    public bool HasActiveTransaction => _currentTransaction.Value is not null;
+
+    public void BeginTransaction()
+    {
+        _currentTransaction.Value ??= new JsonTransaction();
+    }
+
+    internal TState GetOrCreateState<TState>(
+        IJsonTransactionalResource resource,
+        Func<TState> stateFactory)
+        where TState : class
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(stateFactory);
+
+        BeginTransaction();
+        return _currentTransaction.Value!.GetOrCreateState(resource, stateFactory);
+    }
+
+    internal bool TryGetState<TState>(
+        IJsonTransactionalResource resource,
+        out TState? state)
+        where TState : class
+    {
+        state = null;
+        return _currentTransaction.Value is not null &&
+               _currentTransaction.Value.TryGetState(resource, out state);
+    }
+
+    public async Task<Result> CommitAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = _currentTransaction.Value;
+        if (transaction is null)
+        {
+            return Result.Success();
+        }
+
+        await _commitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var preparedWrites = new List<JsonPreparedWrite>();
+
+        try
+        {
+            foreach (var resource in transaction.EnlistedResources)
+            {
+                var preparedWrite = await resource
+                    .PrepareCommitAsync(transaction, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (preparedWrite is not null)
+                {
+                    preparedWrites.Add(preparedWrite);
+                }
+            }
+
+            foreach (var preparedWrite in preparedWrites)
+            {
+                await preparedWrite.StageAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var preparedWrite in preparedWrites)
+            {
+                preparedWrite.Apply();
+            }
+
+            foreach (var resource in transaction.EnlistedResources)
+            {
+                await resource.AcceptCommitAsync(transaction, cancellationToken).ConfigureAwait(false);
+            }
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            foreach (var preparedWrite in preparedWrites.AsEnumerable().Reverse())
+            {
+                preparedWrite.Restore();
+            }
+
+            foreach (var resource in transaction.EnlistedResources)
+            {
+                await resource.RollbackAsync(transaction, cancellationToken).ConfigureAwait(false);
+            }
+
+            return Result.Failure(
+                Error.ExchangeError($"Failed to commit JSON transaction: {ex.Message}"));
+        }
+        finally
+        {
+            foreach (var preparedWrite in preparedWrites)
+            {
+                preparedWrite.Cleanup();
+            }
+
+            _currentTransaction.Value = null;
+            _commitLock.Release();
+        }
+    }
+
+    public async Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = _currentTransaction.Value;
+        if (transaction is null)
+        {
+            return;
+        }
+
+        foreach (var resource in transaction.EnlistedResources)
+        {
+            await resource.RollbackAsync(transaction, cancellationToken).ConfigureAwait(false);
+        }
+
+        _currentTransaction.Value = null;
+    }
+}
+
+internal sealed class JsonTransaction
+{
+    private readonly ConcurrentDictionary<IJsonTransactionalResource, object> _states = new();
+
+    public IReadOnlyCollection<IJsonTransactionalResource> EnlistedResources => _states.Keys.ToList();
+
+    public TState GetOrCreateState<TState>(
+        IJsonTransactionalResource resource,
+        Func<TState> stateFactory)
+        where TState : class
+    {
+        return (TState)_states.GetOrAdd(resource, _ => stateFactory());
+    }
+
+    public bool TryGetState<TState>(
+        IJsonTransactionalResource resource,
+        out TState? state)
+        where TState : class
+    {
+        state = null;
+        if (!_states.TryGetValue(resource, out var current))
+        {
+            return false;
+        }
+
+        state = current as TState;
+        return state is not null;
+    }
+}
+
+internal interface IJsonTransactionalResource
+{
+    Task<JsonPreparedWrite?> PrepareCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken);
+
+    Task AcceptCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken);
+
+    Task RollbackAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class JsonPreparedWrite
+{
+    private readonly string _content;
+    private string? _stagedPath;
+    private string? _backupPath;
+    private bool _applied;
+
+    public JsonPreparedWrite(string targetPath, string content)
+    {
+        if (string.IsNullOrWhiteSpace(targetPath))
+            throw new ArgumentException("Target path cannot be null or empty.", nameof(targetPath));
+
+        TargetPath = targetPath;
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+    }
+
+    public string TargetPath { get; }
+
+    public async Task StageAsync(CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(TargetPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var stagingDirectory = string.IsNullOrEmpty(directory) ? Directory.GetCurrentDirectory() : directory;
+        _stagedPath = Path.Combine(
+            stagingDirectory,
+            $".{Path.GetFileName(TargetPath)}.{Guid.NewGuid():N}.tmp");
+
+        await File.WriteAllTextAsync(_stagedPath, _content, Encoding.UTF8, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public void Apply()
+    {
+        if (string.IsNullOrWhiteSpace(_stagedPath))
+        {
+            throw new InvalidOperationException("Prepared write has not been staged.");
+        }
+
+        if (File.Exists(TargetPath))
+        {
+            _backupPath = $"{TargetPath}.{Guid.NewGuid():N}.bak";
+            File.Copy(TargetPath, _backupPath, overwrite: true);
+        }
+
+        File.Move(_stagedPath, TargetPath, overwrite: true);
+        _stagedPath = null;
+        _applied = true;
+    }
+
+    public void Restore()
+    {
+        if (!_applied)
+        {
+            if (!string.IsNullOrWhiteSpace(_stagedPath) && File.Exists(_stagedPath))
+            {
+                File.Delete(_stagedPath);
+            }
+
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_backupPath) && File.Exists(_backupPath))
+        {
+            File.Move(_backupPath, TargetPath, overwrite: true);
+            _backupPath = null;
+        }
+        else if (File.Exists(TargetPath))
+        {
+            File.Delete(TargetPath);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_stagedPath) && File.Exists(_stagedPath))
+        {
+            File.Delete(_stagedPath);
+        }
+    }
+
+    public void Cleanup()
+    {
+        if (!string.IsNullOrWhiteSpace(_backupPath) && File.Exists(_backupPath))
+        {
+            File.Delete(_backupPath);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_stagedPath) && File.Exists(_stagedPath))
+        {
+            File.Delete(_stagedPath);
+        }
+    }
+}

--- a/IntelliTrader.Infrastructure/Transactions/JsonTransactionalUnitOfWork.cs
+++ b/IntelliTrader.Infrastructure/Transactions/JsonTransactionalUnitOfWork.cs
@@ -37,14 +37,35 @@ public sealed class JsonTransactionCoordinator
 {
     public static JsonTransactionCoordinator Shared { get; } = new();
 
-    private readonly AsyncLocal<JsonTransaction?> _currentTransaction = new();
+    private readonly AsyncLocal<JsonTransactionHolder?> _currentTransaction = new();
     private readonly SemaphoreSlim _commitLock = new(1, 1);
 
-    public bool HasActiveTransaction => _currentTransaction.Value is not null;
+    public bool HasActiveTransaction => CurrentTransaction is not null;
+
+    private JsonTransaction? CurrentTransaction
+    {
+        get => _currentTransaction.Value?.Transaction;
+        set
+        {
+            var holder = _currentTransaction.Value;
+            if (holder is null)
+            {
+                if (value is null)
+                {
+                    return;
+                }
+
+                holder = new JsonTransactionHolder();
+                _currentTransaction.Value = holder;
+            }
+
+            holder.Transaction = value;
+        }
+    }
 
     public void BeginTransaction()
     {
-        _currentTransaction.Value ??= new JsonTransaction();
+        CurrentTransaction ??= new JsonTransaction();
     }
 
     internal TState GetOrCreateState<TState>(
@@ -56,7 +77,7 @@ public sealed class JsonTransactionCoordinator
         ArgumentNullException.ThrowIfNull(stateFactory);
 
         BeginTransaction();
-        return _currentTransaction.Value!.GetOrCreateState(resource, stateFactory);
+        return CurrentTransaction!.GetOrCreateState(resource, stateFactory);
     }
 
     internal bool TryGetState<TState>(
@@ -65,18 +86,19 @@ public sealed class JsonTransactionCoordinator
         where TState : class
     {
         state = null;
-        return _currentTransaction.Value is not null &&
-               _currentTransaction.Value.TryGetState(resource, out state);
+        return CurrentTransaction is not null &&
+               CurrentTransaction.TryGetState(resource, out state);
     }
 
     public async Task<Result> CommitAsync(CancellationToken cancellationToken = default)
     {
-        var transaction = _currentTransaction.Value;
+        var transaction = CurrentTransaction;
         if (transaction is null)
         {
             return Result.Success();
         }
 
+        CurrentTransaction = null;
         await _commitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         var preparedWrites = new List<JsonPreparedWrite>();
 
@@ -133,25 +155,28 @@ public sealed class JsonTransactionCoordinator
                 preparedWrite.Cleanup();
             }
 
-            _currentTransaction.Value = null;
             _commitLock.Release();
         }
     }
 
     public async Task RollbackAsync(CancellationToken cancellationToken = default)
     {
-        var transaction = _currentTransaction.Value;
+        var transaction = CurrentTransaction;
         if (transaction is null)
         {
             return;
         }
 
+        CurrentTransaction = null;
         foreach (var resource in transaction.EnlistedResources)
         {
             await resource.RollbackAsync(transaction, cancellationToken).ConfigureAwait(false);
         }
+    }
 
-        _currentTransaction.Value = null;
+    private sealed class JsonTransactionHolder
+    {
+        public JsonTransaction? Transaction { get; set; }
     }
 }
 

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
@@ -579,7 +579,11 @@ public class ClosePositionHandlerTests
 
         var canceledOrder = CreateTestSellOrderResult(position.Pair) with
         {
-            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Canceled
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Canceled,
+            FilledQuantity = Quantity.Zero,
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT")
         };
 
         _positionRepositoryMock

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
@@ -627,6 +627,68 @@ public class ClosePositionHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenSellOrderPartiallyFilled_PersistsLifecycleWithoutClosingPosition()
+    {
+        // Arrange
+        var position = CreateTestPosition(quantity: 0.02m);
+        var portfolio = CreateTestPortfolio();
+        portfolio.RecordPositionOpened(position.Id, position.Pair, position.TotalCost);
+
+        var command = new ClosePositionCommand
+        {
+            PositionId = position.Id
+        };
+
+        var partialOrder = CreateTestSellOrderResult(position.Pair, quantity: 0.01m) with
+        {
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.PartiallyFilled,
+            RequestedQuantity = position.TotalQuantity
+        };
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(position.Pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketSellAsync(position.Pair, position.TotalQuantity, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(partialOrder));
+
+        // Act
+        var result = await _handler.HandleAsync(command);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("not filled");
+        position.IsClosed.Should().BeFalse();
+        portfolio.HasPositionFor(position.Pair).Should().BeTrue();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id.Value == partialOrder.OrderId &&
+                    order.Status == OrderLifecycleStatus.PartiallyFilled &&
+                    order.AppliedQuantity.IsZero),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenCommitFails_ReturnsFailure()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
@@ -631,7 +631,7 @@ public class ClosePositionHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenSellOrderPartiallyFilled_PersistsLifecycleWithoutClosingPosition()
+    public async Task HandleAsync_WhenSellOrderPartiallyFilled_AppliesPartialCloseWithoutClosingPosition()
     {
         // Arrange
         var position = CreateTestPosition(quantity: 0.02m);
@@ -679,17 +679,28 @@ public class ClosePositionHandlerTests
                 It.Is<OrderLifecycle>(order =>
                     order.Id.Value == partialOrder.OrderId &&
                     order.Status == OrderLifecycleStatus.PartiallyFilled &&
-                    order.AppliedQuantity.IsZero),
+                    order.AppliedQuantity.Value == 0.01m),
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
         _positionRepositoryMock.Verify(
-            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+            x => x.SaveAsync(
+                It.Is<Position>(saved =>
+                    saved.Id == position.Id &&
+                    !saved.IsClosed &&
+                    saved.TotalQuantity.Value == 0.01m &&
+                    saved.TotalCost.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
 
         _portfolioRepositoryMock.Verify(
-            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+            x => x.SaveAsync(
+                It.Is<Portfolio>(saved =>
+                    saved.HasPositionFor(position.Pair) &&
+                    saved.GetPositionCost(position.Id)!.Amount == 500m &&
+                    saved.Balance.Reserved.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
@@ -5,9 +5,12 @@ using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using IntelliTrader.Domain.SharedKernel;
+using OrderFilledDomainEvent = IntelliTrader.Domain.Events.OrderFilledEvent;
+using OrderPlacedDomainEvent = IntelliTrader.Domain.Events.OrderPlacedEvent;
 
 namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
@@ -15,10 +18,11 @@ public class ClosePositionHandlerTests
 {
     private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock;
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ClosePositionHandler _handler;
 
@@ -26,20 +30,42 @@ public class ClosePositionHandlerTests
     {
         _portfolioRepositoryMock = new Mock<IPortfolioRepository>();
         _positionRepositoryMock = new Mock<IPositionRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
         _notificationPortMock = new Mock<INotificationPort>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
         _handler = new ClosePositionHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _unitOfWorkMock
+            .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     private static Portfolio CreateTestPortfolio(decimal balance = 10000m)
@@ -72,9 +98,9 @@ public class ClosePositionHandlerTests
         {
             OrderId = Guid.NewGuid().ToString(),
             Pair = pair,
-            Side = OrderSide.Sell,
-            Type = OrderType.Market,
-            Status = OrderStatus.Filled,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Sell,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
             RequestedQuantity = Quantity.Create(quantity),
             FilledQuantity = Quantity.Create(quantity),
             Price = Price.Create(price),
@@ -282,6 +308,34 @@ public class ClosePositionHandlerTests
         // Assert
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidCommand_SavesOrderLifecycle()
+    {
+        // Arrange
+        var position = CreateTestPosition();
+        var portfolio = CreateTestPortfolio();
+        portfolio.RecordPositionOpened(position.Id, position.Pair, position.TotalCost);
+
+        var command = new ClosePositionCommand
+        {
+            PositionId = position.Id
+        };
+
+        SetupDefaultMocks(position, portfolio);
+
+        // Act
+        await _handler.HandleAsync(command);
+
+        // Assert
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Pair == position.Pair &&
+                    order.Status == OrderLifecycleStatus.Filled),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -523,7 +577,10 @@ public class ClosePositionHandlerTests
             PositionId = position.Id
         };
 
-        var canceledOrder = CreateTestSellOrderResult(position.Pair) with { Status = OrderStatus.Canceled };
+        var canceledOrder = CreateTestSellOrderResult(position.Pair) with
+        {
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Canceled
+        };
 
         _positionRepositoryMock
             .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
@@ -547,6 +604,26 @@ public class ClosePositionHandlerTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Message.Should().Contain("not filled");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id.Value == canceledOrder.OrderId &&
+                    order.Status == OrderLifecycleStatus.Canceled),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderPlacedDomainEvent>().Count() == 1 &&
+                    !events.OfType<OrderFilledDomainEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -679,9 +756,10 @@ public class ClosePositionByPairHandlerTests
 {
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
     private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ClosePositionHandler _closePositionHandler;
 
@@ -689,14 +767,16 @@ public class ClosePositionByPairHandlerTests
     {
         _positionRepositoryMock = new Mock<IPositionRepository>();
         _portfolioRepositoryMock = new Mock<IPortfolioRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
         _closePositionHandler = new ClosePositionHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
@@ -772,9 +852,9 @@ public class ClosePositionByPairHandlerTests
             {
                 OrderId = "sell-order-123",
                 Pair = pair,
-                Side = OrderSide.Sell,
-                Type = OrderType.Market,
-                Status = OrderStatus.Filled,
+                Side = IntelliTrader.Application.Ports.Driven.OrderSide.Sell,
+                Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+                Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
                 RequestedQuantity = Quantity.Create(0.1m),
                 FilledQuantity = Quantity.Create(0.1m),
                 Price = Price.Create(55000m),
@@ -783,6 +863,14 @@ public class ClosePositionByPairHandlerTests
                 Fees = Money.Create(5.5m, "USDT"),
                 Timestamp = DateTimeOffset.UtcNow
             }));
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _unitOfWorkMock
             .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
@@ -195,6 +195,34 @@ public sealed class ExchangeOrderLifecycleFactoryTests
     }
 
     [Fact]
+    public void Refresh_WhenSubmittedLifecycleIsCanceledWithExecutedQuantity_CapturesFillBeforeCanceling()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        lifecycle.ClearDomainEvents();
+
+        var orderInfo = CreateExchangeOrderInfo(
+            status: ExchangeOrderStatus.Canceled,
+            filledQuantity: 0.01m,
+            averagePrice: 50100m,
+            fees: 0.5m);
+
+        // Act
+        var changed = InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        changed.Should().BeTrue();
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.Canceled);
+        lifecycle.FilledQuantity.Value.Should().Be(0.01m);
+        lifecycle.AveragePrice.Value.Should().Be(50100m);
+        lifecycle.Cost.Amount.Should().Be(501m);
+        lifecycle.Fees.Amount.Should().Be(0.5m);
+        lifecycle.HasUnappliedFill.Should().BeTrue();
+        lifecycle.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+    }
+
+    [Fact]
     public void Refresh_WhenStatusIsUnsupported_ThrowsArgumentOutOfRangeException()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
@@ -1,0 +1,307 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using FluentAssertions;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+using ExchangeOrderSide = IntelliTrader.Application.Ports.Driven.OrderSide;
+using ExchangeOrderStatus = IntelliTrader.Application.Ports.Driven.OrderStatus;
+using ExchangeOrderType = IntelliTrader.Application.Ports.Driven.OrderType;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class ExchangeOrderLifecycleFactoryTests
+{
+    private static readonly Type FactoryType = typeof(RefreshOrderStatusHandler)
+        .Assembly
+        .GetType("IntelliTrader.Application.Trading.Handlers.ExchangeOrderLifecycleFactory", throwOnError: true)!;
+
+    private static readonly MethodInfo CreateMethod = FactoryType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+    private static readonly MethodInfo RefreshMethod = FactoryType.GetMethod("Refresh", BindingFlags.Public | BindingFlags.Static)!;
+
+    [Fact]
+    public void Create_WhenStatusIsPendingCancel_MapsToCanceledLifecycle()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(status: ExchangeOrderStatus.PendingCancel);
+
+        // Act
+        var lifecycle = InvokeCreate(orderResult);
+
+        // Assert
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.Canceled);
+    }
+
+    [Fact]
+    public void Create_WhenStatusIsExpired_MapsToRejectedLifecycle()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(status: ExchangeOrderStatus.Expired);
+
+        // Act
+        var lifecycle = InvokeCreate(orderResult);
+
+        // Assert
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.Rejected);
+    }
+
+    [Fact]
+    public void Create_WhenTypeIsStopLossLimit_MapsToStopLoss()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(type: ExchangeOrderType.StopLossLimit);
+
+        // Act
+        var lifecycle = InvokeCreate(orderResult);
+
+        // Assert
+        lifecycle.Type.Should().Be(DomainOrderType.StopLoss);
+    }
+
+    [Fact]
+    public void Create_WhenTypeIsTakeProfitLimit_MapsToTakeProfit()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(type: ExchangeOrderType.TakeProfitLimit);
+
+        // Act
+        var lifecycle = InvokeCreate(orderResult);
+
+        // Assert
+        lifecycle.Type.Should().Be(DomainOrderType.TakeProfit);
+    }
+
+    [Fact]
+    public void Create_WhenSideIsUnsupported_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(side: (ExchangeOrderSide)999);
+
+        // Act
+        var act = () => InvokeCreate(orderResult);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Unsupported order side*");
+    }
+
+    [Fact]
+    public void Create_WhenTypeIsUnsupported_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(type: (ExchangeOrderType)999);
+
+        // Act
+        var act = () => InvokeCreate(orderResult);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Unsupported order type*");
+    }
+
+    [Fact]
+    public void Create_WhenStatusIsUnsupported_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var orderResult = CreateExchangeOrderResult(status: (ExchangeOrderStatus)999);
+
+        // Act
+        var act = () => InvokeCreate(orderResult);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Unsupported order status*");
+    }
+
+    [Fact]
+    public void Refresh_WhenExchangeStatusMatchesSubmittedLifecycle_ReturnsFalseWithoutChangingLifecycle()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        lifecycle.ClearDomainEvents();
+
+        var orderInfo = CreateExchangeOrderInfo(status: ExchangeOrderStatus.New);
+
+        // Act
+        var changed = InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        changed.Should().BeFalse();
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.Submitted);
+        lifecycle.FilledQuantity.Should().Be(Quantity.Zero);
+        lifecycle.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Refresh_WhenExchangeReportsSubmittedForPartiallyFilledLifecycle_ReturnsFalseWithoutRegressingState()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        lifecycle.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        lifecycle.ClearDomainEvents();
+
+        var orderInfo = CreateExchangeOrderInfo(
+            status: ExchangeOrderStatus.New,
+            filledQuantity: 0m,
+            averagePrice: 0m,
+            fees: 0m);
+
+        // Act
+        var changed = InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        changed.Should().BeFalse();
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        lifecycle.FilledQuantity.Value.Should().Be(0.02m);
+        lifecycle.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Refresh_WhenPartialFillSnapshotMatchesCurrentState_ReturnsFalseWithoutNewEvents()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        lifecycle.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        lifecycle.ClearDomainEvents();
+
+        var orderInfo = CreateExchangeOrderInfo(
+            status: ExchangeOrderStatus.PartiallyFilled,
+            filledQuantity: 0.02m,
+            averagePrice: 50000m,
+            fees: 1m);
+
+        // Act
+        var changed = InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        changed.Should().BeFalse();
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        lifecycle.FilledQuantity.Value.Should().Be(0.02m);
+        lifecycle.Cost.Amount.Should().Be(1000m);
+        lifecycle.Fees.Amount.Should().Be(1m);
+        lifecycle.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Refresh_WhenStatusIsUnsupported_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        var orderInfo = CreateExchangeOrderInfo(status: (ExchangeOrderStatus)999);
+
+        // Act
+        var act = () => InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Unsupported order status*");
+    }
+
+    private static OrderLifecycle InvokeCreate(
+        ExchangeOrderResult orderResult,
+        string? signalRule = null,
+        OrderIntent intent = OrderIntent.Unknown,
+        PositionId? relatedPositionId = null)
+    {
+        try
+        {
+            return (OrderLifecycle)CreateMethod.Invoke(null, [orderResult, signalRule, intent, relatedPositionId])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static bool InvokeRefresh(OrderLifecycle lifecycle, ExchangeOrderInfo orderInfo)
+    {
+        try
+        {
+            return (bool)RefreshMethod.Invoke(null, [lifecycle, orderInfo])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static OrderLifecycle CreateSubmittedLifecycle()
+    {
+        var lifecycle = OrderLifecycle.Submit(
+            OrderId.From("factory-refresh-order-1"),
+            TradingPair.Create("BTCUSDT", "USDT"),
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.05m),
+            Price.Create(50000m),
+            signalRule: "MomentumBreakout",
+            timestamp: DateTimeOffset.UtcNow,
+            intent: OrderIntent.OpenPosition);
+        lifecycle.ClearDomainEvents();
+        return lifecycle;
+    }
+
+    private static ExchangeOrderResult CreateExchangeOrderResult(
+        ExchangeOrderStatus status = ExchangeOrderStatus.New,
+        ExchangeOrderSide side = ExchangeOrderSide.Buy,
+        ExchangeOrderType type = ExchangeOrderType.Market,
+        decimal requestedQuantity = 0.05m,
+        decimal filledQuantity = 0m,
+        decimal price = 50000m,
+        decimal averagePrice = 0m,
+        decimal fees = 0m)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "exchange-order-result-1",
+            Pair = TradingPair.Create("BTCUSDT", "USDT"),
+            Side = side,
+            Type = type,
+            Status = status,
+            RequestedQuantity = Quantity.Create(requestedQuantity),
+            FilledQuantity = Quantity.Create(filledQuantity),
+            Price = Price.Create(price),
+            AveragePrice = Price.Create(averagePrice),
+            Cost = Money.Create(averagePrice * filledQuantity, "USDT"),
+            Fees = Money.Create(fees, "USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderInfo CreateExchangeOrderInfo(
+        ExchangeOrderStatus status,
+        decimal filledQuantity = 0m,
+        decimal averagePrice = 0m,
+        decimal fees = 0m)
+    {
+        return new ExchangeOrderInfo
+        {
+            OrderId = "exchange-order-info-1",
+            Pair = TradingPair.Create("BTCUSDT", "USDT"),
+            Side = ExchangeOrderSide.Buy,
+            Type = ExchangeOrderType.Market,
+            Status = status,
+            OriginalQuantity = Quantity.Create(0.05m),
+            FilledQuantity = Quantity.Create(filledQuantity),
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Create(averagePrice),
+            Fees = Money.Create(fees, "USDT"),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExecuteDCAHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExecuteDCAHandlerTests.cs
@@ -5,9 +5,12 @@ using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Domain.SharedKernel;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using Moq;
+using OrderFilledDomainEvent = IntelliTrader.Domain.Events.OrderFilledEvent;
+using OrderPlacedDomainEvent = IntelliTrader.Domain.Events.OrderPlacedEvent;
 
 namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
@@ -15,10 +18,11 @@ public class ExecuteDCAHandlerTests
 {
     private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock;
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ExecuteDCAHandler _handler;
 
@@ -26,20 +30,42 @@ public class ExecuteDCAHandlerTests
     {
         _portfolioRepositoryMock = new Mock<IPortfolioRepository>();
         _positionRepositoryMock = new Mock<IPositionRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
         _notificationPortMock = new Mock<INotificationPort>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
         _handler = new ExecuteDCAHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _unitOfWorkMock
+            .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     #region Helper Methods
@@ -75,9 +101,9 @@ public class ExecuteDCAHandlerTests
         {
             OrderId = Guid.NewGuid().ToString(),
             Pair = pair,
-            Side = OrderSide.Buy,
-            Type = OrderType.Market,
-            Status = OrderStatus.Filled,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
             RequestedQuantity = Quantity.Create(quantity),
             FilledQuantity = Quantity.Create(quantity),
             Price = Price.Create(price),
@@ -339,6 +365,36 @@ public class ExecuteDCAHandlerTests
         // Assert
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidCommand_SavesOrderLifecycle()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreateOpenPosition(pair, 50000m, 0.1m);
+        var portfolio = CreatePortfolio(10000m);
+        portfolio.RecordPositionOpened(position.Id, pair, Money.Create(5000m, "USDT"));
+
+        var command = new ExecuteDCACommand
+        {
+            PositionId = position.Id,
+            Cost = Money.Create(500m, "USDT")
+        };
+
+        SetupDefaultMocks(position, portfolio, 45000m, 500m);
+
+        // Act
+        await _handler.HandleAsync(command);
+
+        // Assert
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Pair == pair &&
+                    order.Status == OrderLifecycleStatus.Filled),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -677,9 +733,9 @@ public class ExecuteDCAHandlerTests
         {
             OrderId = Guid.NewGuid().ToString(),
             Pair = pair,
-            Side = OrderSide.Buy,
-            Type = OrderType.Market,
-            Status = OrderStatus.Rejected,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Rejected,
             RequestedQuantity = Quantity.Create(0.01m),
             FilledQuantity = Quantity.Zero,
             Price = Price.Create(45000m),
@@ -700,6 +756,26 @@ public class ExecuteDCAHandlerTests
         result.IsFailure.Should().BeTrue();
         result.Error.Code.Should().Be("ExchangeError");
         result.Error.Message.Should().Contain("not filled");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id.Value == unfilledOrder.OrderId &&
+                    order.Status == OrderLifecycleStatus.Rejected),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderPlacedDomainEvent>().Count() == 1 &&
+                    !events.OfType<OrderFilledDomainEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -781,6 +857,7 @@ public class ExecuteDCAHandlerTests
         var handlerWithoutNotification = new ExecuteDCAHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
@@ -868,9 +945,10 @@ public class ExecuteDCAByPairHandlerTests
 {
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
     private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ExecuteDCAHandler _executeDCAHandler;
 
@@ -878,14 +956,16 @@ public class ExecuteDCAByPairHandlerTests
     {
         _positionRepositoryMock = new Mock<IPositionRepository>();
         _portfolioRepositoryMock = new Mock<IPortfolioRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
         _executeDCAHandler = new ExecuteDCAHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
@@ -978,9 +1058,9 @@ public class ExecuteDCAByPairHandlerTests
             {
                 OrderId = "dca-order-123",
                 Pair = pair,
-                Side = OrderSide.Buy,
-                Type = OrderType.Market,
-                Status = OrderStatus.Filled,
+                Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+                Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+                Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
                 RequestedQuantity = Quantity.Create(0.011m),
                 FilledQuantity = Quantity.Create(0.011m),
                 Price = Price.Create(45000m),
@@ -989,6 +1069,14 @@ public class ExecuteDCAByPairHandlerTests
                 Fees = Money.Create(0.5m, "USDT"),
                 Timestamp = DateTimeOffset.UtcNow
             }));
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _unitOfWorkMock
             .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
@@ -6,6 +6,7 @@ using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Domain.Events;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using IntelliTrader.Domain.SharedKernel;
@@ -193,6 +194,54 @@ public class OpenPositionHandlerTests
         _positionRepositoryMock.Verify(
             x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithPartiallyFilledOrder_SavesLifecycleLinkedToOpenedPosition()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT")
+        };
+
+        var partialOrder = CreateTestOrderResult(pair, quantity: 0.01m) with
+        {
+            Status = ExchangeOrderStatus.PartiallyFilled,
+            RequestedQuantity = Quantity.Create(0.02m)
+        };
+        OrderLifecycle? savedOrder = null;
+        Position? savedPosition = null;
+
+        SetupDefaultMocks(portfolio, pair);
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, It.IsAny<Money>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(partialOrder));
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Callback<OrderLifecycle, CancellationToken>((order, _) => savedOrder = order)
+            .Returns(Task.CompletedTask);
+
+        _positionRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()))
+            .Callback<Position, CancellationToken>((position, _) => savedPosition = position)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _handler.HandleAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        savedOrder.Should().NotBeNull();
+        savedPosition.Should().NotBeNull();
+        savedOrder!.RelatedPositionId.Should().Be(savedPosition!.Id);
+        savedOrder.AppliedQuantity.Value.Should().Be(0.01m);
+        savedOrder.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
     }
 
     [Fact]

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
@@ -4,10 +4,15 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Domain.Events;
 using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using IntelliTrader.Domain.SharedKernel;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using ExchangeOrderSide = IntelliTrader.Application.Ports.Driven.OrderSide;
+using ExchangeOrderStatus = IntelliTrader.Application.Ports.Driven.OrderStatus;
+using ExchangeOrderType = IntelliTrader.Application.Ports.Driven.OrderType;
 
 namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
@@ -15,10 +20,11 @@ public class OpenPositionHandlerTests
 {
     private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock;
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly OpenPositionHandler _handler;
 
@@ -26,20 +32,42 @@ public class OpenPositionHandlerTests
     {
         _portfolioRepositoryMock = new Mock<IPortfolioRepository>();
         _positionRepositoryMock = new Mock<IPositionRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
         _notificationPortMock = new Mock<INotificationPort>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
         _handler = new OpenPositionHandler(
             _portfolioRepositoryMock.Object,
             _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<IntelliTrader.Domain.Trading.Orders.OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _unitOfWorkMock
+            .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     private static Portfolio CreateTestPortfolio(
@@ -78,9 +106,9 @@ public class OpenPositionHandlerTests
         {
             OrderId = Guid.NewGuid().ToString(),
             Pair = pair,
-            Side = OrderSide.Buy,
-            Type = OrderType.Market,
-            Status = OrderStatus.Filled,
+            Side = ExchangeOrderSide.Buy,
+            Type = ExchangeOrderType.Market,
+            Status = ExchangeOrderStatus.Filled,
             RequestedQuantity = Quantity.Create(quantity),
             FilledQuantity = Quantity.Create(quantity),
             Price = Price.Create(price),
@@ -168,6 +196,75 @@ public class OpenPositionHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenOrderIsSubmitted_PersistsOrderAndReturnsFailure()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT")
+        };
+
+        var submittedOrder = CreateTestOrderResult(pair, quantity: 0.02m) with
+        {
+            Status = ExchangeOrderStatus.New,
+            FilledQuantity = Quantity.Zero,
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT")
+        };
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTestRules(pair.Symbol)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, It.IsAny<Money>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(submittedOrder));
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _handler.HandleAsync(command);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("not filled");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<IntelliTrader.Domain.Trading.Orders.OrderLifecycle>(order =>
+                    order.Id.Value == submittedOrder.OrderId &&
+                    order.Status == IntelliTrader.Domain.Trading.Orders.OrderLifecycleStatus.Submitted),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderPlacedEvent>().Count() == 1 &&
+                    !events.OfType<OrderFilledEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WithValidCommand_SavesPortfolio()
     {
         // Arrange
@@ -233,6 +330,88 @@ public class OpenPositionHandlerTests
         // Assert
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithFilledOrder_DispatchesOrderLifecycleEvents()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+
+        SetupDefaultMocks(portfolio, pair);
+
+        // Act
+        await _handler.HandleAsync(command);
+
+        // Assert
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    HasOrderLifecycleEvents(events, pair.Symbol, DomainOrderSide.Buy, false, "MomentumBreakout")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithPartiallyFilledOrder_DispatchesPartialFillEventAndReturnsSuccess()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT")
+        };
+
+        var partialOrder = CreateTestOrderResult(pair, quantity: 0.01m) with
+        {
+            Status = ExchangeOrderStatus.PartiallyFilled,
+            RequestedQuantity = Quantity.Create(0.02m)
+        };
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTestRules(pair.Symbol)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, It.IsAny<Money>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(partialOrder));
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _notificationPortMock
+            .Setup(x => x.SendAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _handler.HandleAsync(command);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    HasOrderLifecycleEvents(events, pair.Symbol, DomainOrderSide.Buy, true, null)),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -677,4 +856,25 @@ public class OpenPositionHandlerTests
     }
 
     #endregion
+
+    private static bool HasOrderLifecycleEvents(
+        IEnumerable<IDomainEvent> events,
+        string pair,
+        DomainOrderSide side,
+        bool isPartialFill,
+        string? signalRule = null)
+    {
+        var eventList = events.ToList();
+        var placed = eventList.OfType<OrderPlacedEvent>().SingleOrDefault();
+        var filled = eventList.OfType<OrderFilledEvent>().SingleOrDefault();
+
+        return placed is not null &&
+               filled is not null &&
+               placed.Pair == pair &&
+               placed.Side == side &&
+               placed.SignalRule == signalRule &&
+               filled.Pair == pair &&
+               filled.Side == side &&
+               filled.IsPartialFill == isPartialFill;
+    }
 }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
@@ -756,7 +756,14 @@ public class OpenPositionHandlerTests
             Cost = Money.Create(1000m, "USDT")
         };
 
-        var orderResult = CreateTestOrderResult(pair) with { Status = OrderStatus.Canceled };
+        var orderResult = CreateTestOrderResult(pair) with
+        {
+            Status = OrderStatus.Canceled,
+            FilledQuantity = Quantity.Zero,
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT")
+        };
 
         _portfolioRepositoryMock
             .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
@@ -111,6 +111,83 @@ public class OrderQueryHandlerTests
         result.Value.Should().OnlyContain(order => !order.IsTerminal);
     }
 
+    [Fact]
+    public async Task HandleAsync_WithTradingHistoryQuery_ReturnsFilledOrdersMappedAsTrades()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var positionId = PositionId.Create();
+        var initialBuy = CreateFilledOrder(
+            "order-buy-1",
+            pair,
+            DateTimeOffset.UtcNow.AddMinutes(-30),
+            OrderIntent.OpenPosition,
+            positionId);
+        var dcaBuy = CreateFilledOrder(
+            "order-dca-1",
+            pair,
+            DateTimeOffset.UtcNow.AddMinutes(-20),
+            OrderIntent.ExecuteDca,
+            positionId);
+        var sell = CreateFilledOrder(
+            "order-sell-1",
+            pair,
+            DateTimeOffset.UtcNow.AddMinutes(-10),
+            OrderIntent.ClosePosition,
+            positionId,
+            DomainOrderSide.Sell);
+        var pending = CreateSubmittedOrder(
+            "order-pending-1",
+            pair,
+            DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        var handler = new GetTradingHistoryHandler(_orderRepositoryMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { pending, initialBuy, sell, dcaBuy });
+
+        // Act
+        var result = await handler.HandleAsync(new GetTradingHistoryQuery
+        {
+            Pair = pair,
+            Limit = 10
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Select(entry => entry.OrderId).Should().Equal("order-sell-1", "order-dca-1", "order-buy-1");
+        result.Value.Select(entry => entry.Type).Should().Equal(TradeType.Sell, TradeType.DCA, TradeType.Buy);
+        result.Value.Should().OnlyContain(entry => entry.PositionId == positionId);
+        result.Value.Should().OnlyContain(entry => entry.Pair == pair);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithTradingHistoryQuery_SkipsFilledOrdersWithoutPositionLink()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var unlinkedFilledOrder = CreateFilledOrder(
+            "order-unlinked-1",
+            pair,
+            DateTimeOffset.UtcNow.AddMinutes(-10),
+            OrderIntent.OpenPosition,
+            relatedPositionId: null);
+
+        var handler = new GetTradingHistoryHandler(_orderRepositoryMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { unlinkedFilledOrder });
+
+        // Act
+        var result = await handler.HandleAsync(new GetTradingHistoryQuery { Pair = pair });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
     private static OrderLifecycle CreateSubmittedOrder(
         string orderId,
         TradingPair? pair = null,
@@ -135,12 +212,47 @@ public class OrderQueryHandlerTests
         TradingPair? pair = null,
         DateTimeOffset? submittedAt = null)
     {
-        var order = CreateSubmittedOrder(orderId, pair, submittedAt);
+        return CreateFilledOrder(
+            orderId,
+            pair,
+            submittedAt,
+            OrderIntent.OpenPosition,
+            PositionId.Create());
+    }
+
+    private static OrderLifecycle CreateFilledOrder(
+        string orderId,
+        TradingPair? pair,
+        DateTimeOffset? submittedAt,
+        OrderIntent intent,
+        PositionId? relatedPositionId,
+        DomainOrderSide side = DomainOrderSide.Buy)
+    {
+        var tradingPair = pair ?? TradingPair.Create("BTCUSDT", "USDT");
+        var submittedRelatedPositionId = intent == OrderIntent.OpenPosition ? null : relatedPositionId;
+        var order = OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            tradingPair,
+            side,
+            DomainOrderType.Market,
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            "MomentumBreakout",
+            submittedAt ?? DateTimeOffset.UtcNow,
+            intent,
+            submittedRelatedPositionId);
+
+        order.ClearDomainEvents();
         order.MarkFilled(
             Quantity.Create(0.02m),
             Price.Create(50000m),
             Money.Create(1000m, "USDT"),
             Money.Create(1m, "USDT"));
+        if (intent == OrderIntent.OpenPosition && relatedPositionId is not null)
+        {
+            order.LinkRelatedPosition(relatedPositionId);
+        }
+
         order.ClearDomainEvents();
         return order;
     }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
@@ -76,6 +76,41 @@ public class OrderQueryHandlerTests
         result.Value[0].Status.Should().Be(OrderLifecycleStatus.Submitted);
     }
 
+    [Fact]
+    public async Task HandleAsync_WithActiveOrdersQuery_ReturnsOnlyNonTerminalOrders()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var newestPartial = CreatePartiallyFilledOrder("order-5", pair, DateTimeOffset.UtcNow);
+        var olderSubmitted = CreateSubmittedOrder("order-6", pair, DateTimeOffset.UtcNow.AddMinutes(-1));
+        var filled = CreateFilledOrder("order-7", pair, DateTimeOffset.UtcNow.AddMinutes(-2));
+        var otherPair = CreateSubmittedOrder(
+            "order-8",
+            TradingPair.Create("ETHUSDT", "USDT"),
+            DateTimeOffset.UtcNow.AddMinutes(-3));
+
+        var handler = new GetActiveOrdersHandler(_orderRepositoryMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { olderSubmitted, otherPair, filled, newestPartial });
+
+        var query = new GetActiveOrdersQuery
+        {
+            Pair = pair,
+            Side = DomainOrderSide.Buy,
+            Limit = 10
+        };
+
+        // Act
+        var result = await handler.HandleAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Select(order => order.Id).Should().Equal(newestPartial.Id, olderSubmitted.Id);
+        result.Value.Should().OnlyContain(order => !order.IsTerminal);
+    }
+
     private static OrderLifecycle CreateSubmittedOrder(
         string orderId,
         TradingPair? pair = null,
@@ -106,6 +141,21 @@ public class OrderQueryHandlerTests
             Price.Create(50000m),
             Money.Create(1000m, "USDT"),
             Money.Create(1m, "USDT"));
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static OrderLifecycle CreatePartiallyFilledOrder(
+        string orderId,
+        TradingPair? pair = null,
+        DateTimeOffset? submittedAt = null)
+    {
+        var order = CreateSubmittedOrder(orderId, pair, submittedAt);
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.01m),
+            Price.Create(50000m),
+            Money.Create(500m, "USDT"),
+            Money.Create(0.5m, "USDT"));
         order.ClearDomainEvents();
         return order;
     }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public class OrderQueryHandlerTests
+{
+    private readonly Mock<IOrderRepository> _orderRepositoryMock = new();
+
+    [Fact]
+    public async Task HandleAsync_WithExistingOrder_ReturnsMappedOrderView()
+    {
+        // Arrange
+        var order = CreateFilledOrder("order-1");
+        var handler = new GetOrderHandler(_orderRepositoryMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var query = new GetOrderQuery { OrderId = order.Id };
+
+        // Act
+        var result = await handler.HandleAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(order.Id);
+        result.Value.Pair.Should().Be(order.Pair);
+        result.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.CanAffectPosition.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithFilters_ReturnsRecentMatchingOrdersOnly()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var matching = CreateSubmittedOrder("order-2", pair, DateTimeOffset.UtcNow.AddMinutes(-1));
+        var nonMatchingStatus = CreateFilledOrder("order-3", pair, DateTimeOffset.UtcNow.AddMinutes(-2));
+        var nonMatchingPair = CreateSubmittedOrder(
+            "order-4",
+            TradingPair.Create("ETHUSDT", "USDT"),
+            DateTimeOffset.UtcNow);
+
+        var handler = new GetRecentOrdersHandler(_orderRepositoryMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { nonMatchingStatus, matching, nonMatchingPair });
+
+        var query = new GetRecentOrdersQuery
+        {
+            Pair = pair,
+            Status = OrderLifecycleStatus.Submitted,
+            Side = DomainOrderSide.Buy,
+            Limit = 10
+        };
+
+        // Act
+        var result = await handler.HandleAsync(query);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].Id.Should().Be(matching.Id);
+        result.Value[0].Status.Should().Be(OrderLifecycleStatus.Submitted);
+    }
+
+    private static OrderLifecycle CreateSubmittedOrder(
+        string orderId,
+        TradingPair? pair = null,
+        DateTimeOffset? submittedAt = null)
+    {
+        var order = OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            pair ?? TradingPair.Create("BTCUSDT", "USDT"),
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            "MomentumBreakout",
+            submittedAt ?? DateTimeOffset.UtcNow);
+
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static OrderLifecycle CreateFilledOrder(
+        string orderId,
+        TradingPair? pair = null,
+        DateTimeOffset? submittedAt = null)
+    {
+        var order = CreateSubmittedOrder(orderId, pair, submittedAt);
+        order.MarkFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        order.ClearDomainEvents();
+        return order;
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioQueryHandlerTests.cs
@@ -1,0 +1,168 @@
+using IntelliTrader.Application.Common;
+using FluentAssertions;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class PortfolioQueryHandlerTests
+{
+    private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock = new();
+    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+
+    [Fact]
+    public async Task GetPortfolio_WithDefaultPortfolio_ReturnsMappedBalances()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var positionId = PositionId.Create();
+        var portfolio = Portfolio.Create("Default", "USDT", 10000m, 5, 100m);
+        portfolio.RecordPositionOpened(positionId, pair, Money.Create(1000m, "USDT"));
+        portfolio.ClearDomainEvents();
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        var handler = new GetPortfolioHandler(_portfolioRepositoryMock.Object);
+
+        var result = await handler.HandleAsync(new GetPortfolioQuery());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(portfolio.Id);
+        result.Value.Name.Should().Be("Default");
+        result.Value.TotalBalance.Amount.Should().Be(10000m);
+        result.Value.AvailableBalance.Amount.Should().Be(9000m);
+        result.Value.ReservedBalance.Amount.Should().Be(1000m);
+        result.Value.ActivePositionCount.Should().Be(1);
+        result.Value.CanOpenNewPosition.Should().BeTrue();
+        result.Value.AvailablePercentage.Should().Be(90m);
+        result.Value.ReservedPercentage.Should().Be(10m);
+        result.Value.LastUpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPortfolio_WithMissingNamedPortfolio_ReturnsNotFound()
+    {
+        _portfolioRepositoryMock
+            .Setup(x => x.GetByNameAsync("Missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        var handler = new GetPortfolioHandler(_portfolioRepositoryMock.Object);
+
+        var result = await handler.HandleAsync(new GetPortfolioQuery { Name = "Missing" });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain("Missing");
+    }
+
+    [Fact]
+    public async Task GetPortfolioStatistics_WithActivePositions_ReturnsCurrentPortfolioMetrics()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+        var position = Position.Open(
+            pair,
+            OrderId.From("order-btc-1"),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"));
+        portfolio.RecordPositionOpened(position.Id, pair, Money.Create(1000m, "USDT"));
+        portfolio.ClearDomainEvents();
+        position.ClearDomainEvents();
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+        _positionRepositoryMock
+            .Setup(x => x.GetClosedPositionsAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Position>());
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        var handler = new GetPortfolioStatisticsHandler(
+            _portfolioRepositoryMock.Object,
+            _positionRepositoryMock.Object,
+            _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PortfolioId.Should().Be(portfolio.Id);
+        result.Value.TotalBalance.Amount.Should().Be(5000m);
+        result.Value.AvailableBalance.Amount.Should().Be(4000m);
+        result.Value.InvestedBalance.Amount.Should().Be(1000m);
+        result.Value.ActivePositions.Should().Be(1);
+        result.Value.PositionSlotsAvailable.Should().Be(4);
+        result.Value.TotalUnrealizedPnL.Amount.Should().Be(99m);
+        result.Value.OverallMargin.Percentage.Should().BeApproximately(9.8901098901m, 0.0000000001m);
+        result.Value.TotalTradesCount.Should().Be(1);
+        result.Value.WinningTradesCount.Should().Be(1);
+        result.Value.LosingTradesCount.Should().Be(0);
+        result.Value.WinRate.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioStatistics_WhenPortfolioMissing_ReturnsNotFound()
+    {
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        var handler = new GetPortfolioStatisticsHandler(
+            _portfolioRepositoryMock.Object,
+            _positionRepositoryMock.Object,
+            _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task GetPortfolioStatistics_WhenPriceLookupFails_ReturnsFailure()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+        var position = Position.Open(
+            pair,
+            OrderId.From("order-btc-1"),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"));
+        position.ClearDomainEvents();
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
+
+        var handler = new GetPortfolioStatisticsHandler(
+            _portfolioRepositoryMock.Object,
+            _positionRepositoryMock.Object,
+            _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("price unavailable");
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionQueryHandlerTests.cs
@@ -1,0 +1,367 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class PositionQueryHandlerTests
+{
+    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+
+    [Fact]
+    public async Task GetPosition_WithPair_ReturnsMappedViewUsingCurrentPrice()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var openedAt = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m, openedAt);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByPairAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery { Pair = pair });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(position.Id);
+        result.Value.Pair.Should().Be(pair);
+        result.Value.CurrentPrice.Value.Should().Be(55000m);
+        result.Value.CurrentValue.Amount.Should().Be(1100m);
+        result.Value.UnrealizedPnL.Amount.Should().Be(99m);
+        result.Value.CurrentMargin.Percentage.Should().BeApproximately(9.8901098901m, 0.0000000001m);
+        result.Value.EntryCount.Should().Be(1);
+        result.Value.IsClosed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetPosition_WithoutIdentifier_ReturnsValidationFailure()
+    {
+        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("PositionId or Pair");
+    }
+
+    [Fact]
+    public async Task GetPosition_WithMissingPositionId_ReturnsNotFound()
+    {
+        var positionId = PositionId.Create();
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(positionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Position?)null);
+
+        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery { PositionId = positionId });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain(positionId.ToString());
+    }
+
+    [Fact]
+    public async Task GetPosition_WithClosedPosition_UsesAveragePriceWithoutExchangeLookup()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreateClosedPosition(
+            pair,
+            "order-btc-1",
+            "sell-btc-1",
+            50000m,
+            0.02m,
+            1m,
+            55000m,
+            1m,
+            DateTimeOffset.UtcNow);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery { PositionId = position.Id });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsClosed.Should().BeTrue();
+        result.Value.CurrentPrice.Should().Be(position.AveragePrice);
+        _exchangePortMock.Verify(
+            x => x.GetCurrentPriceAsync(It.IsAny<TradingPair>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPosition_WhenActivePositionPriceLookupFails_ReturnsFailure()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
+
+        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery { PositionId = position.Id });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ExchangeError");
+    }
+
+    [Fact]
+    public async Task GetActivePositions_FiltersByMarketAndSortsByMarginDescending()
+    {
+        var btc = TradingPair.Create("BTCUSDT", "USDT");
+        var eth = TradingPair.Create("ETHUSDT", "USDT");
+        var adaBtc = TradingPair.Create("ADABTC", "BTC");
+
+        var btcPosition = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m);
+        var ethPosition = CreatePosition(eth, "order-eth-1", 2500m, 0.4m, 1m);
+        var adaPosition = CreatePosition(adaBtc, "order-ada-1", 0.00001m, 1000m, 0.000001m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ethPosition, adaPosition, btcPosition });
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(eth, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(2400m)));
+
+        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetActivePositionsQuery
+        {
+            Market = "USDT",
+            SortBy = PositionSortOrder.Margin,
+            Descending = true
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Select(position => position.Pair).Should().Equal(btc, eth);
+        result.Value.Should().OnlyContain(position => position.Pair.QuoteCurrency == "USDT");
+        result.Value[0].CurrentMargin.Percentage.Should().BeGreaterThan(result.Value[1].CurrentMargin.Percentage);
+    }
+
+    [Fact]
+    public async Task GetActivePositions_WhenPriceLookupFails_ReturnsFailure()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
+
+        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetActivePositionsQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ExchangeError");
+        result.Error.Message.Should().Contain("price unavailable");
+    }
+
+    [Theory]
+    [InlineData(PositionSortOrder.Pair, false, "ADAUSDT", "BTCUSDT")]
+    [InlineData(PositionSortOrder.Pair, true, "BTCUSDT", "ADAUSDT")]
+    [InlineData(PositionSortOrder.Cost, true, "BTCUSDT", "ADAUSDT")]
+    [InlineData(PositionSortOrder.Cost, false, "ADAUSDT", "BTCUSDT")]
+    [InlineData(PositionSortOrder.DCALevel, true, "BTCUSDT", "ADAUSDT")]
+    [InlineData(PositionSortOrder.DCALevel, false, "ADAUSDT", "BTCUSDT")]
+    [InlineData(PositionSortOrder.OpenedAt, false, "ADAUSDT", "BTCUSDT")]
+    [InlineData(PositionSortOrder.OpenedAt, true, "BTCUSDT", "ADAUSDT")]
+    public async Task GetActivePositions_AppliesSortOrder(
+        PositionSortOrder sortOrder,
+        bool descending,
+        string firstSymbol,
+        string secondSymbol)
+    {
+        var btc = TradingPair.Create("BTCUSDT", "USDT");
+        var ada = TradingPair.Create("ADAUSDT", "USDT");
+        var newerBtc = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m, DateTimeOffset.UtcNow);
+        newerBtc.AddDCAEntry(
+            OrderId.From("order-btc-dca-1"),
+            Price.Create(49000m),
+            Quantity.Create(0.01m),
+            Money.Create(0.5m, "USDT"));
+        newerBtc.ClearDomainEvents();
+        var olderAda = CreatePosition(ada, "order-ada-1", 1m, 100m, 1m, DateTimeOffset.UtcNow.AddHours(-1));
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { newerBtc, olderAda });
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(51000m)));
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(ada, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(1.01m)));
+
+        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetActivePositionsQuery
+        {
+            SortBy = sortOrder,
+            Descending = descending
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Select(position => position.Pair.Symbol).Should().Equal(firstSymbol, secondSymbol);
+    }
+
+    [Fact]
+    public async Task GetActivePositions_AppliesMarginRangeFilters()
+    {
+        var btc = TradingPair.Create("BTCUSDT", "USDT");
+        var eth = TradingPair.Create("ETHUSDT", "USDT");
+        var btcPosition = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m);
+        var ethPosition = CreatePosition(eth, "order-eth-1", 2500m, 0.4m, 1m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { btcPosition, ethPosition });
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(eth, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(2400m)));
+
+        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetActivePositionsQuery
+        {
+            MinMargin = 0m,
+            MaxMargin = 20m
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].Pair.Should().Be(btc);
+    }
+
+    [Fact]
+    public async Task GetClosedPositions_FiltersByPairAndLimitsResults()
+    {
+        var btc = TradingPair.Create("BTCUSDT", "USDT");
+        var eth = TradingPair.Create("ETHUSDT", "USDT");
+        var newerBtc = CreateClosedPosition(btc, "order-btc-1", "sell-btc-1", 50000m, 0.02m, 1m, 55000m, 1m, DateTimeOffset.UtcNow);
+        var olderBtc = CreateClosedPosition(btc, "order-btc-2", "sell-btc-2", 51000m, 0.02m, 1m, 52000m, 1m, DateTimeOffset.UtcNow.AddMinutes(-10));
+        var otherPair = CreateClosedPosition(eth, "order-eth-1", "sell-eth-1", 2500m, 0.4m, 1m, 2600m, 1m, DateTimeOffset.UtcNow);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetClosedPositionsAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { olderBtc, otherPair, newerBtc });
+
+        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+
+        var result = await handler.HandleAsync(new GetClosedPositionsQuery
+        {
+            Pair = btc,
+            Limit = 1
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].Id.Should().Be(newerBtc.Id);
+        result.Value[0].IsClosed.Should().BeTrue();
+        result.Value[0].CurrentPrice.Should().Be(newerBtc.AveragePrice);
+
+        _exchangePortMock.Verify(
+            x => x.GetCurrentPriceAsync(It.IsAny<TradingPair>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetClosedPositions_WithProfitableOnlyFilter_ReturnsValidationFailure()
+    {
+        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+
+        var result = await handler.HandleAsync(new GetClosedPositionsQuery { ProfitableOnly = true });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("closed-position PnL projection");
+    }
+
+    [Fact]
+    public async Task GetClosedPositions_WithInvalidRange_ReturnsValidationFailure()
+    {
+        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+
+        var result = await handler.HandleAsync(new GetClosedPositionsQuery
+        {
+            From = DateTimeOffset.UtcNow,
+            To = DateTimeOffset.UtcNow.AddDays(-1)
+        });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+    }
+
+    private static Position CreatePosition(
+        TradingPair pair,
+        string orderId,
+        decimal price,
+        decimal quantity,
+        decimal fees,
+        DateTimeOffset? openedAt = null)
+    {
+        var position = Position.Open(
+            pair,
+            OrderId.From(orderId),
+            Price.Create(price),
+            Quantity.Create(quantity),
+            Money.Create(fees, pair.QuoteCurrency),
+            "MomentumBreakout",
+            openedAt);
+
+        position.ClearDomainEvents();
+        return position;
+    }
+
+    private static Position CreateClosedPosition(
+        TradingPair pair,
+        string orderId,
+        string sellOrderId,
+        decimal entryPrice,
+        decimal quantity,
+        decimal entryFees,
+        decimal sellPrice,
+        decimal sellFees,
+        DateTimeOffset closedAt)
+    {
+        var position = CreatePosition(pair, orderId, entryPrice, quantity, entryFees, closedAt.AddHours(-4));
+        position.Close(OrderId.From(sellOrderId), Price.Create(sellPrice), Money.Create(sellFees, pair.QuoteCurrency), closedAt);
+        position.ClearDomainEvents();
+        return position;
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -152,6 +152,62 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenExchangeReportsOverfilledOrder_ReturnsValidationFailureWithoutPersistence()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-open-overfill-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout",
+            requestedQuantity: 0.02m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.03m,
+                fees: 1.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("cannot exceed requested quantity");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenSubmittedCloseOrderBecomesFilled_ClosesPositionAndReleasesPortfolio()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -169,7 +169,8 @@ public sealed class RefreshOrderStatusHandlerTests
             pair: pair,
             side: DomainOrderSide.Sell,
             intent: OrderIntent.ClosePosition,
-            relatedPositionId: position.Id);
+            relatedPositionId: position.Id,
+            requestedQuantity: position.TotalQuantity.Value);
 
         _orderRepositoryMock
             .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
@@ -245,7 +246,8 @@ public sealed class RefreshOrderStatusHandlerTests
             pair: pair,
             side: DomainOrderSide.Sell,
             intent: OrderIntent.ClosePosition,
-            relatedPositionId: position.Id);
+            relatedPositionId: position.Id,
+            requestedQuantity: position.TotalQuantity.Value);
 
         _orderRepositoryMock
             .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
@@ -407,7 +409,8 @@ public sealed class RefreshOrderStatusHandlerTests
             pair: pair,
             side: DomainOrderSide.Buy,
             intent: OrderIntent.ExecuteDca,
-            relatedPositionId: position.Id);
+            relatedPositionId: position.Id,
+            requestedQuantity: 5m);
 
         _orderRepositoryMock
             .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
@@ -879,14 +882,15 @@ public sealed class RefreshOrderStatusHandlerTests
         DomainOrderSide side,
         OrderIntent intent,
         string? signalRule = null,
-        PositionId? relatedPositionId = null)
+        PositionId? relatedPositionId = null,
+        decimal requestedQuantity = 0.02m)
     {
         var order = OrderLifecycle.Submit(
             OrderId.From(orderId),
             pair,
             side,
             DomainOrderType.Market,
-            Quantity.Create(0.02m),
+            Quantity.Create(requestedQuantity),
             Price.Create(50000m),
             signalRule: signalRule,
             timestamp: DateTimeOffset.UtcNow,

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -675,6 +675,105 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenAppliedPartialOpenOrderReceivesLargerPartialFill_AppliesOnlyFillDelta()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var orderId = OrderId.From("refresh-open-partial-growth-1");
+        var position = Position.Open(
+            pair,
+            orderId,
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+
+        var partialOrder = OrderLifecycle.Submit(
+            orderId,
+            pair,
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.05m),
+            Price.Create(50000m),
+            signalRule: "MomentumBreakout",
+            intent: OrderIntent.OpenPosition);
+        partialOrder.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        partialOrder.LinkRelatedPosition(position.Id);
+        partialOrder.MarkCurrentFillApplied();
+        partialOrder.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(partialOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partialOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, partialOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: partialOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.PartiallyFilled,
+                price: 50000m,
+                quantity: 0.03m,
+                fees: 1.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = partialOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    savedPosition.DCALevel == 0 &&
+                    savedPosition.TotalQuantity.Value == 0.03m &&
+                    savedPosition.TotalCost.Amount == 1500m &&
+                    savedPosition.TotalFees.Amount == 1.5m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio =>
+                    savedPortfolio.GetPositionId(pair) == position.Id &&
+                    savedPortfolio.GetTotalInvestedCost().Amount == 1500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == partialOrder.Id &&
+                    order.Status == OrderLifecycleStatus.PartiallyFilled &&
+                    order.AppliedQuantity.Value == 0.03m &&
+                    order.AppliedCost.Amount == 1500m &&
+                    order.AppliedFees.Amount == 1.5m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenLegacyAppliedPartialOpenOrderHasNoRelatedPosition_UsesActivePortfolioPosition()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -285,7 +285,7 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenSubmittedCloseOrderBecomesPartiallyFilled_PersistsLifecycleWithoutClosingPosition()
+    public async Task HandleAsync_WhenSubmittedCloseOrderBecomesPartiallyFilled_AppliesPartialCloseDeltaWithoutClosingPosition()
     {
         // Arrange
         var pair = TradingPair.Create("ETHUSDT", "USDT");
@@ -338,7 +338,7 @@ public sealed class RefreshOrderStatusHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value.PositionId.Should().Be(position.Id);
         result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.PartiallyFilled);
-        result.Value.AppliedDomainEffects.Should().BeFalse();
+        result.Value.AppliedDomainEffects.Should().BeTrue();
         position.IsClosed.Should().BeFalse();
         portfolio.HasPositionFor(pair).Should().BeTrue();
 
@@ -347,17 +347,121 @@ public sealed class RefreshOrderStatusHandlerTests
                 It.Is<OrderLifecycle>(order =>
                     order.Id == submittedOrder.Id &&
                     order.Status == OrderLifecycleStatus.PartiallyFilled &&
-                    order.AppliedQuantity.IsZero),
+                    order.AppliedQuantity.Value == 0.2m),
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
         _positionRepositoryMock.Verify(
-            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    !savedPosition.IsClosed &&
+                    savedPosition.TotalQuantity.Value == 0.2m &&
+                    savedPosition.TotalCost.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
 
         _portfolioRepositoryMock.Verify(
-            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio =>
+                    savedPortfolio.HasPositionFor(pair) &&
+                    savedPortfolio.GetPositionCost(position.Id)!.Amount == 500m &&
+                    savedPortfolio.Balance.Reserved.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedCloseOrderIsCanceledWithExecutedQuantity_AppliesPartialCloseDelta()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-close-canceled-partial-1"),
+            Price.Create(2500m),
+            Quantity.Create(0.4m),
+            Money.Create(1m, "USDT"),
+            "ExitRule");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-close-canceled-partial-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id,
+            requestedQuantity: position.TotalQuantity.Value);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.Canceled,
+                price: 2600m,
+                quantity: 0.2m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Canceled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == submittedOrder.Id &&
+                    order.Status == OrderLifecycleStatus.Canceled &&
+                    order.AppliedQuantity.Value == 0.2m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    !savedPosition.IsClosed &&
+                    savedPosition.TotalQuantity.Value == 0.2m &&
+                    savedPosition.TotalCost.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio =>
+                    savedPortfolio.HasPositionFor(pair) &&
+                    savedPortfolio.GetPositionCost(position.Id)!.Amount == 500m &&
+                    savedPortfolio.Balance.Reserved.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any(e => e.FilledAmount == 0.2m && e.IsPartialFill) &&
+                    events.OfType<PositionPartiallyClosed>().Any(e => e.SoldQuantity.Value == 0.2m)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -1825,10 +1929,10 @@ public sealed class RefreshOrderStatusHandlerTests
                 orderId: order.Id.Value,
                 pair: pair,
                 side: ExchangeOrderSide.Sell,
-                status: ExchangeOrderStatus.PartiallyFilled,
+                status: ExchangeOrderStatus.Canceled,
                 price: 2600m,
-                quantity: 0.2m,
-                fees: 0.5m)));
+                quantity: 0m,
+                fees: 0m)));
 
         _orderRepositoryMock
             .Setup(x => x.SaveAsync(It.Is<OrderLifecycle>(saved => saved.Id == order.Id), It.IsAny<CancellationToken>()))

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -1205,6 +1205,170 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenSubmittedOpenOrderIsCanceledWithExecutedQuantity_AppliesFillBeforeTerminalState()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-canceled-open-partial-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Canceled,
+                price: 50000m,
+                quantity: 0.01m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Canceled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+        var openedPositionId = result.Value.PositionId;
+        openedPositionId.Should().NotBeNull();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(saved =>
+                    saved.Id == order.Id &&
+                    saved.Status == OrderLifecycleStatus.Canceled &&
+                    saved.FilledQuantity.Value == 0.01m &&
+                    saved.AppliedQuantity.Value == 0.01m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(saved =>
+                    saved.Pair == pair &&
+                    saved.TotalQuantity.Value == 0.01m &&
+                    saved.Entries.Single().OrderId == order.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(saved =>
+                    saved.HasPositionFor(pair) &&
+                    saved.GetPositionCost(openedPositionId!)!.Amount == 500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any(e => e.FilledAmount == 0.01m && e.IsPartialFill) &&
+                    events.OfType<PositionOpened>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDcaOrderIsCanceledWithExecutedQuantity_AppliesFillDeltaBeforeTerminalState()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-dca-canceled-partial-1"),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-canceled-dca-partial-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: position.Id,
+            requestedQuantity: 0.02m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.PendingCancel,
+                price: 49000m,
+                quantity: 0.01m,
+                fees: 0.49m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Canceled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(saved =>
+                    saved.Id == order.Id &&
+                    saved.Status == OrderLifecycleStatus.Canceled &&
+                    saved.FilledQuantity.Value == 0.01m &&
+                    saved.AppliedQuantity.Value == 0.01m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(saved =>
+                    saved.Id == position.Id &&
+                    saved.TotalQuantity.Value == 0.03m &&
+                    saved.Entries.Any(entry => entry.OrderId == order.Id && entry.Quantity.Value == 0.01m)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(saved =>
+                    saved.GetPositionCost(position.Id)!.Amount == 1490m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenPartiallyFilledOpenOrderHasNoPortfolio_ReturnsNotFound()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -410,6 +410,192 @@ public sealed class RefreshOrderStatusHandlerTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task HandleAsync_WhenAppliedPartialOpenOrderBecomesFilled_AppliesOnlyFillDeltaToExistingPosition()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var orderId = OrderId.From("refresh-open-partial-1");
+        var position = Position.Open(
+            pair,
+            orderId,
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+
+        var partialOrder = OrderLifecycle.Submit(
+            orderId,
+            pair,
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.05m),
+            Price.Create(50000m),
+            signalRule: "MomentumBreakout",
+            intent: OrderIntent.OpenPosition);
+        partialOrder.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        partialOrder.LinkRelatedPosition(position.Id);
+        partialOrder.MarkCurrentFillApplied();
+        partialOrder.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(partialOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partialOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, partialOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: partialOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.05m,
+                fees: 2.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = partialOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    savedPosition.DCALevel == 0 &&
+                    savedPosition.Entries.Count == 1 &&
+                    savedPosition.TotalQuantity.Value == 0.05m &&
+                    savedPosition.TotalCost.Amount == 2500m &&
+                    savedPosition.TotalFees.Amount == 2.5m &&
+                    savedPosition.GetEntryAtLevel(0)!.OrderId == partialOrder.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio =>
+                    savedPortfolio.GetPositionId(pair) == position.Id &&
+                    savedPortfolio.GetTotalInvestedCost().Amount == 2500m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == partialOrder.Id &&
+                    order.Status == OrderLifecycleStatus.Filled &&
+                    order.RelatedPositionId == position.Id &&
+                    order.AppliedQuantity.Value == 0.05m &&
+                    order.AppliedCost.Amount == 2500m &&
+                    order.AppliedFees.Amount == 2.5m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenLegacyAppliedPartialOpenOrderHasNoRelatedPosition_UsesActivePortfolioPosition()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var orderId = OrderId.From("refresh-open-legacy-partial-1");
+        var position = Position.Open(
+            pair,
+            orderId,
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+
+        var partialOrder = OrderLifecycle.Submit(
+            orderId,
+            pair,
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.05m),
+            Price.Create(50000m),
+            signalRule: "MomentumBreakout",
+            intent: OrderIntent.OpenPosition);
+        partialOrder.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        partialOrder.MarkCurrentFillApplied();
+        partialOrder.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(partialOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partialOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, partialOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: partialOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.05m,
+                fees: 2.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = partialOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == partialOrder.Id &&
+                    order.RelatedPositionId == position.Id &&
+                    order.AppliedQuantity.Value == 0.05m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    savedPosition.TotalQuantity.Value == 0.05m &&
+                    savedPosition.GetEntryAtLevel(0)!.OrderId == partialOrder.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static Portfolio CreateTestPortfolio(
         decimal balance = 10000m,
         int maxPositions = 5,

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -916,6 +916,932 @@ public sealed class RefreshOrderStatusHandlerTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task HandleAsync_WhenOrderDoesNotExist_ReturnsNotFoundWithoutExchangeLookup()
+    {
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = OrderId.From("missing-order-1")
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain("missing-order-1");
+
+        _exchangePortMock.Verify(
+            x => x.GetOrderAsync(It.IsAny<TradingPair>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderIntentIsUnknown_ReturnsValidationFailureWithoutExchangeLookup()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-unknown-intent-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.Unknown);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("does not contain refreshable intent metadata");
+
+        _exchangePortMock.Verify(
+            x => x.GetOrderAsync(It.IsAny<TradingPair>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTerminalOrderHasNoUnappliedFill_ReturnsCurrentStateWithoutExchangeLookup()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-terminal-noop-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+        order.MarkFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        order.MarkCurrentFillApplied();
+        order.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PreviousStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeFalse();
+
+        _exchangePortMock.Verify(
+            x => x.GetOrderAsync(It.IsAny<TradingPair>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenExchangeLookupFails_ReturnsFailureWithoutPersistence()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-exchange-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Failure(Error.ExchangeError("exchange unavailable")));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(Error.ExchangeError("exchange unavailable"));
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenExchangeStatusWouldBreakLifecycleTransition_ReturnsValidationFailure()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-invalid-transition-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout",
+            requestedQuantity: 0.05m);
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        order.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Rejected,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("Cannot transition order");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenExchangeStatusIsStillSubmitted_ReturnsNoopWithoutPersistence()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-submitted-noop-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.New,
+                price: 50000m,
+                quantity: 0m,
+                fees: 0m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PreviousStatus.Should().Be(OrderLifecycleStatus.Submitted);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Submitted);
+        result.Value.AppliedDomainEffects.Should().BeFalse();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedOrderIsCanceled_PersistsOrderOnlyWithoutDispatchingEvents()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-canceled-order-only-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Canceled,
+                price: 50000m,
+                quantity: 0m,
+                fees: 0m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Canceled);
+        result.Value.AppliedDomainEffects.Should().BeFalse();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(saved =>
+                    saved.Id == order.Id &&
+                    saved.Status == OrderLifecycleStatus.Canceled),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPartiallyFilledOpenOrderHasNoPortfolio_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-open-no-portfolio-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.PartiallyFilled,
+                price: 50000m,
+                quantity: 0.01m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain("Portfolio");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPartiallyFilledOpenOrderReferencesMissingPosition_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var missingPositionId = PositionId.Create();
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-open-missing-position-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout",
+            requestedQuantity: 0.05m);
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        order.LinkRelatedPosition(missingPositionId);
+        order.MarkCurrentFillApplied();
+        order.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestPortfolio());
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(missingPositionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Position?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.05m,
+                fees: 2.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain(missingPositionId.Value.ToString());
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOpenOrderResolvesPositionWithoutOpeningEntry_ReturnsValidationFailure()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var existingPosition = Position.Open(
+            pair,
+            OrderId.From("different-opening-order"),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+        var portfolio = CreatePortfolioWithOpenPosition(existingPosition, 10000m);
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-open-missing-opening-entry-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout",
+            requestedQuantity: 0.05m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(existingPosition.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingPosition);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.PartiallyFilled,
+                price: 50000m,
+                quantity: 0.03m,
+                fees: 1.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("does not contain opening order");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFilledCloseOrderReferencesMissingPosition_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var missingPositionId = PositionId.Create();
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-close-missing-position-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: missingPositionId,
+            requestedQuantity: 0.4m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(missingPositionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Position?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.Filled,
+                price: 2600m,
+                quantity: 0.4m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain(missingPositionId.Value.ToString());
+
+        _portfolioRepositoryMock.Verify(
+            x => x.GetDefaultAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFilledCloseOrderHasNoPortfolio_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-close-no-portfolio-1"),
+            Price.Create(2500m),
+            Quantity.Create(0.4m),
+            Money.Create(1m, "USDT"),
+            "ExitRule");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-close-no-portfolio-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id,
+            requestedQuantity: position.TotalQuantity.Value);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.Filled,
+                price: 2600m,
+                quantity: position.TotalQuantity.Value,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain("Portfolio");
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFilledDcaOrderReferencesMissingPosition_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var missingPositionId = PositionId.Create();
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-dca-missing-position-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: missingPositionId,
+            requestedQuantity: 5m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(missingPositionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Position?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 90m,
+                quantity: 5m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain(missingPositionId.Value.ToString());
+
+        _portfolioRepositoryMock.Verify(
+            x => x.GetDefaultAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFilledDcaOrderHasNoPortfolio_ReturnsNotFound()
+    {
+        // Arrange
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-dca-no-portfolio-1"),
+            Price.Create(100m),
+            Quantity.Create(10m),
+            Money.Create(1m, "USDT"),
+            "DipBuy");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-dca-no-portfolio-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: position.Id,
+            requestedQuantity: 5m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 90m,
+                quantity: 5m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain("Portfolio");
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderIntentIsUnsupported_ReturnsValidationFailure()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-unsupported-intent-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: (OrderIntent)999,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        result.Error.Message.Should().Contain("Unsupported order intent");
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderOnlyPersistenceThrows_RollsBackAndReturnsExchangeError()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var positionId = PositionId.Create();
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-order-only-persist-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: positionId,
+            requestedQuantity: 0.4m);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.PartiallyFilled,
+                price: 2600m,
+                quantity: 0.2m,
+                fees: 0.5m)));
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.Is<OrderLifecycle>(saved => saved.Id == order.Id), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("storage down"));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ExchangeError");
+        result.Error.Message.Should().Contain("Failed to persist refreshed order");
+        result.Error.Message.Should().Contain("storage down");
+
+        _unitOfWorkMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderOnlyCommitFails_ReturnsCommitFailureWithoutDispatchingEvents()
+    {
+        // Arrange
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-order-only-commit-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Canceled,
+                price: 50000m,
+                quantity: 0m,
+                fees: 0m)));
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(Error.ExchangeError("commit failed")));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(Error.ExchangeError("commit failed"));
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderEffectsPersistenceThrows_RollsBackAndReturnsExchangeError()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-effects-persist-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        _positionRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("write conflict"));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ExchangeError");
+        result.Error.Message.Should().Contain("Failed to persist refreshed order effects");
+        result.Error.Message.Should().Contain("write conflict");
+
+        _unitOfWorkMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrderEffectsCommitFails_ReturnsCommitFailureWithoutDispatchingEvents()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var order = CreateSubmittedOrder(
+            orderId: "refresh-effects-commit-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, order.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: order.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(Error.ExchangeError("commit failed")));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = order.Id
+        });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(Error.ExchangeError("commit failed"));
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private static Portfolio CreateTestPortfolio(
         decimal balance = 10000m,
         int maxPositions = 5,

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -1,0 +1,478 @@
+using FluentAssertions;
+using Moq;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.Services;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+using ExchangeOrderSide = IntelliTrader.Application.Ports.Driven.OrderSide;
+using ExchangeOrderStatus = IntelliTrader.Application.Ports.Driven.OrderStatus;
+using ExchangeOrderType = IntelliTrader.Application.Ports.Driven.OrderType;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class RefreshOrderStatusHandlerTests
+{
+    private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock = new();
+    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IOrderRepository> _orderRepositoryMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+    private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock = new();
+    private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock = new();
+    private readonly RefreshOrderStatusHandler _handler;
+
+    public RefreshOrderStatusHandlerTests()
+    {
+        _handler = new RefreshOrderStatusHandler(
+            _portfolioRepositoryMock.Object,
+            _positionRepositoryMock.Object,
+            _orderRepositoryMock.Object,
+            _exchangePortMock.Object,
+            _eventDispatcherMock.Object,
+            _unitOfWorkMock.Object);
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _positionRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventDispatcherMock
+            .Setup(x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(false);
+
+        _unitOfWorkMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        _unitOfWorkMock
+            .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedOpenOrderBecomesFilled_OpensPositionAndUpdatesPortfolio()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-open-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.OrderId.Should().Be(submittedOrder.Id);
+        result.Value.PreviousStatus.Should().Be(OrderLifecycleStatus.Submitted);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+        result.Value.PositionId.Should().NotBeNull();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == submittedOrder.Id &&
+                    order.Status == OrderLifecycleStatus.Filled &&
+                    order.Intent == OrderIntent.OpenPosition),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(position =>
+                    position.Pair == pair &&
+                    position.SignalRule == "MomentumBreakout" &&
+                    !position.IsClosed),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio => savedPortfolio.HasPositionFor(pair)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<PositionOpened>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedCloseOrderBecomesFilled_ClosesPositionAndReleasesPortfolio()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-close-1"),
+            Price.Create(2500m),
+            Quantity.Create(0.4m),
+            Money.Create(1m, "USDT"),
+            "ExitRule");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-close-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.Filled,
+                price: 2600m,
+                quantity: position.TotalQuantity.Value,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition => savedPosition.Id == position.Id && savedPosition.IsClosed),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio => !savedPortfolio.HasPositionFor(pair)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<PositionClosed>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedDcaOrderBecomesFilled_AddsDcaEntryAndIncreasesPortfolioCost()
+    {
+        // Arrange
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-dca-1"),
+            Price.Create(100m),
+            Quantity.Create(10m),
+            Money.Create(1m, "USDT"),
+            "DipBuy");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-dca-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: position.Id);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 90m,
+                quantity: 5m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    savedPosition.DCALevel == 1 &&
+                    savedPosition.TotalQuantity.Value == 15m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio => savedPortfolio.GetTotalInvestedCost().Amount == 1450m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<DCAExecuted>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAppliedPartialDcaOrderBecomesFilled_AppliesOnlyFillDelta()
+    {
+        // Arrange
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var orderId = OrderId.From("refresh-dca-partial-1");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-dca-partial-1"),
+            Price.Create(100m),
+            Quantity.Create(10m),
+            Money.Create(1m, "USDT"),
+            "DipBuy");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+
+        position.AddDCAEntry(
+            orderId,
+            Price.Create(90m),
+            Quantity.Create(5m),
+            Money.Create(0.5m, "USDT"));
+
+        portfolio.RecordPositionCostIncreased(position.Id, pair, Money.Create(450m, "USDT"));
+        portfolio.ClearDomainEvents();
+
+        var partialOrder = OrderLifecycle.Submit(
+            orderId,
+            pair,
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(10m),
+            Price.Create(90m),
+            intent: OrderIntent.ExecuteDca,
+            relatedPositionId: position.Id);
+        partialOrder.MarkPartiallyFilled(
+            Quantity.Create(5m),
+            Price.Create(90m),
+            Money.Create(450m, "USDT"),
+            Money.Create(0.5m, "USDT"));
+        partialOrder.MarkCurrentFillApplied();
+        partialOrder.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(partialOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partialOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, partialOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: partialOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 90m,
+                quantity: 10m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = partialOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition =>
+                    savedPosition.Id == position.Id &&
+                    savedPosition.DCALevel == 1 &&
+                    savedPosition.TotalQuantity.Value == 20m &&
+                    savedPosition.GetEntryAtLevel(1)!.Quantity.Value == 10m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio =>
+                    savedPortfolio.GetTotalInvestedCost().Amount == 1900m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == partialOrder.Id &&
+                    order.Status == OrderLifecycleStatus.Filled &&
+                    order.AppliedQuantity.Value == 10m &&
+                    order.AppliedCost.Amount == 900m &&
+                    order.AppliedFees.Amount == 1m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static Portfolio CreateTestPortfolio(
+        decimal balance = 10000m,
+        int maxPositions = 5,
+        decimal minPositionCost = 10m)
+    {
+        return Portfolio.Create("Default", "USDT", balance, maxPositions, minPositionCost);
+    }
+
+    private static Portfolio CreatePortfolioWithOpenPosition(Position position, decimal balance)
+    {
+        var portfolio = CreateTestPortfolio(balance);
+        portfolio.RecordPositionOpened(position.Id, position.Pair, position.TotalCost);
+        portfolio.ClearDomainEvents();
+        return portfolio;
+    }
+
+    private static OrderLifecycle CreateSubmittedOrder(
+        string orderId,
+        TradingPair pair,
+        DomainOrderSide side,
+        OrderIntent intent,
+        string? signalRule = null,
+        PositionId? relatedPositionId = null)
+    {
+        var order = OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            pair,
+            side,
+            DomainOrderType.Market,
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            signalRule: signalRule,
+            timestamp: DateTimeOffset.UtcNow,
+            intent: intent,
+            relatedPositionId: relatedPositionId);
+
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static ExchangeOrderInfo CreateExchangeOrderInfo(
+        string orderId,
+        TradingPair pair,
+        ExchangeOrderSide side,
+        ExchangeOrderStatus status,
+        decimal price,
+        decimal quantity,
+        decimal fees)
+    {
+        return new ExchangeOrderInfo
+        {
+            OrderId = orderId,
+            Pair = pair,
+            Side = side,
+            Type = ExchangeOrderType.Market,
+            Status = status,
+            OriginalQuantity = Quantity.Create(quantity),
+            FilledQuantity = Quantity.Create(quantity),
+            Price = Price.Create(price),
+            AveragePrice = Price.Create(price),
+            Fees = Money.Create(fees, "USDT"),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -228,6 +228,168 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenSubmittedCloseOrderBecomesPartiallyFilled_PersistsLifecycleWithoutClosingPosition()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-close-partial-1"),
+            Price.Create(2500m),
+            Quantity.Create(0.4m),
+            Money.Create(1m, "USDT"),
+            "ExitRule");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-close-partial-1",
+            pair: pair,
+            side: DomainOrderSide.Sell,
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id);
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.PartiallyFilled,
+                price: 2600m,
+                quantity: 0.2m,
+                fees: 0.5m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        result.Value.AppliedDomainEffects.Should().BeFalse();
+        position.IsClosed.Should().BeFalse();
+        portfolio.HasPositionFor(pair).Should().BeTrue();
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == submittedOrder.Id &&
+                    order.Status == OrderLifecycleStatus.PartiallyFilled &&
+                    order.AppliedQuantity.IsZero),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPartialCloseOrderBecomesFilled_ClosesPositionAndMarksFillApplied()
+    {
+        // Arrange
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("seed-buy-close-partial-2"),
+            Price.Create(2500m),
+            Quantity.Create(0.4m),
+            Money.Create(1m, "USDT"),
+            "ExitRule");
+        var portfolio = CreatePortfolioWithOpenPosition(position, 10000m);
+        var partialOrder = OrderLifecycle.Submit(
+            OrderId.From("refresh-close-partial-2"),
+            pair,
+            DomainOrderSide.Sell,
+            DomainOrderType.Market,
+            Quantity.Create(0.4m),
+            Price.Create(2600m),
+            intent: OrderIntent.ClosePosition,
+            relatedPositionId: position.Id);
+        partialOrder.MarkPartiallyFilled(
+            Quantity.Create(0.2m),
+            Price.Create(2600m),
+            Money.Create(520m, "USDT"),
+            Money.Create(0.5m, "USDT"));
+        partialOrder.ClearDomainEvents();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(partialOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partialOrder);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, partialOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: partialOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Sell,
+                status: ExchangeOrderStatus.Filled,
+                price: 2600m,
+                quantity: 0.4m,
+                fees: 1m)));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = partialOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _positionRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Position>(savedPosition => savedPosition.Id == position.Id && savedPosition.IsClosed),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _portfolioRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<Portfolio>(savedPortfolio => !savedPortfolio.HasPositionFor(pair)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _orderRepositoryMock.Verify(
+            x => x.SaveAsync(
+                It.Is<OrderLifecycle>(order =>
+                    order.Id == partialOrder.Id &&
+                    order.AppliedQuantity.Value == 0.4m &&
+                    order.AppliedCost.Amount == 1040m &&
+                    order.AppliedFees.Amount == 1m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenSubmittedDcaOrderBecomesFilled_AddsDcaEntryAndIncreasesPortfolioCost()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshSubmittedOrdersHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshSubmittedOrdersHandlerTests.cs
@@ -75,6 +75,50 @@ public sealed class RefreshSubmittedOrdersHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenOrderIsPartiallyFilled_RefreshesItWithSubmittedOrders()
+    {
+        // Arrange
+        var partiallyFilled = CreatePartiallyFilledOrder("partial-oldest", DateTimeOffset.UtcNow.AddMinutes(-10));
+        var submitted = CreateSubmittedOrder("submitted-newest", DateTimeOffset.UtcNow.AddMinutes(-1));
+        var filledOrder = CreateFilledOrder("filled-order", DateTimeOffset.UtcNow.AddMinutes(-5));
+        var dispatchedOrderIds = new List<OrderId>();
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { submitted, filledOrder, partiallyFilled });
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                It.IsAny<RefreshOrderStatusCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RefreshOrderStatusCommand command, CancellationToken _) =>
+            {
+                dispatchedOrderIds.Add(command.OrderId);
+
+                return Result<RefreshOrderStatusResult>.Success(new RefreshOrderStatusResult
+                {
+                    OrderId = command.OrderId,
+                    PreviousStatus = OrderLifecycleStatus.PartiallyFilled,
+                    CurrentStatus = OrderLifecycleStatus.Filled,
+                    AppliedDomainEffects = true
+                });
+            });
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshSubmittedOrdersCommand());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalSubmitted.Should().Be(2);
+        result.Value.AttemptedCount.Should().Be(2);
+        result.Value.RefreshedCount.Should().Be(2);
+        result.Value.AppliedDomainEffectsCount.Should().Be(2);
+        result.Value.FailedCount.Should().Be(0);
+
+        dispatchedOrderIds.Should().Equal(partiallyFilled.Id, submitted.Id);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenSomeRefreshesFail_AccumulatesFailureCountsWithoutStoppingBatch()
     {
         // Arrange
@@ -124,6 +168,18 @@ public sealed class RefreshSubmittedOrdersHandlerTests
             timestamp: submittedAt,
             intent: OrderIntent.OpenPosition);
 
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static OrderLifecycle CreatePartiallyFilledOrder(string orderId, DateTimeOffset submittedAt)
+    {
+        var order = CreateSubmittedOrder(orderId, submittedAt);
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.01m),
+            Price.Create(50000m),
+            Money.Create(500m, "USDT"),
+            Money.Create(0.5m, "USDT"));
         order.ClearDomainEvents();
         return order;
     }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshSubmittedOrdersHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshSubmittedOrdersHandlerTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Moq;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class RefreshSubmittedOrdersHandlerTests
+{
+    private readonly Mock<IOrderRepository> _orderRepositoryMock = new();
+    private readonly Mock<ICommandDispatcher> _commandDispatcherMock = new();
+    private readonly RefreshSubmittedOrdersHandler _handler;
+
+    public RefreshSubmittedOrdersHandlerTests()
+    {
+        _handler = new RefreshSubmittedOrdersHandler(
+            _orderRepositoryMock.Object,
+            _commandDispatcherMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenLimitIsApplied_RefreshesOldestSubmittedOrdersOnly()
+    {
+        // Arrange
+        var oldestSubmitted = CreateSubmittedOrder("submitted-oldest", DateTimeOffset.UtcNow.AddMinutes(-10));
+        var newestSubmitted = CreateSubmittedOrder("submitted-newest", DateTimeOffset.UtcNow.AddMinutes(-1));
+        var filledOrder = CreateFilledOrder("filled-order", DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { newestSubmitted, filledOrder, oldestSubmitted });
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                It.IsAny<RefreshOrderStatusCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RefreshOrderStatusCommand command, CancellationToken _) =>
+                Result<RefreshOrderStatusResult>.Success(new RefreshOrderStatusResult
+                {
+                    OrderId = command.OrderId,
+                    PreviousStatus = OrderLifecycleStatus.Submitted,
+                    CurrentStatus = OrderLifecycleStatus.Filled,
+                    AppliedDomainEffects = true
+                }));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshSubmittedOrdersCommand { Limit = 1 });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalSubmitted.Should().Be(2);
+        result.Value.AttemptedCount.Should().Be(1);
+        result.Value.RefreshedCount.Should().Be(1);
+        result.Value.AppliedDomainEffectsCount.Should().Be(1);
+        result.Value.FailedCount.Should().Be(0);
+
+        _commandDispatcherMock.Verify(
+            x => x.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                It.Is<RefreshOrderStatusCommand>(command => command.OrderId == oldestSubmitted.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _commandDispatcherMock.Verify(
+            x => x.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                It.Is<RefreshOrderStatusCommand>(command => command.OrderId == newestSubmitted.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSomeRefreshesFail_AccumulatesFailureCountsWithoutStoppingBatch()
+    {
+        // Arrange
+        var firstSubmitted = CreateSubmittedOrder("submitted-first", DateTimeOffset.UtcNow.AddMinutes(-2));
+        var secondSubmitted = CreateSubmittedOrder("submitted-second", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        _orderRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { firstSubmitted, secondSubmitted });
+
+        _commandDispatcherMock
+            .SetupSequence(x => x.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+                It.IsAny<RefreshOrderStatusCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<RefreshOrderStatusResult>.Success(new RefreshOrderStatusResult
+            {
+                OrderId = firstSubmitted.Id,
+                PreviousStatus = OrderLifecycleStatus.Submitted,
+                CurrentStatus = OrderLifecycleStatus.Submitted,
+                AppliedDomainEffects = false
+            }))
+            .ReturnsAsync(Result<RefreshOrderStatusResult>.Failure(
+                Error.ExchangeError("exchange unavailable")));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshSubmittedOrdersCommand());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalSubmitted.Should().Be(2);
+        result.Value.AttemptedCount.Should().Be(2);
+        result.Value.RefreshedCount.Should().Be(1);
+        result.Value.AppliedDomainEffectsCount.Should().Be(0);
+        result.Value.FailedCount.Should().Be(1);
+    }
+
+    private static OrderLifecycle CreateSubmittedOrder(string orderId, DateTimeOffset submittedAt)
+    {
+        var order = OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            TradingPair.Create("BTCUSDT", "USDT"),
+            DomainOrderSide.Buy,
+            DomainOrderType.Market,
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            signalRule: "MomentumBreakout",
+            timestamp: submittedAt,
+            intent: OrderIntent.OpenPosition);
+
+        order.ClearDomainEvents();
+        return order;
+    }
+
+    private static OrderLifecycle CreateFilledOrder(string orderId, DateTimeOffset submittedAt)
+    {
+        var order = CreateSubmittedOrder(orderId, submittedAt);
+        order.MarkFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            Money.Create(1000m, "USDT"),
+            Money.Create(1m, "USDT"));
+        order.ClearDomainEvents();
+        return order;
+    }
+}

--- a/tests/IntelliTrader.Application.Tests/Trading/TradingUseCaseTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/TradingUseCaseTests.cs
@@ -1,0 +1,670 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+
+namespace IntelliTrader.Application.Tests.Trading;
+
+public sealed class TradingUseCaseTests
+{
+    private readonly Mock<ICommandDispatcher> _commandDispatcherMock = new();
+    private readonly Mock<IQueryDispatcher> _queryDispatcherMock = new();
+    private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock = new();
+    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+
+    [Fact]
+    public async Task OpenPositionAsync_DispatchesOpenPositionCommand()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+        var expected = new OpenPositionResult
+        {
+            PositionId = PositionId.Create(),
+            Pair = pair,
+            OrderId = OrderId.From("order-1"),
+            EntryPrice = Price.Create(50000m),
+            Quantity = Quantity.Create(0.02m),
+            Cost = Money.Create(1000m, "USDT"),
+            Fees = Money.Create(1m, "USDT"),
+            OpenedAt = DateTimeOffset.UtcNow
+        };
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<OpenPositionCommand, OpenPositionResult>(
+                command,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<OpenPositionResult>.Success(expected));
+
+        var useCase = CreateUseCase();
+
+        var result = await useCase.OpenPositionAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+        _commandDispatcherMock.Verify(
+            x => x.DispatchAsync<OpenPositionCommand, OpenPositionResult>(
+                command,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClosePositionAsync_DispatchesClosePositionCommand()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var positionId = PositionId.Create();
+        var command = new ClosePositionCommand
+        {
+            PositionId = positionId,
+            Reason = CloseReason.TakeProfit
+        };
+        var expected = CreateClosePositionResult(positionId, pair);
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+                command,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ClosePositionResult>.Success(expected));
+
+        var result = await CreateUseCase().ClosePositionAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ClosePositionByPairAsync_DispatchesClosePositionByPairCommand()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new ClosePositionByPairCommand
+        {
+            Pair = pair,
+            Reason = CloseReason.Manual
+        };
+        var expected = CreateClosePositionResult(PositionId.Create(), pair);
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ClosePositionByPairCommand, ClosePositionResult>(
+                command,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ClosePositionResult>.Success(expected));
+
+        var result = await CreateUseCase().ClosePositionByPairAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ExecuteDCAAsync_DispatchesExecuteDcaCommand()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var positionId = PositionId.Create();
+        var command = new ExecuteDCACommand
+        {
+            PositionId = positionId,
+            Cost = Money.Create(500m, "USDT")
+        };
+        var expected = CreateExecuteDcaResult(positionId, pair);
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ExecuteDCACommand, ExecuteDCAResult>(
+                command,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExecuteDCAResult>.Success(expected));
+
+        var result = await CreateUseCase().ExecuteDCAAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ExecuteDCAByPairAsync_DispatchesExecuteDcaByPairCommand()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new ExecuteDCAByPairCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(500m, "USDT")
+        };
+        var expected = CreateExecuteDcaResult(PositionId.Create(), pair);
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ExecuteDCAByPairCommand, ExecuteDCAResult>(
+                command,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExecuteDCAResult>.Success(expected));
+
+        var result = await CreateUseCase().ExecuteDCAByPairAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task CloseAllPositionsAsync_DispatchesCloseForEachActivePosition()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var first = CreatePosition(pair, "order-1");
+        var second = CreatePosition(TradingPair.Create("ETHUSDT", "USDT"), "order-2");
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { first, second });
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+                It.IsAny<ClosePositionCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ClosePositionCommand command, CancellationToken _) =>
+                Result<ClosePositionResult>.Success(CreateClosePositionResult(command.PositionId, pair)));
+
+        var result = await CreateUseCase().CloseAllPositionsAsync(CloseReason.SystemShutdown);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        _commandDispatcherMock.Verify(
+            x => x.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+                It.Is<ClosePositionCommand>(command =>
+                    command.PositionId == first.Id &&
+                    command.Reason == CloseReason.SystemShutdown),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _commandDispatcherMock.Verify(
+            x => x.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+                It.Is<ClosePositionCommand>(command =>
+                    command.PositionId == second.Id &&
+                    command.Reason == CloseReason.SystemShutdown),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CloseAllPositionsAsync_WhenCloseFails_ReturnsFailure()
+    {
+        var position = CreatePosition(TradingPair.Create("BTCUSDT", "USDT"), "order-1");
+
+        _positionRepositoryMock
+            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+
+        _commandDispatcherMock
+            .Setup(x => x.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+                It.IsAny<ClosePositionCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ClosePositionResult>.Failure(Error.ExchangeError("close failed")));
+
+        var result = await CreateUseCase().CloseAllPositionsAsync();
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("close failed");
+    }
+
+    [Fact]
+    public async Task QueryMethods_DispatchToQueryDispatcher()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var positionView = CreatePositionView("BTCUSDT", 1000m, 1100m, 99m, 9.89m);
+        var portfolioView = CreatePortfolioView();
+        var statistics = CreatePortfolioStatistics();
+        var history = new[] { CreateTradeHistoryEntry(positionView.Id, pair) };
+
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetPositionQuery, PositionView>(
+                It.IsAny<GetPositionQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PositionView>.Success(positionView));
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetActivePositionsQuery, IReadOnlyList<PositionView>>(
+                It.Is<GetActivePositionsQuery>(query => query.Market == "USDT"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PositionView>>.Success(new[] { positionView }));
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetClosedPositionsQuery, IReadOnlyList<PositionView>>(
+                It.IsAny<GetClosedPositionsQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PositionView>>.Success(new[] { positionView }));
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetPortfolioQuery, PortfolioView>(
+                It.IsAny<GetPortfolioQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PortfolioView>.Success(portfolioView));
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetPortfolioStatisticsQuery, PortfolioStatistics>(
+                It.IsAny<GetPortfolioStatisticsQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<PortfolioStatistics>.Success(statistics));
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetTradingHistoryQuery, IReadOnlyList<TradeHistoryEntry>>(
+                It.IsAny<GetTradingHistoryQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<TradeHistoryEntry>>.Success(history));
+
+        var useCase = CreateUseCase();
+
+        (await useCase.GetPositionAsync(new GetPositionQuery { Pair = pair })).Value.Should().Be(positionView);
+        (await useCase.GetActivePositionsAsync(new GetActivePositionsQuery { Market = "USDT" })).Value.Should().ContainSingle();
+        (await useCase.GetClosedPositionsAsync(new GetClosedPositionsQuery { Pair = pair })).Value.Should().ContainSingle();
+        (await useCase.GetPortfolioAsync(new GetPortfolioQuery())).Value.Should().Be(portfolioView);
+        (await useCase.GetPortfolioStatisticsAsync(new GetPortfolioStatisticsQuery())).Value.Should().Be(statistics);
+        (await useCase.GetTradingHistoryAsync(new GetTradingHistoryQuery { Pair = pair })).Value.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetPositionsSummaryAsync_ComposesSummaryFromActivePositionQuery()
+    {
+        var btc = CreatePositionView("BTCUSDT", 1000m, 1100m, 99m, 9.89m);
+        var eth = CreatePositionView("ETHUSDT", 1000m, 900m, -101m, -10.09m);
+
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetActivePositionsQuery, IReadOnlyList<PositionView>>(
+                It.IsAny<GetActivePositionsQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PositionView>>.Success(new[] { btc, eth }));
+
+        var useCase = CreateUseCase();
+
+        var result = await useCase.GetPositionsSummaryAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalPositions.Should().Be(2);
+        result.Value.ProfitablePositions.Should().Be(1);
+        result.Value.LosingPositions.Should().Be(1);
+        result.Value.TotalInvested.Amount.Should().Be(2000m);
+        result.Value.TotalCurrentValue.Amount.Should().Be(2000m);
+        result.Value.TotalUnrealizedPnL.Amount.Should().Be(-2m);
+        result.Value.BestPerformer.Should().Be(btc.Pair);
+        result.Value.WorstPerformer.Should().Be(eth.Pair);
+    }
+
+    [Fact]
+    public async Task GetPositionsSummaryAsync_WhenNoActivePositions_ReturnsZeroSummary()
+    {
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetActivePositionsQuery, IReadOnlyList<PositionView>>(
+                It.IsAny<GetActivePositionsQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PositionView>>.Success(Array.Empty<PositionView>()));
+
+        var result = await CreateUseCase().GetPositionsSummaryAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalPositions.Should().Be(0);
+        result.Value.TotalInvested.Amount.Should().Be(0m);
+        result.Value.AverageMargin.Should().Be(Margin.Zero);
+    }
+
+    [Fact]
+    public async Task GetPositionsSummaryAsync_WhenActivePositionQueryFails_ReturnsFailure()
+    {
+        _queryDispatcherMock
+            .Setup(x => x.DispatchAsync<GetActivePositionsQuery, IReadOnlyList<PositionView>>(
+                It.IsAny<GetActivePositionsQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PositionView>>.Failure(Error.ExchangeError("price failed")));
+
+        var result = await CreateUseCase().GetPositionsSummaryAsync();
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("price failed");
+    }
+
+    [Fact]
+    public async Task CanOpenPositionAsync_WhenPortfolioHasCapacityAndFunds_AllowsOpen()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        var useCase = CreateUseCase();
+
+        var result = await useCase.CanOpenPositionAsync(pair, Money.Create(1000m, "USDT"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanOpen.Should().BeTrue();
+        result.Value.Pair.Should().Be(pair);
+        result.Value.AvailableBalance.Amount.Should().Be(5000m);
+        result.Value.CurrentPositionCount.Should().Be(0);
+        result.Value.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CanOpenPositionAsync_WhenPairAlreadyExists_ReturnsValidationErrors()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+        portfolio.RecordPositionOpened(PositionId.Create(), pair, Money.Create(1000m, "USDT"));
+        portfolio.ClearDomainEvents();
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        var useCase = CreateUseCase();
+
+        var result = await useCase.CanOpenPositionAsync(pair, Money.Create(1000m, "USDT"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanOpen.Should().BeFalse();
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("already exists", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CanOpenPositionAsync_WhenPortfolioMissing_ReturnsFailure()
+    {
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Portfolio?)null);
+
+        var result = await CreateUseCase().CanOpenPositionAsync(
+            TradingPair.Create("BTCUSDT", "USDT"),
+            Money.Create(1000m, "USDT"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task CanOpenPositionAsync_WhenCostViolatesConstraints_ReturnsAllValidationErrors()
+    {
+        var existingPair = TradingPair.Create("ETHUSDT", "USDT");
+        var requestedPair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 1000m, 1, 100m);
+        portfolio.RecordPositionOpened(PositionId.Create(), existingPair, Money.Create(900m, "USDT"));
+        portfolio.ClearDomainEvents();
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        var result = await CreateUseCase().CanOpenPositionAsync(requestedPair, Money.Create(200m, "USDT"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanOpen.Should().BeFalse();
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("Insufficient funds", StringComparison.Ordinal));
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("Maximum positions", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CanOpenPositionAsync_WhenCurrencyDoesNotMatch_ReturnsValidationError()
+    {
+        var portfolio = Portfolio.Create("Default", "USDT", 1000m, 5, 100m);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        var result = await CreateUseCase().CanOpenPositionAsync(
+            TradingPair.Create("BTCEUR", "EUR"),
+            Money.Create(200m, "EUR"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanOpen.Should().BeFalse();
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("does not match", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CanExecuteDCAAsync_WhenPositionCanDca_ReturnsAllowed()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreatePosition(pair, "order-btc-1");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+        portfolio.RecordPositionOpened(position.Id, pair, Money.Create(1000m, "USDT"));
+        portfolio.ClearDomainEvents();
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        var result = await CreateUseCase().CanExecuteDCAAsync(position.Id, Money.Create(500m, "USDT"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanDCA.Should().BeTrue();
+        result.Value.PositionId.Should().Be(position.Id);
+        result.Value.CurrentDCALevel.Should().Be(0);
+        result.Value.MaxDCALevels.Should().Be(int.MaxValue);
+        result.Value.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CanExecuteDCAAsync_WhenPositionMissing_ReturnsFailure()
+    {
+        var positionId = PositionId.Create();
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(positionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Position?)null);
+
+        var result = await CreateUseCase().CanExecuteDCAAsync(positionId, Money.Create(500m, "USDT"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task CanExecuteDCAAsync_WhenExchangePriceFails_ReturnsFailure()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreatePosition(pair, "order-btc-1");
+        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price failed")));
+
+        var result = await CreateUseCase().CanExecuteDCAAsync(position.Id, Money.Create(500m, "USDT"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("price failed");
+    }
+
+    [Fact]
+    public async Task CanExecuteDCAAsync_WhenPositionCannotDca_ReturnsValidationErrors()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreatePosition(pair, "order-btc-1");
+        position.Close(OrderId.From("sell-btc-1"), Price.Create(55000m), Money.Create(1m, "USDT"));
+        position.ClearDomainEvents();
+        var portfolio = Portfolio.Create("Default", "USDT", 100m, 5, 100m);
+
+        _positionRepositoryMock
+            .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        var result = await CreateUseCase().CanExecuteDCAAsync(position.Id, Money.Create(500m, "EUR"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CanDCA.Should().BeFalse();
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("closed", StringComparison.Ordinal));
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("does not contain active position", StringComparison.Ordinal));
+        result.Value.ValidationErrors.Should().Contain(error => error.Contains("does not match", StringComparison.Ordinal));
+    }
+
+    private TradingUseCase CreateUseCase()
+    {
+        return new TradingUseCase(
+            _commandDispatcherMock.Object,
+            _queryDispatcherMock.Object,
+            _portfolioRepositoryMock.Object,
+            _positionRepositoryMock.Object,
+            _exchangePortMock.Object);
+    }
+
+    private static PositionView CreatePositionView(
+        string symbol,
+        decimal invested,
+        decimal currentValue,
+        decimal pnl,
+        decimal margin)
+    {
+        var pair = TradingPair.Create(symbol, "USDT");
+        return new PositionView
+        {
+            Id = PositionId.Create(),
+            Pair = pair,
+            AveragePrice = Price.Create(invested),
+            CurrentPrice = Price.Create(currentValue),
+            TotalQuantity = Quantity.Create(1m),
+            TotalCost = Money.Create(invested, "USDT"),
+            TotalFees = Money.Zero("USDT"),
+            CurrentValue = Money.Create(currentValue, "USDT"),
+            UnrealizedPnL = Money.Create(pnl, "USDT"),
+            CurrentMargin = Margin.FromPercentage(margin),
+            DCALevel = 0,
+            EntryCount = 1,
+            OpenedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            HoldingPeriod = TimeSpan.FromHours(2),
+            IsClosed = false
+        };
+    }
+
+    private static Position CreatePosition(TradingPair pair, string orderId)
+    {
+        var position = Position.Open(
+            pair,
+            OrderId.From(orderId),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, pair.QuoteCurrency));
+
+        position.ClearDomainEvents();
+        return position;
+    }
+
+    private static ClosePositionResult CreateClosePositionResult(PositionId positionId, TradingPair pair)
+    {
+        return new ClosePositionResult
+        {
+            PositionId = positionId,
+            Pair = pair,
+            SellOrderId = OrderId.From($"sell-{positionId.Value:N}"),
+            SellPrice = Price.Create(55000m),
+            Quantity = Quantity.Create(0.02m),
+            Proceeds = Money.Create(1100m, pair.QuoteCurrency),
+            Fees = Money.Create(1m, pair.QuoteCurrency),
+            TotalCost = Money.Create(1000m, pair.QuoteCurrency),
+            RealizedPnL = Money.Create(99m, pair.QuoteCurrency),
+            RealizedMargin = Margin.FromPercentage(9.89m),
+            HoldingPeriod = TimeSpan.FromHours(2),
+            Reason = CloseReason.Manual,
+            ClosedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExecuteDCAResult CreateExecuteDcaResult(PositionId positionId, TradingPair pair)
+    {
+        return new ExecuteDCAResult
+        {
+            PositionId = positionId,
+            Pair = pair,
+            OrderId = OrderId.From($"dca-{positionId.Value:N}"),
+            EntryPrice = Price.Create(49000m),
+            Quantity = Quantity.Create(0.01m),
+            Cost = Money.Create(500m, pair.QuoteCurrency),
+            Fees = Money.Create(0.5m, pair.QuoteCurrency),
+            NewDCALevel = 1,
+            NewAveragePrice = Price.Create(49666.66666667m),
+            NewTotalQuantity = Quantity.Create(0.03m),
+            NewTotalCost = Money.Create(1500m, pair.QuoteCurrency),
+            ExecutedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static PortfolioView CreatePortfolioView()
+    {
+        return new PortfolioView
+        {
+            Id = PortfolioId.Create(),
+            Name = "Default",
+            Market = "USDT",
+            TotalBalance = Money.Create(5000m, "USDT"),
+            AvailableBalance = Money.Create(4000m, "USDT"),
+            ReservedBalance = Money.Create(1000m, "USDT"),
+            ActivePositionCount = 1,
+            MaxPositions = 5,
+            MinPositionCost = Money.Create(100m, "USDT"),
+            CanOpenNewPosition = true,
+            AvailablePercentage = 80m,
+            ReservedPercentage = 20m,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static PortfolioStatistics CreatePortfolioStatistics()
+    {
+        return new PortfolioStatistics
+        {
+            PortfolioId = PortfolioId.Create(),
+            TotalBalance = Money.Create(5000m, "USDT"),
+            AvailableBalance = Money.Create(4000m, "USDT"),
+            InvestedBalance = Money.Create(1000m, "USDT"),
+            ActivePositions = 1,
+            MaxPositions = 5,
+            PositionSlotsAvailable = 4,
+            TotalUnrealizedPnL = Money.Create(99m, "USDT"),
+            TotalRealizedPnL = Money.Zero("USDT"),
+            OverallMargin = Margin.FromPercentage(9.89m),
+            TotalTradesCount = 1,
+            WinningTradesCount = 1,
+            LosingTradesCount = 0,
+            WinRate = 100m,
+            AverageWin = Money.Create(99m, "USDT"),
+            AverageLoss = Money.Zero("USDT"),
+            ProfitFactor = 0m,
+            MaxDrawdown = Money.Zero("USDT"),
+            MaxDrawdownPercent = 0m,
+            Sharpe = 0m,
+            StatisticsAsOf = DateTimeOffset.UtcNow,
+            AverageHoldingPeriod = TimeSpan.FromHours(2)
+        };
+    }
+
+    private static TradeHistoryEntry CreateTradeHistoryEntry(PositionId positionId, TradingPair pair)
+    {
+        return new TradeHistoryEntry
+        {
+            PositionId = positionId,
+            Pair = pair,
+            Type = TradeType.Buy,
+            Price = Price.Create(50000m),
+            Quantity = Quantity.Create(0.02m),
+            Cost = Money.Create(1000m, pair.QuoteCurrency),
+            Fees = Money.Create(1m, pair.QuoteCurrency),
+            Timestamp = DateTimeOffset.UtcNow,
+            OrderId = "order-1"
+        };
+    }
+}

--- a/tests/IntelliTrader.Core.Tests/CoreServiceAdditionalTests.cs
+++ b/tests/IntelliTrader.Core.Tests/CoreServiceAdditionalTests.cs
@@ -21,7 +21,7 @@ public class CoreServiceAdditionalTests
     private readonly Mock<IWebService> _webServiceMock;
     private readonly Mock<IBacktestingService> _backtestingServiceMock;
     private readonly Mock<IAlertingService> _alertingServiceMock;
-    private readonly Mock<ISubmittedOrderRefreshService> _submittedOrderRefreshServiceMock;
+    private readonly Mock<IActiveOrderRefreshService> _activeOrderRefreshServiceMock;
     private readonly Mock<IApplicationContext> _applicationContextMock;
     private readonly Mock<IConfigProvider> _configProviderMock;
     private readonly Mock<ISecretRotationService> _secretRotationServiceMock;
@@ -36,7 +36,7 @@ public class CoreServiceAdditionalTests
         _webServiceMock = new Mock<IWebService>();
         _backtestingServiceMock = new Mock<IBacktestingService>();
         _alertingServiceMock = new Mock<IAlertingService>();
-        _submittedOrderRefreshServiceMock = new Mock<ISubmittedOrderRefreshService>();
+        _activeOrderRefreshServiceMock = new Mock<IActiveOrderRefreshService>();
         _applicationContextMock = new Mock<IApplicationContext>();
         _applicationContextMock.Setup(x => x.Speed).Returns(1.0);
         _configProviderMock = new Mock<IConfigProvider>();
@@ -90,7 +90,7 @@ public class CoreServiceAdditionalTests
             _webServiceMock.Object,
             _backtestingServiceMock.Object,
             _alertingServiceMock.Object,
-            _submittedOrderRefreshServiceMock.Object,
+            _activeOrderRefreshServiceMock.Object,
             _applicationContextMock.Object,
             _configProviderMock.Object,
             new Lazy<ISecretRotationService>(() => _secretRotationServiceMock.Object)

--- a/tests/IntelliTrader.Core.Tests/CoreServiceAdditionalTests.cs
+++ b/tests/IntelliTrader.Core.Tests/CoreServiceAdditionalTests.cs
@@ -21,6 +21,7 @@ public class CoreServiceAdditionalTests
     private readonly Mock<IWebService> _webServiceMock;
     private readonly Mock<IBacktestingService> _backtestingServiceMock;
     private readonly Mock<IAlertingService> _alertingServiceMock;
+    private readonly Mock<ISubmittedOrderRefreshService> _submittedOrderRefreshServiceMock;
     private readonly Mock<IApplicationContext> _applicationContextMock;
     private readonly Mock<IConfigProvider> _configProviderMock;
     private readonly Mock<ISecretRotationService> _secretRotationServiceMock;
@@ -35,6 +36,7 @@ public class CoreServiceAdditionalTests
         _webServiceMock = new Mock<IWebService>();
         _backtestingServiceMock = new Mock<IBacktestingService>();
         _alertingServiceMock = new Mock<IAlertingService>();
+        _submittedOrderRefreshServiceMock = new Mock<ISubmittedOrderRefreshService>();
         _applicationContextMock = new Mock<IApplicationContext>();
         _applicationContextMock.Setup(x => x.Speed).Returns(1.0);
         _configProviderMock = new Mock<IConfigProvider>();
@@ -88,6 +90,7 @@ public class CoreServiceAdditionalTests
             _webServiceMock.Object,
             _backtestingServiceMock.Object,
             _alertingServiceMock.Object,
+            _submittedOrderRefreshServiceMock.Object,
             _applicationContextMock.Object,
             _configProviderMock.Object,
             new Lazy<ISecretRotationService>(() => _secretRotationServiceMock.Object)

--- a/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
+++ b/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
@@ -19,7 +19,7 @@ public class CoreServiceTests
     private readonly Mock<IWebService> _webServiceMock;
     private readonly Mock<IBacktestingService> _backtestingServiceMock;
     private readonly Mock<IAlertingService> _alertingServiceMock;
-    private readonly Mock<ISubmittedOrderRefreshService> _submittedOrderRefreshServiceMock;
+    private readonly Mock<IActiveOrderRefreshService> _activeOrderRefreshServiceMock;
     private readonly Mock<IApplicationContext> _applicationContextMock;
     private readonly Mock<IConfigProvider> _configProviderMock;
     private readonly Mock<ISecretRotationService> _secretRotationServiceMock;
@@ -34,7 +34,7 @@ public class CoreServiceTests
         _webServiceMock = new Mock<IWebService>();
         _backtestingServiceMock = new Mock<IBacktestingService>();
         _alertingServiceMock = new Mock<IAlertingService>();
-        _submittedOrderRefreshServiceMock = new Mock<ISubmittedOrderRefreshService>();
+        _activeOrderRefreshServiceMock = new Mock<IActiveOrderRefreshService>();
         _applicationContextMock = new Mock<IApplicationContext>();
         _applicationContextMock.Setup(x => x.Speed).Returns(1.0);
         _configProviderMock = new Mock<IConfigProvider>();
@@ -109,7 +109,7 @@ public class CoreServiceTests
             _webServiceMock.Object,
             _backtestingServiceMock.Object,
             _alertingServiceMock.Object,
-            _submittedOrderRefreshServiceMock.Object,
+            _activeOrderRefreshServiceMock.Object,
             _applicationContextMock.Object,
             _configProviderMock.Object,
             new Lazy<ISecretRotationService>(() => _secretRotationServiceMock.Object)
@@ -377,7 +377,7 @@ public class CoreServiceTests
     #region Runtime Service Wiring Tests
 
     [Fact]
-    public void Start_WhenTradingEnabled_StartsSubmittedOrderRefreshService()
+    public void Start_WhenTradingEnabled_StartsActiveOrderRefreshService()
     {
         // Arrange
         var tradingConfigMock = new Mock<ITradingConfig>();
@@ -389,20 +389,50 @@ public class CoreServiceTests
         _sut.Stop();
 
         // Assert
-        _submittedOrderRefreshServiceMock.Verify(x => x.Start(), Times.Once);
-        _submittedOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Once);
+        _activeOrderRefreshServiceMock.Verify(x => x.Start(), Times.Once);
+        _activeOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Once);
     }
 
     [Fact]
-    public void Start_WhenTradingDisabled_DoesNotStartSubmittedOrderRefreshService()
+    public void Start_WhenTradingDisabled_DoesNotStartActiveOrderRefreshService()
     {
         // Act
         _sut.Start();
         _sut.Stop();
 
         // Assert
-        _submittedOrderRefreshServiceMock.Verify(x => x.Start(), Times.Never);
-        _submittedOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Never);
+        _activeOrderRefreshServiceMock.Verify(x => x.Start(), Times.Never);
+        _activeOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Never);
+    }
+
+    [Fact]
+    public void StartAndStop_WhenTradingEnabled_StartsAndStopsActiveRefreshAroundTrading()
+    {
+        // Arrange
+        var tradingConfigMock = new Mock<ITradingConfig>();
+        tradingConfigMock.Setup(x => x.Enabled).Returns(true);
+        _tradingServiceMock.Setup(x => x.Config).Returns(tradingConfigMock.Object);
+
+        var lifecycleCalls = new List<string>();
+        _tradingServiceMock.Setup(x => x.Start())
+            .Callback(() => lifecycleCalls.Add("trading-start"));
+        _activeOrderRefreshServiceMock.Setup(x => x.Start())
+            .Callback(() => lifecycleCalls.Add("refresh-start"));
+        _activeOrderRefreshServiceMock.Setup(x => x.Stop())
+            .Callback(() => lifecycleCalls.Add("refresh-stop"));
+        _tradingServiceMock.Setup(x => x.Stop())
+            .Callback(() => lifecycleCalls.Add("trading-stop"));
+
+        // Act
+        _sut.Start();
+        _sut.Stop();
+
+        // Assert
+        lifecycleCalls.Should().ContainInOrder(
+            "trading-start",
+            "refresh-start",
+            "refresh-stop",
+            "trading-stop");
     }
 
     #endregion

--- a/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
+++ b/tests/IntelliTrader.Core.Tests/CoreServiceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Xunit;
 using IntelliTrader.Core;
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
 
 #pragma warning disable CS0612 // Type or member is obsolete
 using System.Reflection;
@@ -18,6 +19,7 @@ public class CoreServiceTests
     private readonly Mock<IWebService> _webServiceMock;
     private readonly Mock<IBacktestingService> _backtestingServiceMock;
     private readonly Mock<IAlertingService> _alertingServiceMock;
+    private readonly Mock<ISubmittedOrderRefreshService> _submittedOrderRefreshServiceMock;
     private readonly Mock<IApplicationContext> _applicationContextMock;
     private readonly Mock<IConfigProvider> _configProviderMock;
     private readonly Mock<ISecretRotationService> _secretRotationServiceMock;
@@ -32,6 +34,7 @@ public class CoreServiceTests
         _webServiceMock = new Mock<IWebService>();
         _backtestingServiceMock = new Mock<IBacktestingService>();
         _alertingServiceMock = new Mock<IAlertingService>();
+        _submittedOrderRefreshServiceMock = new Mock<ISubmittedOrderRefreshService>();
         _applicationContextMock = new Mock<IApplicationContext>();
         _applicationContextMock.Setup(x => x.Speed).Returns(1.0);
         _configProviderMock = new Mock<IConfigProvider>();
@@ -44,6 +47,21 @@ public class CoreServiceTests
 
     private void SetupDefaultMocks()
     {
+        var coreConfig = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{Constants.ServiceNames.CoreService}:InstanceName"] = "TestInstance",
+                [$"{Constants.ServiceNames.CoreService}:HealthCheckEnabled"] = "true",
+                [$"{Constants.ServiceNames.CoreService}:HealthCheckInterval"] = "10",
+                [$"{Constants.ServiceNames.CoreService}:HealthCheckSuspendTradingTimeout"] = "0",
+                [$"{Constants.ServiceNames.CoreService}:HealthCheckFailuresToRestartServices"] = "0"
+            })
+            .Build();
+
+        _configProviderMock
+            .Setup(x => x.GetSection(Constants.ServiceNames.CoreService, It.IsAny<Action<IConfigurationSection>>()))
+            .Returns(coreConfig.GetSection(Constants.ServiceNames.CoreService));
+
         // Setup backtesting config (disabled by default)
         var backtestingConfigMock = new Mock<IBacktestingConfig>();
         backtestingConfigMock.Setup(x => x.Enabled).Returns(false);
@@ -91,6 +109,7 @@ public class CoreServiceTests
             _webServiceMock.Object,
             _backtestingServiceMock.Object,
             _alertingServiceMock.Object,
+            _submittedOrderRefreshServiceMock.Object,
             _applicationContextMock.Object,
             _configProviderMock.Object,
             new Lazy<ISecretRotationService>(() => _secretRotationServiceMock.Object)
@@ -351,6 +370,39 @@ public class CoreServiceTests
 
         // Assert
         act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region Runtime Service Wiring Tests
+
+    [Fact]
+    public void Start_WhenTradingEnabled_StartsSubmittedOrderRefreshService()
+    {
+        // Arrange
+        var tradingConfigMock = new Mock<ITradingConfig>();
+        tradingConfigMock.Setup(x => x.Enabled).Returns(true);
+        _tradingServiceMock.Setup(x => x.Config).Returns(tradingConfigMock.Object);
+
+        // Act
+        _sut.Start();
+        _sut.Stop();
+
+        // Assert
+        _submittedOrderRefreshServiceMock.Verify(x => x.Start(), Times.Once);
+        _submittedOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Once);
+    }
+
+    [Fact]
+    public void Start_WhenTradingDisabled_DoesNotStartSubmittedOrderRefreshService()
+    {
+        // Act
+        _sut.Start();
+        _sut.Stop();
+
+        // Assert
+        _submittedOrderRefreshServiceMock.Verify(x => x.Start(), Times.Never);
+        _submittedOrderRefreshServiceMock.Verify(x => x.Stop(), Times.Never);
     }
 
     #endregion

--- a/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PortfolioTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PortfolioTests.cs
@@ -386,6 +386,48 @@ public class PortfolioTests
 
     #endregion
 
+    #region Record Position Cost Reduced
+
+    [Fact]
+    public void RecordPositionCostReduced_WithPartialClose_UpdatesReservedCostAndRealizedPnL()
+    {
+        // Arrange
+        var portfolio = Portfolio.Create("Main", "USDT", 10000m, 10, 100m);
+        var positionId = CreatePositionId();
+        var pair = CreatePair();
+        portfolio.RecordPositionOpened(positionId, pair, CreateMoney(1000m));
+        portfolio.ClearDomainEvents();
+
+        // Act
+        portfolio.RecordPositionCostReduced(positionId, pair, CreateMoney(400m), CreateMoney(450m));
+
+        // Assert
+        portfolio.HasPositionFor(pair).Should().BeTrue();
+        portfolio.GetPositionCost(positionId)!.Amount.Should().Be(600m);
+        portfolio.Balance.Reserved.Amount.Should().Be(600m);
+        portfolio.Balance.Available.Amount.Should().Be(9450m);
+        portfolio.Balance.Total.Amount.Should().Be(10050m);
+        portfolio.DomainEvents.Should().Contain(e => e is PortfolioBalanceChanged);
+    }
+
+    [Fact]
+    public void RecordPositionCostReduced_WhenReleasedCostExceedsTrackedCost_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var portfolio = Portfolio.Create("Main", "USDT", 10000m, 10, 100m);
+        var positionId = CreatePositionId();
+        var pair = CreatePair();
+        portfolio.RecordPositionOpened(positionId, pair, CreateMoney(1000m));
+
+        // Act
+        var act = () => portfolio.RecordPositionCostReduced(positionId, pair, CreateMoney(1001m), CreateMoney(1200m));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cannot reduce more than tracked position cost*");
+    }
+
+    #endregion
+
     #region CanOpenNewPosition
 
     [Fact]

--- a/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
@@ -110,6 +110,35 @@ public class PositionTests
         act.Should().Throw<ArgumentNullException>().WithParameterName("pair");
     }
 
+    [Fact]
+    public void ApplyOpeningFillDelta_WithHigherCumulativeQuantity_UpdatesInitialEntryWithoutIncreasingDcaLevel()
+    {
+        // Arrange
+        var orderId = CreateOrderId("open-partial-1");
+        var position = Position.Open(
+            CreatePair(),
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.02m),
+            CreateFees(1m),
+            "buy_signal");
+
+        // Act
+        position.ApplyOpeningFillDelta(
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.05m),
+            CreateFees(2.5m));
+
+        // Assert
+        position.DCALevel.Should().Be(0);
+        position.Entries.Should().ContainSingle();
+        position.TotalQuantity.Value.Should().Be(0.05m);
+        position.TotalCost.Amount.Should().Be(2500m);
+        position.TotalFees.Amount.Should().Be(2.5m);
+        position.GetEntryAtLevel(0)!.OrderId.Should().Be(orderId);
+    }
+
     #endregion
 
     #region DCA Entry

--- a/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
@@ -399,6 +399,37 @@ public class PositionTests
     }
 
     [Fact]
+    public void ApplyCloseFillDelta_WhenPartiallySold_ReducesPositionAndRaisesPartialCloseEvent()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("buy1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.ClearDomainEvents();
+
+        // Act
+        var result = position.ApplyCloseFillDelta(
+            CreateOrderId("sell1"),
+            CreatePrice(55000m),
+            CreateQuantity(0.04m),
+            CreateFees(2m));
+
+        // Assert
+        result.PositionClosed.Should().BeFalse();
+        result.ReleasedCost.Amount.Should().Be(2000m);
+        result.Proceeds.Amount.Should().Be(2200m);
+        position.IsClosed.Should().BeFalse();
+        position.TotalQuantity.Value.Should().Be(0.06m);
+        position.TotalCost.Amount.Should().Be(3000m);
+        position.TotalFees.Amount.Should().Be(3m);
+        position.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<PositionPartiallyClosed>();
+    }
+
+    [Fact]
     public void Close_OnAlreadyClosedPosition_ThrowsInvalidOperationException()
     {
         // Arrange

--- a/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
@@ -270,6 +270,54 @@ public class PositionTests
     }
 
     [Fact]
+    public void AddDCAEntry_WithZeroPrice_ThrowsArgumentException()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.AddDCAEntry(
+            CreateOrderId("order2"),
+            Price.Zero,
+            CreateQuantity(0.15m),
+            CreateFees(6m));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("price")
+            .WithMessage("*Price cannot be zero*");
+    }
+
+    [Fact]
+    public void AddDCAEntry_WithZeroQuantity_ThrowsArgumentException()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.AddDCAEntry(
+            CreateOrderId("order2"),
+            CreatePrice(45000m),
+            Quantity.Zero,
+            CreateFees(6m));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("quantity")
+            .WithMessage("*Quantity cannot be zero*");
+    }
+
+    [Fact]
     public void MultipleDCAEntries_CalculatesCorrectDCALevel()
     {
         // Arrange
@@ -372,6 +420,29 @@ public class PositionTests
         // Assert
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*closed*");
+    }
+
+    [Fact]
+    public void Close_WithZeroSellPrice_ThrowsArgumentException()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("buy1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.Close(
+            CreateOrderId("sell1"),
+            Price.Zero,
+            CreateFees(5m));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("sellPrice")
+            .WithMessage("*Sell price cannot be zero*");
     }
 
     #endregion
@@ -507,6 +578,26 @@ public class PositionTests
         pnl.IsNegative.Should().BeTrue();
     }
 
+    [Fact]
+    public void CalculateUnrealizedPnL_WithEstimatedSellFees_AccountsForAdditionalFees()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId(),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(50m));
+
+        // Act
+        var pnl = position.CalculateUnrealizedPnL(
+            CreatePrice(55000m),
+            CreateFees(25m));
+
+        // Assert
+        pnl.Amount.Should().Be(425m); // 5500 - (5000 + 50 + 25)
+    }
+
     #endregion
 
     #region DCA Conditions
@@ -631,6 +722,24 @@ public class PositionTests
     }
 
     [Fact]
+    public void GetEntryAtLevel_WithNegativeLevel_ReturnsNull()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var entry = position.GetEntryAtLevel(-1);
+
+        // Assert
+        entry.Should().BeNull();
+    }
+
+    [Fact]
     public void GetLastBuyMargin_ReturnsMarginForLastEntry()
     {
         // Arrange
@@ -708,6 +817,261 @@ public class PositionTests
 
         // Assert
         timeSinceLastBuy.TotalMinutes.Should().BeApproximately(30, 1);
+    }
+
+    #endregion
+
+    #region Fill Delta
+
+    [Fact]
+    public void ApplyDCAFillDelta_WithHigherCumulativeQuantity_UpdatesExistingEntryWithDeltaEvent()
+    {
+        // Arrange
+        var openOrderId = CreateOrderId("order1");
+        var dcaOrderId = CreateOrderId("order2");
+        var position = Position.Open(
+            CreatePair(),
+            openOrderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.AddDCAEntry(
+            dcaOrderId,
+            CreatePrice(45000m),
+            CreateQuantity(0.1m),
+            CreateFees(4m));
+        position.ClearDomainEvents();
+
+        // Act
+        position.ApplyDCAFillDelta(
+            dcaOrderId,
+            CreatePrice(44000m),
+            CreateQuantity(0.15m),
+            CreateFees(6m));
+
+        // Assert
+        position.DCALevel.Should().Be(1);
+        position.TotalQuantity.Value.Should().Be(0.25m);
+        position.TotalCost.Amount.Should().Be(11600m); // 5000 + 6600
+        position.TotalFees.Amount.Should().Be(11m); // 5 + 6
+        position.GetEntryAtLevel(1)!.Quantity.Value.Should().Be(0.15m);
+
+        position.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<DCAExecuted>();
+
+        var evt = (DCAExecuted)position.DomainEvents.Single();
+        evt.Quantity.Value.Should().Be(0.05m);
+        evt.Fees.Amount.Should().Be(2m);
+        evt.Cost.Amount.Should().Be(2100m);
+    }
+
+    [Fact]
+    public void ApplyDCAFillDelta_WithMissingEntry_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.ApplyDCAFillDelta(
+            CreateOrderId("missing"),
+            CreatePrice(44000m),
+            CreateQuantity(0.15m),
+            CreateFees(6m));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*No DCA entry exists*");
+    }
+
+    [Fact]
+    public void ApplyDCAFillDelta_WithLowerCumulativeQuantity_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var dcaOrderId = CreateOrderId("order2");
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.AddDCAEntry(
+            dcaOrderId,
+            CreatePrice(45000m),
+            CreateQuantity(0.1m),
+            CreateFees(4m));
+
+        // Act
+        var act = () => position.ApplyDCAFillDelta(
+            dcaOrderId,
+            CreatePrice(44000m),
+            CreateQuantity(0.05m),
+            CreateFees(3m));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot be lower than the already applied quantity*");
+    }
+
+    [Fact]
+    public void ApplyDCAFillDelta_WithSameCumulativeQuantity_DoesNothing()
+    {
+        // Arrange
+        var dcaOrderId = CreateOrderId("order2");
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.AddDCAEntry(
+            dcaOrderId,
+            CreatePrice(45000m),
+            CreateQuantity(0.1m),
+            CreateFees(4m));
+        position.ClearDomainEvents();
+
+        // Act
+        position.ApplyDCAFillDelta(
+            dcaOrderId,
+            CreatePrice(45000m),
+            CreateQuantity(0.1m),
+            CreateFees(4m));
+
+        // Assert
+        position.TotalQuantity.Value.Should().Be(0.2m);
+        position.TotalFees.Amount.Should().Be(9m);
+        position.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyDCAFillDelta_WithDifferentCurrency_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var dcaOrderId = CreateOrderId("order2");
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.AddDCAEntry(
+            dcaOrderId,
+            CreatePrice(45000m),
+            CreateQuantity(0.1m),
+            CreateFees(4m));
+
+        // Act
+        var act = () => position.ApplyDCAFillDelta(
+            dcaOrderId,
+            CreatePrice(44000m),
+            CreateQuantity(0.15m),
+            Money.Create(6m, "BTC"));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Fee currency mismatch*");
+    }
+
+    [Fact]
+    public void ApplyOpeningFillDelta_WithDifferentCurrency_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var orderId = CreateOrderId("order1");
+        var position = Position.Open(
+            CreatePair(),
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.ApplyOpeningFillDelta(
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.15m),
+            Money.Create(6m, "BTC"));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Fee currency mismatch*");
+    }
+
+    [Fact]
+    public void ApplyOpeningFillDelta_WithMissingOpeningEntry_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("order1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.ApplyOpeningFillDelta(
+            CreateOrderId("missing"),
+            CreatePrice(50000m),
+            CreateQuantity(0.15m),
+            CreateFees(6m));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*No opening entry exists*");
+    }
+
+    [Fact]
+    public void ApplyOpeningFillDelta_WithLowerCumulativeQuantity_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var orderId = CreateOrderId("order1");
+        var position = Position.Open(
+            CreatePair(),
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Act
+        var act = () => position.ApplyOpeningFillDelta(
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.05m),
+            CreateFees(4m));
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot be lower than the already applied quantity*");
+    }
+
+    [Fact]
+    public void ApplyOpeningFillDelta_WithSameCumulativeQuantity_DoesNothing()
+    {
+        // Arrange
+        var orderId = CreateOrderId("order1");
+        var position = Position.Open(
+            CreatePair(),
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+        position.ClearDomainEvents();
+
+        // Act
+        position.ApplyOpeningFillDelta(
+            orderId,
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(5m));
+
+        // Assert
+        position.TotalQuantity.Value.Should().Be(0.1m);
+        position.TotalFees.Amount.Should().Be(5m);
+        position.DomainEvents.Should().BeEmpty();
     }
 
     #endregion

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -133,6 +133,47 @@ public class OrderLifecycleTests
             .WithMessage("*Canceled*");
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ApplyFill_WhenFilledQuantityExceedsRequestedQuantity_ThrowsArgumentException(bool isPartialFill)
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.02m),
+            CreatePrice());
+
+        // Act
+        var action = () =>
+        {
+            if (isPartialFill)
+            {
+                order.MarkPartiallyFilled(
+                    Quantity.Create(0.03m),
+                    CreatePrice(),
+                    CreateMoney(1500m),
+                    CreateMoney(1.5m));
+            }
+            else
+            {
+                order.MarkFilled(
+                    Quantity.Create(0.03m),
+                    CreatePrice(),
+                    CreateMoney(1500m),
+                    CreateMoney(1.5m));
+            }
+        };
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("filledQuantity")
+            .WithMessage("*cannot exceed requested quantity*");
+    }
+
     [Fact]
     public void LinkRelatedPosition_WithOpenPositionOrder_AssignsPositionId()
     {

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -74,6 +74,40 @@ public class OrderLifecycleTests
     }
 
     [Fact]
+    public void MarkPartiallyFilled_WhenAlreadyPartiallyFilledWithHigherCumulativeQuantity_UpdatesFill()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+        order.ClearDomainEvents();
+
+        // Act
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.03m),
+            Price.Create(50000m),
+            CreateMoney(1500m),
+            CreateMoney(1.5m));
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        order.FilledQuantity.Value.Should().Be(0.03m);
+        order.Cost.Amount.Should().Be(1500m);
+        order.Fees.Amount.Should().Be(1.5m);
+        order.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+    }
+
+    [Fact]
     public void MarkFilled_AfterCancellation_ThrowsInvalidOperationException()
     {
         // Arrange

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -338,7 +338,7 @@ public class OrderLifecycleTests
     }
 
     [Fact]
-    public void Cancel_FromPartiallyFilled_MarksOrderAsTerminalWithoutUnappliedFillCapability()
+    public void Cancel_FromPartiallyFilled_PreservesUnappliedBuyFillUntilApplied()
     {
         // Arrange
         var order = OrderLifecycle.Submit(
@@ -361,7 +361,11 @@ public class OrderLifecycleTests
         // Assert
         order.Status.Should().Be(OrderLifecycleStatus.Canceled);
         order.IsTerminal.Should().BeTrue();
-        order.CanAffectPosition.Should().BeFalse();
+        order.CanAffectPosition.Should().BeTrue();
+        order.HasUnappliedFill.Should().BeTrue();
+
+        order.MarkCurrentFillApplied();
+
         order.HasUnappliedFill.Should().BeFalse();
     }
 

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -98,4 +98,25 @@ public class OrderLifecycleTests
         action.Should().Throw<InvalidOperationException>()
             .WithMessage("*Canceled*");
     }
+
+    [Fact]
+    public void LinkRelatedPosition_WithOpenPositionOrder_AssignsPositionId()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            intent: OrderIntent.OpenPosition);
+        var positionId = PositionId.Create();
+
+        // Act
+        order.LinkRelatedPosition(positionId);
+
+        // Assert
+        order.RelatedPositionId.Should().Be(positionId);
+    }
 }

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -1,0 +1,101 @@
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Domain.Tests.Trading.Orders;
+
+public class OrderLifecycleTests
+{
+    private static TradingPair CreatePair() => TradingPair.Create("BTCUSDT", "USDT");
+    private static OrderId CreateOrderId(string value = "order-123") => OrderId.From(value);
+    private static Quantity CreateQuantity(decimal value = 0.02m) => Quantity.Create(value);
+    private static Price CreatePrice(decimal value = 50000m) => Price.Create(value);
+    private static Money CreateMoney(decimal value, string currency = "USDT") => Money.Create(value, currency);
+
+    [Fact]
+    public void Submit_WithValidParameters_RaisesOrderPlacedEvent()
+    {
+        // Act
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            "MomentumBreakout");
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.Submitted);
+        order.CanAffectPosition.Should().BeFalse();
+        order.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderPlacedEvent>();
+
+        var domainEvent = (OrderPlacedEvent)order.DomainEvents.Single();
+        domainEvent.OrderId.Should().Be("order-123");
+        domainEvent.Pair.Should().Be("BTCUSDT");
+        domainEvent.Side.Should().Be(OrderSide.Buy);
+        domainEvent.OrderType.Should().Be(OrderType.Market);
+        domainEvent.Amount.Should().Be(0.02m);
+        domainEvent.SignalRule.Should().Be("MomentumBreakout");
+    }
+
+    [Fact]
+    public void MarkPartiallyFilled_WithValidTransition_RaisesPartialFillEvent()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+        order.ClearDomainEvents();
+
+        // Act
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.01m),
+            Price.Create(50010m),
+            CreateMoney(500.10m),
+            CreateMoney(0.5m));
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        order.CanAffectPosition.Should().BeTrue();
+        order.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+
+        var domainEvent = (OrderFilledEvent)order.DomainEvents.Single();
+        domainEvent.OrderId.Should().Be("order-123");
+        domainEvent.IsPartialFill.Should().BeTrue();
+        domainEvent.FilledAmount.Should().Be(0.01m);
+        domainEvent.AveragePrice.Should().Be(50010m);
+    }
+
+    [Fact]
+    public void MarkFilled_AfterCancellation_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+
+        order.Cancel();
+
+        // Act
+        var action = () => order.MarkFilled(
+            CreateQuantity(),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Canceled*");
+    }
+}

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -194,4 +194,411 @@ public class OrderLifecycleTests
         // Assert
         order.RelatedPositionId.Should().Be(positionId);
     }
+
+    [Fact]
+    public void Submit_WithZeroRequestedQuantity_ThrowsArgumentException()
+    {
+        // Act
+        var action = () => OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Zero,
+            CreatePrice());
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("requestedQuantity")
+            .WithMessage("*Requested quantity cannot be zero*");
+    }
+
+    [Theory]
+    [InlineData(OrderIntent.ClosePosition)]
+    [InlineData(OrderIntent.ExecuteDca)]
+    public void Submit_WhenCloseOrDcaOrderDoesNotProvideRelatedPosition_ThrowsArgumentException(OrderIntent intent)
+    {
+        // Act
+        var action = () => OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Sell,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            intent: intent);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("relatedPositionId")
+            .WithMessage("*required for close and DCA orders*");
+    }
+
+    [Fact]
+    public void Submit_WhenOpenPositionOrderReferencesExistingPosition_ThrowsArgumentException()
+    {
+        // Act
+        var action = () => OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            intent: OrderIntent.OpenPosition,
+            relatedPositionId: PositionId.Create());
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("relatedPositionId")
+            .WithMessage("*cannot reference an existing position*");
+    }
+
+    [Fact]
+    public void MarkFilled_WithValidTransition_TracksUnappliedFillUntilApplied()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+        order.ClearDomainEvents();
+
+        // Act
+        order.MarkFilled(
+            CreateQuantity(),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.Filled);
+        order.IsTerminal.Should().BeTrue();
+        order.CanAffectPosition.Should().BeTrue();
+        order.HasUnappliedFill.Should().BeTrue();
+        order.UnappliedQuantity.Value.Should().Be(0.02m);
+        order.UnappliedCost.Amount.Should().Be(1000m);
+        order.UnappliedFees.Amount.Should().Be(1m);
+        order.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+
+        order.MarkCurrentFillApplied();
+
+        order.AppliedQuantity.Value.Should().Be(0.02m);
+        order.AppliedCost.Amount.Should().Be(1000m);
+        order.AppliedFees.Amount.Should().Be(1m);
+        order.HasUnappliedFill.Should().BeFalse();
+        order.UnappliedQuantity.Value.Should().Be(0m);
+        order.UnappliedCost.Amount.Should().Be(0m);
+        order.UnappliedFees.Amount.Should().Be(0m);
+    }
+
+    [Fact]
+    public void MarkCurrentFillApplied_WhenOrderHasNoFill_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+
+        // Act
+        var action = () => order.MarkCurrentFillApplied();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*status Submitted has no fill*");
+    }
+
+    [Fact]
+    public void Reject_FromSubmitted_MarksOrderAsTerminal()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+
+        // Act
+        order.Reject();
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.Rejected);
+        order.IsTerminal.Should().BeTrue();
+        order.CanAffectPosition.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cancel_FromPartiallyFilled_MarksOrderAsTerminalWithoutUnappliedFillCapability()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+        order.ClearDomainEvents();
+
+        // Act
+        order.Cancel();
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.Canceled);
+        order.IsTerminal.Should().BeTrue();
+        order.CanAffectPosition.Should().BeFalse();
+        order.HasUnappliedFill.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Reject_AfterPartialFill_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Act
+        var action = () => order.Reject();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*from PartiallyFilled to Rejected*");
+    }
+
+    [Fact]
+    public void Cancel_AfterFilled_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+        order.MarkFilled(
+            CreateQuantity(),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Act
+        var action = () => order.Cancel();
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*from Filled to Canceled*");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ApplyFill_WhenFilledQuantityIsZero_ThrowsArgumentException(bool isPartialFill)
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+
+        // Act
+        var action = () =>
+        {
+            if (isPartialFill)
+            {
+                order.MarkPartiallyFilled(
+                    Quantity.Zero,
+                    CreatePrice(),
+                    CreateMoney(0m),
+                    CreateMoney(0m));
+            }
+            else
+            {
+                order.MarkFilled(
+                    Quantity.Zero,
+                    CreatePrice(),
+                    CreateMoney(0m),
+                    CreateMoney(0m));
+            }
+        };
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("filledQuantity")
+            .WithMessage("*Filled quantity cannot be zero*");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ApplyFill_WhenAveragePriceIsZero_ThrowsArgumentException(bool isPartialFill)
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice());
+
+        // Act
+        var action = () =>
+        {
+            if (isPartialFill)
+            {
+                order.MarkPartiallyFilled(
+                    Quantity.Create(0.01m),
+                    Price.Zero,
+                    CreateMoney(500m),
+                    CreateMoney(0.5m));
+            }
+            else
+            {
+                order.MarkFilled(
+                    Quantity.Create(0.02m),
+                    Price.Zero,
+                    CreateMoney(1000m),
+                    CreateMoney(1m));
+            }
+        };
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithParameterName("averagePrice")
+            .WithMessage("*Average price cannot be zero*");
+    }
+
+    [Fact]
+    public void ApplyFill_WhenCumulativeQuantityRegresses_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.03m),
+            CreatePrice(),
+            CreateMoney(1500m),
+            CreateMoney(1.5m));
+
+        // Act
+        var action = () => order.MarkFilled(
+            Quantity.Create(0.02m),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot be lower than the current filled quantity*");
+    }
+
+    [Fact]
+    public void MarkPartiallyFilled_WhenSnapshotIsUnchanged_DoesNothing()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+        order.ClearDomainEvents();
+
+        // Act
+        order.MarkPartiallyFilled(
+            Quantity.Create(0.02m),
+            CreatePrice(),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        order.FilledQuantity.Value.Should().Be(0.02m);
+        order.Cost.Amount.Should().Be(1000m);
+        order.Fees.Amount.Should().Be(1m);
+        order.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LinkRelatedPosition_WhenIntentIsNotOpenPosition_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Sell,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            intent: OrderIntent.Unknown);
+
+        // Act
+        var action = () => order.LinkRelatedPosition(PositionId.Create());
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Only open position orders can be linked*");
+    }
+
+    [Fact]
+    public void LinkRelatedPosition_WhenAlreadyLinkedToDifferentPosition_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            CreateQuantity(),
+            CreatePrice(),
+            intent: OrderIntent.OpenPosition);
+        order.LinkRelatedPosition(PositionId.Create());
+
+        // Act
+        var action = () => order.LinkRelatedPosition(PositionId.Create());
+
+        // Assert
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already linked to position*");
+    }
 }

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonOrderRepositoryTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonOrderRepositoryTests.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using FluentAssertions;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.Transactions;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class JsonOrderRepositoryTests : IDisposable
+{
+    private readonly string _testFilePath;
+    private readonly JsonOrderRepository _sut;
+
+    public JsonOrderRepositoryTests()
+    {
+        _testFilePath = Path.Combine(Path.GetTempPath(), $"test_orders_{Guid.NewGuid():N}.json");
+        _sut = new JsonOrderRepository(_testFilePath);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullFilePath_ThrowsArgumentException()
+    {
+        var act = () => new JsonOrderRepository(null!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("filePath");
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyFilePath_ThrowsArgumentException()
+    {
+        var act = () => new JsonOrderRepository(string.Empty);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("filePath");
+    }
+
+    [Fact]
+    public async Task SaveAsync_NewOrder_PersistsToFile()
+    {
+        var order = CreateSubmittedOrder("order-001", "BTCUSDT", submittedAt: new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero));
+
+        await _sut.SaveAsync(order);
+
+        File.Exists(_testFilePath).Should().BeTrue();
+        var persisted = await _sut.GetByIdAsync(order.Id);
+        persisted.Should().NotBeNull();
+        persisted!.Pair.Symbol.Should().Be("BTCUSDT");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesDirectoryIfItDoesNotExist()
+    {
+        var nestedDirectory = Path.Combine(Path.GetTempPath(), $"nested_orders_{Guid.NewGuid():N}", "data");
+        var nestedFilePath = Path.Combine(nestedDirectory, "orders.json");
+        using var repository = new JsonOrderRepository(nestedFilePath);
+
+        await repository.SaveAsync(CreateSubmittedOrder("order-nested", "ETHUSDT"));
+
+        File.Exists(nestedFilePath).Should().BeTrue();
+
+        Directory.Delete(Path.GetDirectoryName(nestedDirectory)!, recursive: true);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_IsCaseInsensitive()
+    {
+        var order = CreateSubmittedOrder("Order-Case", "ADAUSDT");
+        await _sut.SaveAsync(order);
+
+        var retrieved = await _sut.GetByIdAsync(OrderId.From("order-case"));
+
+        retrieved.Should().NotBeNull();
+        retrieved!.Id.Should().Be(order.Id);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsOrdersSortedBySubmittedAtDescending()
+    {
+        var oldest = CreateSubmittedOrder("order-oldest", "BTCUSDT", submittedAt: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var newest = CreateSubmittedOrder("order-newest", "ETHUSDT", submittedAt: new DateTimeOffset(2024, 1, 3, 0, 0, 0, TimeSpan.Zero));
+        var middle = CreateSubmittedOrder("order-middle", "ADAUSDT", submittedAt: new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero));
+
+        await _sut.SaveAsync(oldest);
+        await _sut.SaveAsync(newest);
+        await _sut.SaveAsync(middle);
+
+        var orders = await _sut.GetAllAsync();
+
+        orders.Select(order => order.Id.Value).Should().Equal("order-newest", "order-middle", "order-oldest");
+    }
+
+    [Fact]
+    public async Task ReloadAsync_RefreshesCacheFromExternalChanges()
+    {
+        var original = CreateSubmittedOrder("order-original", "BTCUSDT");
+        await _sut.SaveAsync(original);
+
+        using var otherRepository = new JsonOrderRepository(_testFilePath);
+        await otherRepository.SaveAsync(CreateSubmittedOrder("order-external", "ETHUSDT"));
+
+        await _sut.ReloadAsync();
+
+        var orders = await _sut.GetAllAsync();
+        orders.Should().HaveCount(2);
+        orders.Select(order => order.Id.Value).Should().Contain(["order-original", "order-external"]);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithinTransaction_ExposesStagedOrderWithoutPersistingUntilCommit()
+    {
+        var transactionCoordinator = new JsonTransactionCoordinator();
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        using var repository = new JsonOrderRepository(_testFilePath, transactionCoordinator);
+        var staged = CreateSubmittedOrder("order-staged", "XRPUSDT");
+
+        await unitOfWork.BeginTransactionAsync();
+        await repository.SaveAsync(staged);
+
+        File.Exists(_testFilePath).Should().BeFalse();
+
+        var readDuringTransaction = await repository.GetByIdAsync(staged.Id);
+        readDuringTransaction.Should().NotBeNull();
+        readDuringTransaction!.Pair.Symbol.Should().Be("XRPUSDT");
+
+        await unitOfWork.RollbackAsync();
+
+        var readAfterRollback = await repository.GetByIdAsync(staged.Id);
+        readAfterRollback.Should().BeNull();
+        File.Exists(_testFilePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EmptyFile_DoesNotThrowAndReturnsNoOrders()
+    {
+        await File.WriteAllTextAsync(_testFilePath, string.Empty);
+
+        var orders = await _sut.GetAllAsync();
+
+        orders.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MalformedJson_ThrowsOnLoad()
+    {
+        await File.WriteAllTextAsync(_testFilePath, "{ invalid json }");
+
+        var act = () => _sut.GetAllAsync();
+
+        await act.Should().ThrowAsync<JsonException>();
+    }
+
+    private static OrderLifecycle CreateSubmittedOrder(
+        string orderId,
+        string symbol,
+        DateTimeOffset? submittedAt = null)
+    {
+        return OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            TradingPair.Create(symbol, "USDT"),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(1m),
+            Price.Create(1m),
+            signalRule: "TestRule",
+            timestamp: submittedAt);
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonPortfolioRepositoryTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonPortfolioRepositoryTests.cs
@@ -1,0 +1,297 @@
+using System.Text.Json;
+using FluentAssertions;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.Transactions;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class JsonPortfolioRepositoryTests : IDisposable
+{
+    private readonly string _testFilePath;
+    private readonly JsonPortfolioRepository _sut;
+
+    public JsonPortfolioRepositoryTests()
+    {
+        _testFilePath = Path.Combine(Path.GetTempPath(), $"test_portfolios_{Guid.NewGuid():N}.json");
+        _sut = new JsonPortfolioRepository(_testFilePath);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        if (File.Exists(_testFilePath))
+        {
+            File.Delete(_testFilePath);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullFilePath_ThrowsArgumentException()
+    {
+        var act = () => new JsonPortfolioRepository(null!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("filePath");
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyFilePath_ThrowsArgumentException()
+    {
+        var act = () => new JsonPortfolioRepository(string.Empty);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("filePath");
+    }
+
+    [Fact]
+    public async Task SaveAsync_FirstPortfolio_PersistsAsDefaultPortfolio()
+    {
+        var portfolio = CreateTestPortfolio("Primary");
+
+        await _sut.SaveAsync(portfolio);
+
+        var persisted = await _sut.GetDefaultAsync();
+        persisted.Should().NotBeNull();
+        persisted!.Id.Should().Be(portfolio.Id);
+        persisted.Name.Should().Be("Primary");
+
+        var json = await File.ReadAllTextAsync(_testFilePath);
+        using var document = JsonDocument.Parse(json);
+        document.RootElement[0].GetProperty("isDefault").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesDirectoryIfItDoesNotExist()
+    {
+        var nestedDirectory = Path.Combine(Path.GetTempPath(), $"nested_portfolios_{Guid.NewGuid():N}", "data");
+        var nestedFilePath = Path.Combine(nestedDirectory, "portfolios.json");
+        using var repository = new JsonPortfolioRepository(nestedFilePath);
+
+        await repository.SaveAsync(CreateTestPortfolio("Nested"));
+
+        File.Exists(nestedFilePath).Should().BeTrue();
+
+        Directory.Delete(Path.GetDirectoryName(nestedDirectory)!, recursive: true);
+    }
+
+    [Fact]
+    public async Task GetDefaultAsync_WhenPersistedPortfoliosHaveNoDefault_PromotesOldestPortfolio()
+    {
+        var oldestId = Guid.NewGuid();
+        var newestId = Guid.NewGuid();
+        var json = $$"""
+        [
+          {
+            "id": "{{oldestId}}",
+            "name": "Oldest",
+            "market": "USDT",
+            "balance": { "currency": "USDT", "total": 1000, "available": 1000, "reserved": 0 },
+            "maxPositions": 5,
+            "minPositionCost": 10,
+            "createdAt": "2024-01-01T00:00:00+00:00",
+            "isDefault": false,
+            "activePositions": [],
+            "positionCosts": []
+          },
+          {
+            "id": "{{newestId}}",
+            "name": "Newest",
+            "market": "USDT",
+            "balance": { "currency": "USDT", "total": 1000, "available": 1000, "reserved": 0 },
+            "maxPositions": 5,
+            "minPositionCost": 10,
+            "createdAt": "2024-01-02T00:00:00+00:00",
+            "isDefault": false,
+            "activePositions": [],
+            "positionCosts": []
+          }
+        ]
+        """;
+        await File.WriteAllTextAsync(_testFilePath, json);
+
+        var defaultPortfolio = await _sut.GetDefaultAsync();
+        var allPortfolios = await _sut.GetAllAsync();
+
+        defaultPortfolio.Should().NotBeNull();
+        defaultPortfolio!.Id.Value.Should().Be(oldestId);
+        allPortfolios.First().Id.Should().Be(defaultPortfolio.Id);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenDeletingDefaultPortfolio_PromotesRemainingPortfolio()
+    {
+        var defaultPortfolio = CreateTestPortfolio("Default");
+        var secondaryPortfolio = CreateTestPortfolio("Secondary");
+
+        await _sut.SaveAsync(defaultPortfolio);
+        await _sut.SaveAsync(secondaryPortfolio);
+
+        await _sut.DeleteAsync(defaultPortfolio.Id);
+
+        var promoted = await _sut.GetDefaultAsync();
+        promoted.Should().NotBeNull();
+        promoted!.Id.Should().Be(secondaryPortfolio.Id);
+        promoted.Name.Should().Be("Secondary");
+
+        var allPortfolios = await _sut.GetAllAsync();
+        allPortfolios.Should().ContainSingle()
+            .Which.Id.Should().Be(secondaryPortfolio.Id);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenPortfolioDoesNotExist_LeavesPersistedPortfoliosUnchanged()
+    {
+        var existing = CreateTestPortfolio("Existing");
+        await _sut.SaveAsync(existing);
+
+        await _sut.DeleteAsync(PortfolioId.Create());
+
+        var allPortfolios = await _sut.GetAllAsync();
+        allPortfolios.Should().ContainSingle()
+            .Which.Id.Should().Be(existing.Id);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenDeletingOnlyDefaultPortfolio_RemovesAllPortfolios()
+    {
+        var onlyPortfolio = CreateTestPortfolio("Only");
+        await _sut.SaveAsync(onlyPortfolio);
+
+        await _sut.DeleteAsync(onlyPortfolio.Id);
+
+        var defaultPortfolio = await _sut.GetDefaultAsync();
+        var allPortfolios = await _sut.GetAllAsync();
+
+        defaultPortfolio.Should().BeNull();
+        allPortfolios.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenNameMatchesIgnoringCase_ReturnsPortfolio()
+    {
+        var portfolio = CreateTestPortfolio("Primary");
+        await _sut.SaveAsync(portfolio);
+
+        var result = await _sut.GetByNameAsync("primary");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(portfolio.Id);
+        result.Name.Should().Be("Primary");
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenNameDoesNotMatch_ReturnsNull()
+    {
+        await _sut.SaveAsync(CreateTestPortfolio("Primary"));
+
+        var result = await _sut.GetByNameAsync("Missing");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WithEmptyName_ThrowsArgumentException()
+    {
+        var act = () => _sut.GetByNameAsync(" ");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("name");
+    }
+
+    [Fact]
+    public async Task ExistsWithNameAsync_WhenNameMatchesIgnoringCase_ReturnsTrue()
+    {
+        await _sut.SaveAsync(CreateTestPortfolio("Primary"));
+
+        var exists = await _sut.ExistsWithNameAsync("PRIMARY");
+
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsWithNameAsync_WhenNameDoesNotMatch_ReturnsFalse()
+    {
+        await _sut.SaveAsync(CreateTestPortfolio("Primary"));
+
+        var exists = await _sut.ExistsWithNameAsync("Missing");
+
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExistsWithNameAsync_WithEmptyName_ThrowsArgumentException()
+    {
+        var act = () => _sut.ExistsWithNameAsync(string.Empty);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("name");
+    }
+
+    [Fact]
+    public async Task ReloadAsync_RefreshesCacheFromExternalChanges()
+    {
+        var original = CreateTestPortfolio("Original");
+        await _sut.SaveAsync(original);
+
+        using var otherRepository = new JsonPortfolioRepository(_testFilePath);
+        await otherRepository.SaveAsync(CreateTestPortfolio("External"));
+
+        await _sut.ReloadAsync();
+
+        var allPortfolios = await _sut.GetAllAsync();
+        allPortfolios.Should().HaveCount(2);
+        allPortfolios.Select(portfolio => portfolio.Name).Should().Contain(["Original", "External"]);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithinTransaction_ExposesStagedPortfolioWithoutPersistingUntilCommit()
+    {
+        var transactionCoordinator = new JsonTransactionCoordinator();
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        using var repository = new JsonPortfolioRepository(_testFilePath, transactionCoordinator);
+        var staged = CreateTestPortfolio("Staged");
+
+        await unitOfWork.BeginTransactionAsync();
+        await repository.SaveAsync(staged);
+
+        File.Exists(_testFilePath).Should().BeFalse();
+
+        var readDuringTransaction = await repository.GetByIdAsync(staged.Id);
+        readDuringTransaction.Should().NotBeNull();
+        readDuringTransaction!.Name.Should().Be("Staged");
+
+        await unitOfWork.RollbackAsync();
+
+        var readAfterRollback = await repository.GetByIdAsync(staged.Id);
+        readAfterRollback.Should().BeNull();
+        File.Exists(_testFilePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EmptyFile_DoesNotThrowAndReturnsNoPortfolios()
+    {
+        await File.WriteAllTextAsync(_testFilePath, string.Empty);
+
+        var portfolios = await _sut.GetAllAsync();
+
+        portfolios.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MalformedJson_ThrowsOnLoad()
+    {
+        await File.WriteAllTextAsync(_testFilePath, "{ invalid json }");
+
+        var act = () => _sut.GetAllAsync();
+
+        await act.Should().ThrowAsync<JsonException>();
+    }
+
+    private static Portfolio CreateTestPortfolio(string name)
+    {
+        return Portfolio.Create(name, "USDT", 1000m, 5, 10m);
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Dispatching/InMemoryCommandDispatcherTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Dispatching/InMemoryCommandDispatcherTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Moq;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Infrastructure.Dispatching;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Dispatching;
+
+public sealed class InMemoryCommandDispatcherTests
+{
+    [Fact]
+    public async Task DispatchAsync_WhenResultHandlerIsMissing_RollsBackActiveTransaction()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var serviceProviderMock = CreateServiceProvider(transactionMock.Object);
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<ResultCommand, string>(new ResultCommand("missing"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenResultHandlerThrows_RollsBackActiveTransactionAndReturnsDispatchError()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var handler = new ThrowingResultHandler();
+        var serviceProviderMock = CreateServiceProvider(
+            transactionMock.Object,
+            (typeof(ICommandHandler<ResultCommand, string>), handler));
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<ResultCommand, string>(new ResultCommand("boom"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("DispatchError");
+        result.Error.Message.Should().Contain("handler exploded");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenVoidHandlerIsMissing_RollsBackActiveTransaction()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var serviceProviderMock = CreateServiceProvider(transactionMock.Object);
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new VoidCommand("missing"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenVoidHandlerReturnsNullTask_RollsBackActiveTransaction()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var handler = new NullVoidHandler();
+        var serviceProviderMock = CreateServiceProvider(
+            transactionMock.Object,
+            (typeof(ICommandHandler<VoidCommand>), handler));
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new VoidCommand("null"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("InvocationFailed");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenResultHandlerReturnsNullTask_RollsBackActiveTransaction()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var handler = new NullResultHandler();
+        var serviceProviderMock = CreateServiceProvider(
+            transactionMock.Object,
+            (typeof(ICommandHandler<ResultCommand, string>), handler));
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<ResultCommand, string>(new ResultCommand("null"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("InvocationFailed");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenVoidHandlerSucceeds_RollsBackActiveTransactionAndReturnsSuccess()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var handler = new SuccessfulVoidHandler();
+        var serviceProviderMock = CreateServiceProvider(
+            transactionMock.Object,
+            (typeof(ICommandHandler<VoidCommand>), handler));
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new VoidCommand("ok"));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenVoidHandlerThrows_RollsBackActiveTransactionAndReturnsDispatchError()
+    {
+        // Arrange
+        var transactionMock = CreateTransactionMock(activeTransaction: true);
+        var handler = new ThrowingVoidHandler();
+        var serviceProviderMock = CreateServiceProvider(
+            transactionMock.Object,
+            (typeof(ICommandHandler<VoidCommand>), handler));
+        var dispatcher = CreateDispatcher(serviceProviderMock.Object);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new VoidCommand("boom"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("DispatchError");
+        result.Error.Message.Should().Contain("void handler exploded");
+
+        transactionMock.Verify(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transactionMock.Verify(x => x.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static InMemoryCommandDispatcher CreateDispatcher(IServiceProvider serviceProvider)
+    {
+        return new InMemoryCommandDispatcher(
+            serviceProvider,
+            Mock.Of<ILogger<InMemoryCommandDispatcher>>());
+    }
+
+    private static Mock<ITransactionalUnitOfWork> CreateTransactionMock(bool activeTransaction)
+    {
+        var transactionMock = new Mock<ITransactionalUnitOfWork>();
+        transactionMock
+            .SetupGet(x => x.HasActiveTransaction)
+            .Returns(activeTransaction);
+        transactionMock
+            .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        transactionMock
+            .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        transactionMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        return transactionMock;
+    }
+
+    private static Mock<IServiceProvider> CreateServiceProvider(
+        ITransactionalUnitOfWork transaction,
+        params (Type serviceType, object implementation)[] registrations)
+    {
+        var registry = registrations.ToDictionary(x => x.serviceType, x => x.implementation);
+        registry[typeof(ITransactionalUnitOfWork)] = transaction;
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock
+            .Setup(x => x.GetService(It.IsAny<Type>()))
+            .Returns<Type>(serviceType =>
+                registry.TryGetValue(serviceType, out var implementation)
+                    ? implementation
+                    : null);
+
+        return serviceProviderMock;
+    }
+
+    private sealed record ResultCommand(string Id);
+
+    private sealed record VoidCommand(string Id);
+
+    private sealed class ThrowingResultHandler : ICommandHandler<ResultCommand, string>
+    {
+        public Task<Result<string>> HandleAsync(ResultCommand command, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException($"result handler exploded for {command.Id}");
+        }
+    }
+
+    private sealed class NullResultHandler : ICommandHandler<ResultCommand, string>
+    {
+        public Task<Result<string>> HandleAsync(ResultCommand command, CancellationToken cancellationToken = default)
+        {
+            return null!;
+        }
+    }
+
+    private sealed class NullVoidHandler : ICommandHandler<VoidCommand>
+    {
+        public Task<Result> HandleAsync(VoidCommand command, CancellationToken cancellationToken = default)
+        {
+            return null!;
+        }
+    }
+
+    private sealed class SuccessfulVoidHandler : ICommandHandler<VoidCommand>
+    {
+        public Task<Result> HandleAsync(VoidCommand command, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Result.Success());
+        }
+    }
+
+    private sealed class ThrowingVoidHandler : ICommandHandler<VoidCommand>
+    {
+        public Task<Result> HandleAsync(VoidCommand command, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException($"void handler exploded for {command.Id}");
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/ActiveOrderRefreshServiceBehaviorTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/ActiveOrderRefreshServiceBehaviorTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Core;
+using IntelliTrader.Infrastructure.BackgroundServices;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class ActiveOrderRefreshServiceBehaviorTests
+{
+    [Fact]
+    public async Task Start_WhenCalledTwiceWhileRunning_DoesNotStartSecondLoop()
+    {
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var dispatcherMock = new Mock<ICommandDispatcher>();
+        var firstDispatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unexpectedSecondDispatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var commands = new ConcurrentQueue<RefreshActiveOrdersCommand>();
+        var dispatchCount = 0;
+
+        dispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.IsAny<RefreshActiveOrdersCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RefreshActiveOrdersCommand command, CancellationToken _) =>
+            {
+                commands.Enqueue(command);
+                var currentCount = Interlocked.Increment(ref dispatchCount);
+                if (currentCount == 1)
+                {
+                    firstDispatch.TrySetResult(true);
+                }
+                else
+                {
+                    unexpectedSecondDispatch.TrySetResult(true);
+                }
+
+                return SuccessfulRefresh();
+            });
+
+        var service = new ActiveOrderRefreshService(
+            loggingServiceMock.Object,
+            dispatcherMock.Object,
+            new OrderStatusRefreshOptions
+            {
+                Interval = TimeSpan.FromSeconds(30),
+                StartDelay = TimeSpan.Zero,
+                MaxOrdersPerCycle = 17
+            });
+
+        try
+        {
+            service.Start();
+            await firstDispatch.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            service.Start();
+
+            var completedTask = await Task.WhenAny(
+                unexpectedSecondDispatch.Task,
+                Task.Delay(TimeSpan.FromMilliseconds(150)));
+
+            completedTask.Should().NotBe(unexpectedSecondDispatch.Task);
+            dispatchCount.Should().Be(1);
+            commands.Should().ContainSingle()
+                .Which.Limit.Should().Be(17);
+
+            InfoMessages(loggingServiceMock).Should().Equal(
+                "Start active order refresh service...",
+                "Active order refresh service started");
+        }
+        finally
+        {
+            service.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Start_WhenStoppedAndStartedAgain_DispatchesNewRefreshCyclePerLifecycle()
+    {
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var dispatcherMock = new Mock<ICommandDispatcher>();
+        var firstDispatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondDispatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var commands = new ConcurrentQueue<RefreshActiveOrdersCommand>();
+        var dispatchCount = 0;
+
+        dispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.IsAny<RefreshActiveOrdersCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RefreshActiveOrdersCommand command, CancellationToken _) =>
+            {
+                commands.Enqueue(command);
+                var currentCount = Interlocked.Increment(ref dispatchCount);
+                if (currentCount == 1)
+                {
+                    firstDispatch.TrySetResult(true);
+                }
+                else if (currentCount == 2)
+                {
+                    secondDispatch.TrySetResult(true);
+                }
+
+                return SuccessfulRefresh();
+            });
+
+        var service = new ActiveOrderRefreshService(
+            loggingServiceMock.Object,
+            dispatcherMock.Object,
+            new OrderStatusRefreshOptions
+            {
+                Interval = TimeSpan.FromSeconds(30),
+                StartDelay = TimeSpan.Zero,
+                MaxOrdersPerCycle = 23
+            });
+
+        try
+        {
+            service.Start();
+            await firstDispatch.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            service.Stop();
+
+            service.Start();
+            await secondDispatch.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            dispatchCount.Should().Be(2);
+            commands.Should().HaveCount(2);
+            commands.Select(command => command.Limit).Should().OnlyContain(limit => limit == 23);
+
+            InfoMessages(loggingServiceMock).Should().Equal(
+                "Start active order refresh service...",
+                "Active order refresh service started",
+                "Stop active order refresh service...",
+                "Active order refresh service stopped",
+                "Start active order refresh service...",
+                "Active order refresh service started");
+        }
+        finally
+        {
+            service.Stop();
+        }
+
+        InfoMessages(loggingServiceMock).Should().Equal(
+            "Start active order refresh service...",
+            "Active order refresh service started",
+            "Stop active order refresh service...",
+            "Active order refresh service stopped",
+            "Start active order refresh service...",
+            "Active order refresh service started",
+            "Stop active order refresh service...",
+            "Active order refresh service stopped");
+    }
+
+    [Fact]
+    public void Stop_WhenServiceWasNotStarted_IsNoOp()
+    {
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var dispatcherMock = new Mock<ICommandDispatcher>();
+        var service = new ActiveOrderRefreshService(loggingServiceMock.Object, dispatcherMock.Object);
+
+        service.Stop();
+
+        loggingServiceMock.Invocations.Should().BeEmpty();
+        dispatcherMock.Invocations.Should().BeEmpty();
+    }
+
+    private static IReadOnlyList<string> InfoMessages(Mock<ILoggingService> loggingServiceMock)
+    {
+        return loggingServiceMock.Invocations
+            .Where(invocation => invocation.Method.Name == nameof(ILoggingService.Info))
+            .Select(invocation => invocation.Arguments.FirstOrDefault())
+            .OfType<string>()
+            .ToList();
+    }
+
+    private static Result<RefreshActiveOrdersResult> SuccessfulRefresh()
+    {
+        return Result<RefreshActiveOrdersResult>.Success(new RefreshActiveOrdersResult
+        {
+            TotalActive = 1,
+            AttemptedCount = 1,
+            RefreshedCount = 1,
+            AppliedDomainEffectsCount = 0,
+            FailedCount = 0
+        });
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/ActiveOrderRefreshServiceRegistrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/ActiveOrderRefreshServiceRegistrationTests.cs
@@ -1,0 +1,33 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Core;
+using IntelliTrader.Infrastructure.BackgroundServices;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class ActiveOrderRefreshServiceRegistrationTests
+{
+    [Fact]
+    public void BuildContainer_ResolvesActiveAndLegacyRefreshContractsToSameSingleton()
+    {
+        // Arrange
+        var loggingServiceMock = new Mock<ILoggingService>();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(loggingServiceMock.Object)
+            .As<ILoggingService>()
+            .SingleInstance();
+
+        using var container = builder.Build();
+
+        // Act
+        var activeService = container.Resolve<IActiveOrderRefreshService>();
+        var legacyService = container.Resolve<ISubmittedOrderRefreshService>();
+
+        // Assert
+        activeService.Should().BeOfType<ActiveOrderRefreshService>();
+        legacyService.Should().BeSameAs(activeService);
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.Transactions;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class JsonTransactionalUnitOfWorkIntegrationTests
+{
+    [Fact]
+    public async Task CommitAsync_WhenOneResourceFails_RestoresPreviouslyAppliedFiles()
+    {
+        // Given
+        var ordersPath = Path.Combine(Path.GetTempPath(), $"json_uow_orders_{Guid.NewGuid():N}.json");
+        var invalidPositionsPath = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"json_uow_invalid_positions_{Guid.NewGuid():N}")).FullName;
+        var transactionCoordinator = new JsonTransactionCoordinator();
+
+        using var orderRepository = new JsonOrderRepository(ordersPath, transactionCoordinator);
+        using var positionRepository = new JsonPositionRepository(invalidPositionsPath, transactionCoordinator);
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        var pair = TradingPair.Create("ADAUSDT", "USDT");
+
+        var order = OrderLifecycle.Submit(
+            OrderId.From("json-uow-order-1"),
+            pair,
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(10m),
+            Price.Create(1m),
+            signalRule: "Atomicity");
+        order.MarkFilled(
+            Quantity.Create(10m),
+            Price.Create(1m),
+            Money.Create(10m, "USDT"),
+            Money.Create(0.1m, "USDT"));
+
+        var position = Position.Open(
+            pair,
+            order.Id,
+            Price.Create(1m),
+            Quantity.Create(10m),
+            Money.Create(0.1m, "USDT"),
+            "Atomicity");
+
+        // When
+        await unitOfWork.BeginTransactionAsync();
+        await orderRepository.SaveAsync(order);
+        await positionRepository.SaveAsync(position);
+        var commitResult = await unitOfWork.CommitAsync();
+
+        // Then
+        commitResult.IsFailure.Should().BeTrue();
+
+        using var reloadedOrders = new JsonOrderRepository(ordersPath);
+        var persistedOrder = await reloadedOrders.GetByIdAsync(order.Id);
+        persistedOrder.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CommitAsync_WhenThreeResourcesAreInvolved_RestoresAllFiles()
+    {
+        // Given
+        var ordersPath = Path.Combine(Path.GetTempPath(), $"json_uow_orders_{Guid.NewGuid():N}.json");
+        var portfoliosPath = Path.Combine(Path.GetTempPath(), $"json_uow_portfolios_{Guid.NewGuid():N}.json");
+        var invalidPositionsPath = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"json_uow_invalid_positions_{Guid.NewGuid():N}")).FullName;
+        var transactionCoordinator = new JsonTransactionCoordinator();
+
+        using var orderRepository = new JsonOrderRepository(ordersPath, transactionCoordinator);
+        using var positionRepository = new JsonPositionRepository(invalidPositionsPath, transactionCoordinator);
+        using var portfolioRepository = new JsonPortfolioRepository(portfoliosPath, transactionCoordinator);
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        var pair = TradingPair.Create("XRPUSDT", "USDT");
+        var portfolio = Portfolio.Create("Default", "USDT", 1000m, 5, 10m);
+        await portfolioRepository.SaveAsync(portfolio);
+
+        var order = OrderLifecycle.Submit(
+            OrderId.From("json-uow-order-portfolio-1"),
+            pair,
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(10m),
+            Price.Create(1m),
+            signalRule: "Atomicity");
+        order.MarkFilled(
+            Quantity.Create(10m),
+            Price.Create(1m),
+            Money.Create(10m, "USDT"),
+            Money.Create(0.1m, "USDT"));
+
+        var position = Position.Open(
+            pair,
+            order.Id,
+            Price.Create(1m),
+            Quantity.Create(10m),
+            Money.Create(0.1m, "USDT"),
+            "Atomicity");
+        portfolio.RecordPositionOpened(position.Id, pair, Money.Create(10m, "USDT"));
+
+        // When
+        await unitOfWork.BeginTransactionAsync();
+        await orderRepository.SaveAsync(order);
+        await positionRepository.SaveAsync(position);
+        await portfolioRepository.SaveAsync(portfolio);
+        var commitResult = await unitOfWork.CommitAsync();
+
+        // Then
+        commitResult.IsFailure.Should().BeTrue();
+
+        using var reloadedOrders = new JsonOrderRepository(ordersPath);
+        using var reloadedPortfolios = new JsonPortfolioRepository(portfoliosPath);
+
+        var persistedOrder = await reloadedOrders.GetByIdAsync(order.Id);
+        persistedOrder.Should().BeNull();
+
+        var persistedPortfolio = await reloadedPortfolios.GetDefaultAsync();
+        persistedPortfolio.Should().NotBeNull();
+        persistedPortfolio!.HasPositionFor(pair).Should().BeFalse();
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
@@ -12,6 +12,71 @@ namespace IntelliTrader.Infrastructure.Tests.Integration;
 public sealed class JsonTransactionalUnitOfWorkIntegrationTests
 {
     [Fact]
+    public async Task CommitAsync_WhenNoTransactionIsActive_ReturnsSuccess()
+    {
+        var unitOfWork = new JsonTransactionalUnitOfWork(new JsonTransactionCoordinator());
+
+        var result = await unitOfWork.CommitAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        unitOfWork.HasActiveTransaction.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RollbackAsync_WhenNoTransactionIsActive_CompletesWithoutChangingState()
+    {
+        var unitOfWork = new JsonTransactionalUnitOfWork(new JsonTransactionCoordinator());
+
+        await unitOfWork.RollbackAsync();
+
+        unitOfWork.HasActiveTransaction.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CommitAsync_WhenTargetDirectoryDoesNotExist_CreatesDirectoryAndPersistsStagedWrite()
+    {
+        // Given
+        var rootDirectory = Path.Combine(Path.GetTempPath(), $"json_uow_nested_{Guid.NewGuid():N}");
+        var ordersPath = Path.Combine(rootDirectory, "data", "orders.json");
+        var transactionCoordinator = new JsonTransactionCoordinator();
+
+        using var orderRepository = new JsonOrderRepository(ordersPath, transactionCoordinator);
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        var pair = TradingPair.Create("ADAUSDT", "USDT");
+        var order = OrderLifecycle.Submit(
+            OrderId.From("json-uow-nested-order-1"),
+            pair,
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(10m),
+            Price.Create(1m),
+            signalRule: "NestedCommit");
+
+        try
+        {
+            // When
+            await unitOfWork.BeginTransactionAsync();
+            await orderRepository.SaveAsync(order);
+            var result = await unitOfWork.CommitAsync();
+
+            // Then
+            result.IsSuccess.Should().BeTrue();
+            File.Exists(ordersPath).Should().BeTrue();
+
+            using var reloadedOrders = new JsonOrderRepository(ordersPath);
+            var persistedOrder = await reloadedOrders.GetByIdAsync(order.Id);
+            persistedOrder.Should().NotBeNull();
+        }
+        finally
+        {
+            if (Directory.Exists(rootDirectory))
+            {
+                Directory.Delete(rootDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task CommitAsync_WhenOneResourceFails_RestoresPreviouslyAppliedFiles()
     {
         // Given

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
@@ -227,6 +227,52 @@ public sealed class OpenPositionCommandDispatchIntegrationTests : IClassFixture<
     }
 
     [Fact]
+    public async Task DispatchAsync_WhenOrderIsPartiallyFilled_ExposesItThroughActiveOrdersQuery()
+    {
+        // Given
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(500m, "USDT"),
+            SignalRule = "DipBuy"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(2500m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, command.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreatePartiallyFilledOrder(pair)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+
+        // When
+        var result = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(command);
+        var activeOrders = await queryDispatcher.DispatchAsync<GetActiveOrdersQuery, IReadOnlyList<OrderView>>(
+            new GetActiveOrdersQuery
+            {
+                Pair = pair,
+                Limit = 10
+            });
+
+        // Then
+        result.IsSuccess.Should().BeTrue();
+        activeOrders.IsSuccess.Should().BeTrue();
+        activeOrders.Value.Should().ContainSingle();
+        activeOrders.Value[0].Id.Should().Be(OrderId.From("order-open-position-partial-1"));
+        activeOrders.Value[0].Status.Should().Be(OrderLifecycleStatus.PartiallyFilled);
+        activeOrders.Value[0].CanAffectPosition.Should().BeTrue();
+        activeOrders.Value[0].IsTerminal.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task DispatchAsync_WhenPersistenceFails_DoesNotLeaveOrderPersistedOnDisk()
     {
         // Given
@@ -375,6 +421,25 @@ public sealed class OpenPositionCommandDispatchIntegrationTests : IClassFixture<
             AveragePrice = Price.Zero,
             Cost = Money.Zero("USDT"),
             Fees = Money.Zero("USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderResult CreatePartiallyFilledOrder(TradingPair pair)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "order-open-position-partial-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.PartiallyFilled,
+            RequestedQuantity = Quantity.Create(0.2m),
+            FilledQuantity = Quantity.Create(0.1m),
+            Price = Price.Create(2500m),
+            AveragePrice = Price.Create(2500m),
+            Cost = Money.Create(250m, "USDT"),
+            Fees = Money.Create(0.25m, "USDT"),
             Timestamp = DateTimeOffset.UtcNow
         };
     }

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
@@ -1,0 +1,381 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+/// <summary>
+/// Integration tests for dispatching OpenPositionCommand through the real CQRS pipeline.
+/// This verifies the new Application/Domain path is actually usable from the container,
+/// rather than only through isolated unit tests.
+/// </summary>
+public sealed class OpenPositionCommandDispatchIntegrationTests : IClassFixture<InfrastructureTestFixture>, IDisposable
+{
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+    private readonly Mock<IAuditService> _auditServiceMock = new();
+    private readonly IContainer _container;
+
+    public OpenPositionCommandDispatchIntegrationTests(InfrastructureTestFixture fixture)
+    {
+        var positionsPath = fixture.CreateTempFilePath("open_position_positions");
+        var portfoliosPath = fixture.CreateTempFilePath("open_position_portfolios");
+        var ordersPath = fixture.CreateTempFilePath("open_position_orders");
+        var transactionCoordinator = new IntelliTrader.Infrastructure.Transactions.JsonTransactionCoordinator();
+
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(transactionCoordinator).SingleInstance();
+
+        // Test-specific concrete adapters.
+        builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonPortfolioRepository(portfoliosPath, transactionCoordinator))
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonOrderRepository(ordersPath, transactionCoordinator))
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterInstance(_exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        builder.RegisterInstance(_auditServiceMock.Object)
+            .As<IAuditService>()
+            .SingleInstance();
+
+        _container = builder.Build();
+
+        SeedDefaultPortfolioAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        _container.Dispose();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithValidOpenPositionCommand_PersistsStateAndAuditsPositionOpened()
+    {
+        // Given
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, command.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateFilledOrder(pair)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+
+        // When
+        var result = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(command);
+
+        // Then
+        result.IsSuccess.Should().BeTrue();
+
+        var persistedPosition = await positionRepository.GetByPairAsync(pair);
+        persistedPosition.Should().NotBeNull();
+        persistedPosition!.SignalRule.Should().Be("MomentumBreakout");
+        persistedPosition.TotalQuantity.Value.Should().Be(0.02m);
+
+        var portfolio = await portfolioRepository.GetDefaultAsync();
+        portfolio.Should().NotBeNull();
+        portfolio!.HasPositionFor(pair).Should().BeTrue();
+        portfolio.GetPositionId(pair).Should().Be(result.Value.PositionId);
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = OrderId.From("order-open-position-1") });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+        persistedOrder.Value.CanAffectPosition.Should().BeTrue();
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderPlaced",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal) &&
+                                         details.Contains("Buy", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal) &&
+                                         details.Contains("order-open-position-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "PositionOpened",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal) &&
+                                         details.Contains(result.Value.PositionId.Value.ToString(), StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenOrderRemainsSubmitted_PersistsOrderForQueryReadSide()
+    {
+        // Given
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(500m, "USDT"),
+            SignalRule = "BreakoutPending"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(2500m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, command.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateSubmittedOrder(pair)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+
+        // When
+        var result = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(command);
+
+        // Then
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("not filled");
+
+        var position = await positionRepository.GetByPairAsync(pair);
+        position.Should().BeNull();
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = OrderId.From("order-open-position-pending-1") });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Submitted);
+        persistedOrder.Value.SignalRule.Should().Be("BreakoutPending");
+        persistedOrder.Value.CanAffectPosition.Should().BeFalse();
+
+        var recentOrders = await queryDispatcher.DispatchAsync<GetRecentOrdersQuery, IReadOnlyList<OrderView>>(
+            new GetRecentOrdersQuery
+            {
+                Pair = pair,
+                Status = OrderLifecycleStatus.Submitted,
+                Limit = 10
+            });
+
+        recentOrders.IsSuccess.Should().BeTrue();
+        recentOrders.Value.Should().ContainSingle(order => order.Id.Value == "order-open-position-pending-1");
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderPlaced",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal) &&
+                                         details.Contains("order-open-position-pending-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenPersistenceFails_DoesNotLeaveOrderPersistedOnDisk()
+    {
+        // Given
+        var invalidPositionsPath = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"open_position_invalid_{Guid.NewGuid():N}")).FullName;
+        var ordersPath = Path.Combine(Path.GetTempPath(), $"open_position_atomic_orders_{Guid.NewGuid():N}.json");
+        var portfoliosPath = Path.Combine(Path.GetTempPath(), $"open_position_atomic_portfolios_{Guid.NewGuid():N}.json");
+        var transactionCoordinator = new IntelliTrader.Infrastructure.Transactions.JsonTransactionCoordinator();
+
+        using var invalidPositionRepository = new JsonPositionRepository(invalidPositionsPath, transactionCoordinator);
+        using var orderRepository = new JsonOrderRepository(ordersPath, transactionCoordinator);
+        using var portfolioRepository = new JsonPortfolioRepository(portfoliosPath, transactionCoordinator);
+
+        await portfolioRepository.SaveAsync(Portfolio.Create("Default", "USDT", 10000m, 5, 10m));
+
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(transactionCoordinator).SingleInstance();
+        builder.RegisterInstance(invalidPositionRepository)
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+        builder.RegisterInstance(portfolioRepository)
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+        builder.RegisterInstance(orderRepository)
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+        builder.RegisterInstance(_exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+        builder.RegisterInstance(_auditServiceMock.Object)
+            .As<IAuditService>()
+            .SingleInstance();
+
+        using var container = builder.Build();
+        var dispatcher = container.Resolve<ICommandDispatcher>();
+        var pair = TradingPair.Create("SOLUSDT", "USDT");
+        var command = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(100m, "USDT"),
+            SignalRule = "AtomicityCheck"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(150m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, command.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(new ExchangeOrderResult
+            {
+                OrderId = "order-open-position-atomicity-1",
+                Pair = pair,
+                Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+                Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+                Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+                RequestedQuantity = Quantity.Create(0.666666m),
+                FilledQuantity = Quantity.Create(0.666666m),
+                Price = Price.Create(150m),
+                AveragePrice = Price.Create(150m),
+                Cost = Money.Create(100m, "USDT"),
+                Fees = Money.Create(0.1m, "USDT"),
+                Timestamp = DateTimeOffset.UtcNow
+            }));
+
+        // When
+        var result = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(command);
+
+        // Then
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("Failed");
+
+        using var reloadedOrders = new JsonOrderRepository(ordersPath);
+        using var reloadedPortfolios = new JsonPortfolioRepository(portfoliosPath);
+
+        var persistedOrder = await reloadedOrders.GetByIdAsync(OrderId.From("order-open-position-atomicity-1"));
+        persistedOrder.Should().BeNull();
+
+        var reloadedPortfolio = await reloadedPortfolios.GetDefaultAsync();
+        reloadedPortfolio.Should().NotBeNull();
+        reloadedPortfolio!.HasPositionFor(pair).Should().BeFalse();
+    }
+
+    private async Task SeedDefaultPortfolioAsync()
+    {
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+        await portfolioRepository.SaveAsync(Portfolio.Create("Default", "USDT", 10000m, 5, 10m));
+    }
+
+    private static TradingPairRules CreateTradingRules(TradingPair pair)
+    {
+        return new TradingPairRules
+        {
+            Pair = pair,
+            MinOrderValue = 10m,
+            MinQuantity = 0.00001m,
+            MaxQuantity = 10000m,
+            QuantityStepSize = 0.00001m,
+            PricePrecision = 2,
+            QuantityPrecision = 5,
+            MinPrice = 0.01m,
+            MaxPrice = 1000000m,
+            IsTradingEnabled = true
+        };
+    }
+
+    private static ExchangeOrderResult CreateFilledOrder(TradingPair pair)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "order-open-position-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Create(0.02m),
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Cost = Money.Create(1000m, "USDT"),
+            Fees = Money.Create(1m, "USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderResult CreateSubmittedOrder(TradingPair pair)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "order-open-position-pending-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.New,
+            RequestedQuantity = Quantity.Create(0.2m),
+            FilledQuantity = Quantity.Zero,
+            Price = Price.Create(2500m),
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderLifecycleCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderLifecycleCommandDispatchIntegrationTests.cs
@@ -1,0 +1,273 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class OrderLifecycleCommandDispatchIntegrationTests : IClassFixture<InfrastructureTestFixture>, IDisposable
+{
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+    private readonly Mock<IAuditService> _auditServiceMock = new();
+    private readonly IContainer _container;
+
+    public OrderLifecycleCommandDispatchIntegrationTests(InfrastructureTestFixture fixture)
+    {
+        var positionsPath = fixture.CreateTempFilePath("order_lifecycle_positions");
+        var portfoliosPath = fixture.CreateTempFilePath("order_lifecycle_portfolios");
+        var ordersPath = fixture.CreateTempFilePath("order_lifecycle_orders");
+        var transactionCoordinator = new IntelliTrader.Infrastructure.Transactions.JsonTransactionCoordinator();
+
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(transactionCoordinator).SingleInstance();
+
+        builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonPortfolioRepository(portfoliosPath, transactionCoordinator))
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonOrderRepository(ordersPath, transactionCoordinator))
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterInstance(_exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        builder.RegisterInstance(_auditServiceMock.Object)
+            .As<IAuditService>()
+            .SingleInstance();
+
+        _container = builder.Build();
+    }
+
+    public void Dispose()
+    {
+        _container.Dispose();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithValidClosePositionCommand_PersistsFilledSellOrder()
+    {
+        // Given
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("buy-order-seed-1"),
+            Price.Create(50000m),
+            Quantity.Create(0.02m),
+            Money.Create(1m, "USDT"),
+            "MomentumBreakout");
+
+        await SeedOpenPositionAsync(position, 10000m);
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketSellAsync(pair, position.TotalQuantity, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateFilledSellOrder(pair, position.TotalQuantity.Value)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+
+        // When
+        var result = await dispatcher.DispatchAsync<ClosePositionCommand, ClosePositionResult>(
+            new ClosePositionCommand
+            {
+                PositionId = position.Id,
+                Reason = CloseReason.Manual
+            });
+
+        // Then
+        result.IsSuccess.Should().BeTrue();
+
+        var persistedPosition = await positionRepository.GetByIdAsync(position.Id);
+        persistedPosition.Should().NotBeNull();
+        persistedPosition!.IsClosed.Should().BeTrue();
+
+        var portfolio = await portfolioRepository.GetDefaultAsync();
+        portfolio.Should().NotBeNull();
+        portfolio!.HasPositionFor(pair).Should().BeFalse();
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = OrderId.From("sell-order-close-1") });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+        persistedOrder.Value.Side.Should().Be(IntelliTrader.Domain.Events.OrderSide.Sell);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderPlaced",
+                It.Is<string>(details => details.Contains("sell-order-close-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.Is<string>(details => details.Contains("sell-order-close-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithValidExecuteDcaCommand_PersistsFilledBuyOrder()
+    {
+        // Given
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("buy-order-seed-2"),
+            Price.Create(2500m),
+            Quantity.Create(0.2m),
+            Money.Create(0.5m, "USDT"),
+            "Breakout");
+
+        await SeedOpenPositionAsync(position, 10000m);
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(2400m)));
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, It.IsAny<Money>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateFilledDcaOrder(pair)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+
+        // When
+        var result = await dispatcher.DispatchAsync<ExecuteDCACommand, ExecuteDCAResult>(
+            new ExecuteDCACommand
+            {
+                PositionId = position.Id,
+                Cost = Money.Create(500m, "USDT")
+            });
+
+        // Then
+        result.IsSuccess.Should().BeTrue();
+
+        var persistedPosition = await positionRepository.GetByIdAsync(position.Id);
+        persistedPosition.Should().NotBeNull();
+        persistedPosition!.DCALevel.Should().Be(1);
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = OrderId.From("buy-order-dca-1") });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+        persistedOrder.Value.Side.Should().Be(IntelliTrader.Domain.Events.OrderSide.Buy);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderPlaced",
+                It.Is<string>(details => details.Contains("buy-order-dca-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.Is<string>(details => details.Contains("buy-order-dca-1", StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    private async Task SeedOpenPositionAsync(Position position, decimal balance)
+    {
+        var positionRepository = _container.Resolve<IPositionRepository>();
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+
+        var portfolio = Portfolio.Create("Default", "USDT", balance, 5, 10m);
+        portfolio.RecordPositionOpened(position.Id, position.Pair, position.TotalCost);
+
+        await positionRepository.SaveAsync(position);
+        await portfolioRepository.SaveAsync(portfolio);
+    }
+
+    private static TradingPairRules CreateTradingRules(TradingPair pair)
+    {
+        return new TradingPairRules
+        {
+            Pair = pair,
+            MinOrderValue = 10m,
+            MinQuantity = 0.00001m,
+            MaxQuantity = 10000m,
+            QuantityStepSize = 0.00001m,
+            PricePrecision = 2,
+            QuantityPrecision = 5,
+            MinPrice = 0.01m,
+            MaxPrice = 1000000m,
+            IsTradingEnabled = true
+        };
+    }
+
+    private static ExchangeOrderResult CreateFilledSellOrder(TradingPair pair, decimal quantity)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "sell-order-close-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Sell,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+            RequestedQuantity = Quantity.Create(quantity),
+            FilledQuantity = Quantity.Create(quantity),
+            Price = Price.Create(55000m),
+            AveragePrice = Price.Create(55000m),
+            Cost = Money.Create(1100m, "USDT"),
+            Fees = Money.Create(1m, "USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderResult CreateFilledDcaOrder(TradingPair pair)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "buy-order-dca-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+            RequestedQuantity = Quantity.Create(0.20833m),
+            FilledQuantity = Quantity.Create(0.20833m),
+            Price = Price.Create(2400m),
+            AveragePrice = Price.Create(2400m),
+            Cost = Money.Create(500m, "USDT"),
+            Fees = Money.Create(0.5m, "USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderStatusRefreshServiceTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderStatusRefreshServiceTests.cs
@@ -5,6 +5,7 @@ using IntelliTrader.Application.Trading.Commands;
 using IntelliTrader.Infrastructure.BackgroundServices;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Reflection;
 using Xunit;
 
 namespace IntelliTrader.Infrastructure.Tests.Integration;
@@ -17,12 +18,12 @@ public sealed class OrderStatusRefreshServiceTests
         // Arrange
         var dispatcherMock = new Mock<ICommandDispatcher>();
         dispatcherMock
-            .Setup(x => x.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
-                It.IsAny<RefreshSubmittedOrdersCommand>(),
+            .Setup(x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.IsAny<RefreshActiveOrdersCommand>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
+            .ReturnsAsync(Result<RefreshActiveOrdersResult>.Success(new RefreshActiveOrdersResult
             {
-                TotalSubmitted = 1,
+                TotalActive = 1,
                 AttemptedCount = 1,
                 RefreshedCount = 1,
                 AppliedDomainEffectsCount = 1,
@@ -49,11 +50,71 @@ public sealed class OrderStatusRefreshServiceTests
 
         // Assert
         dispatcherMock.Verify(
-            x => x.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
-                It.Is<RefreshSubmittedOrdersCommand>(command => command.Limit == 25),
+            x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.Is<RefreshActiveOrdersCommand>(command => command.Limit == 25),
                 It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
 
         service.ExecutionCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ExecuteWorkAsync_WhenRefreshFails_LogsWarningWithErrorDetails()
+    {
+        // Arrange
+        var dispatcherMock = new Mock<ICommandDispatcher>();
+        dispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.IsAny<RefreshActiveOrdersCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<RefreshActiveOrdersResult>.Failure(
+                Error.ExchangeError("exchange unavailable")));
+
+        var loggerMock = new Mock<ILogger<OrderStatusRefreshService>>();
+        var service = new OrderStatusRefreshService(
+            loggerMock.Object,
+            dispatcherMock.Object,
+            new OrderStatusRefreshOptions
+            {
+                MaxOrdersPerCycle = 25
+            });
+
+        // Act
+        await InvokeExecuteWorkAsync(service);
+
+        // Assert
+        dispatcherMock.Verify(
+            x => x.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+                It.Is<RefreshActiveOrdersCommand>(command => command.Limit == 25),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) =>
+                    state.ToString()!.Contains("Failed to refresh active orders") &&
+                    state.ToString()!.Contains("ExchangeError") &&
+                    state.ToString()!.Contains("exchange unavailable")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private static async Task InvokeExecuteWorkAsync(OrderStatusRefreshService service)
+    {
+        var method = typeof(OrderStatusRefreshService).GetMethod(
+            "ExecuteWorkAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        try
+        {
+            await (Task)method.Invoke(service, [CancellationToken.None])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
     }
 }

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderStatusRefreshServiceTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderStatusRefreshServiceTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Infrastructure.BackgroundServices;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class OrderStatusRefreshServiceTests
+{
+    [Fact]
+    public async Task StartAsync_DispatchesBulkRefreshCommandOnSchedule()
+    {
+        // Arrange
+        var dispatcherMock = new Mock<ICommandDispatcher>();
+        dispatcherMock
+            .Setup(x => x.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
+                It.IsAny<RefreshSubmittedOrdersCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<RefreshSubmittedOrdersResult>.Success(new RefreshSubmittedOrdersResult
+            {
+                TotalSubmitted = 1,
+                AttemptedCount = 1,
+                RefreshedCount = 1,
+                AppliedDomainEffectsCount = 1,
+                FailedCount = 0
+            }));
+
+        var loggerMock = new Mock<ILogger<OrderStatusRefreshService>>();
+        var service = new OrderStatusRefreshService(
+            loggerMock.Object,
+            dispatcherMock.Object,
+            new OrderStatusRefreshOptions
+            {
+                Interval = TimeSpan.FromMilliseconds(50),
+                StartDelay = TimeSpan.Zero,
+                MaxOrdersPerCycle = 25
+            });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+
+        // Act
+        await service.StartAsync(cts.Token);
+        await Task.Delay(140);
+        await service.StopAsync(CancellationToken.None);
+
+        // Assert
+        dispatcherMock.Verify(
+            x => x.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
+                It.Is<RefreshSubmittedOrdersCommand>(command => command.Limit == 25),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+
+        service.ExecutionCount.Should().BeGreaterThan(0);
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshOrderStatusCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshOrderStatusCommandDispatchIntegrationTests.cs
@@ -1,0 +1,208 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class RefreshOrderStatusCommandDispatchIntegrationTests : IClassFixture<InfrastructureTestFixture>, IDisposable
+{
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+    private readonly Mock<IAuditService> _auditServiceMock = new();
+    private readonly IContainer _container;
+
+    public RefreshOrderStatusCommandDispatchIntegrationTests(InfrastructureTestFixture fixture)
+    {
+        var positionsPath = fixture.CreateTempFilePath("refresh_order_status_positions");
+        var portfoliosPath = fixture.CreateTempFilePath("refresh_order_status_portfolios");
+        var ordersPath = fixture.CreateTempFilePath("refresh_order_status_orders");
+        var transactionCoordinator = new IntelliTrader.Infrastructure.Transactions.JsonTransactionCoordinator();
+
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(transactionCoordinator).SingleInstance();
+
+        builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonPortfolioRepository(portfoliosPath, transactionCoordinator))
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonOrderRepository(ordersPath, transactionCoordinator))
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterInstance(_exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        builder.RegisterInstance(_auditServiceMock.Object)
+            .As<IAuditService>()
+            .SingleInstance();
+
+        _container = builder.Build();
+        SeedDefaultPortfolioAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        _container.Dispose();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSubmittedOpenOrderIsRefreshedToFilled_PersistsFilledOrderAndCreatesPosition()
+    {
+        // Given
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var openCommand = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, openCommand.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateSubmittedOrder(pair)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+        var orderId = OrderId.From("refresh-open-position-order-1");
+
+        // When
+        var submitResult = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(openCommand);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, orderId.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateFilledOrderInfo(pair, orderId.Value)));
+
+        var refreshResult = await dispatcher.DispatchAsync<RefreshOrderStatusCommand, RefreshOrderStatusResult>(
+            new RefreshOrderStatusCommand { OrderId = orderId });
+
+        // Then
+        submitResult.IsFailure.Should().BeTrue();
+        refreshResult.IsSuccess.Should().BeTrue();
+        refreshResult.Value.CurrentStatus.Should().Be(OrderLifecycleStatus.Filled);
+        refreshResult.Value.AppliedDomainEffects.Should().BeTrue();
+
+        var position = await positionRepository.GetByPairAsync(pair);
+        position.Should().NotBeNull();
+        position!.SignalRule.Should().Be("MomentumBreakout");
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = orderId });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+        persistedOrder.Value.CanAffectPosition.Should().BeTrue();
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderPlaced",
+                It.Is<string>(details => details.Contains(orderId.Value, StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.Is<string>(details => details.Contains(orderId.Value, StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "PositionOpened",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    private async Task SeedDefaultPortfolioAsync()
+    {
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+        await portfolioRepository.SaveAsync(Portfolio.Create("Default", "USDT", 10000m, 5, 10m));
+    }
+
+    private static TradingPairRules CreateTradingRules(TradingPair pair)
+    {
+        return new TradingPairRules
+        {
+            Pair = pair,
+            MinOrderValue = 10m,
+            MinQuantity = 0.00001m,
+            MaxQuantity = 10000m,
+            QuantityStepSize = 0.00001m,
+            PricePrecision = 2,
+            QuantityPrecision = 5,
+            MinPrice = 0.01m,
+            MaxPrice = 1000000m,
+            IsTradingEnabled = true
+        };
+    }
+
+    private static ExchangeOrderResult CreateSubmittedOrder(TradingPair pair)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = "refresh-open-position-order-1",
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.New,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Zero,
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderInfo CreateFilledOrderInfo(TradingPair pair, string orderId)
+    {
+        return new ExchangeOrderInfo
+        {
+            OrderId = orderId,
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+            OriginalQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Create(0.02m),
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Fees = Money.Create(1m, "USDT"),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
@@ -1,0 +1,175 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Core;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class RefreshSubmittedOrdersCommandDispatchIntegrationTests : IClassFixture<InfrastructureTestFixture>, IDisposable
+{
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+    private readonly Mock<IAuditService> _auditServiceMock = new();
+    private readonly IContainer _container;
+
+    public RefreshSubmittedOrdersCommandDispatchIntegrationTests(InfrastructureTestFixture fixture)
+    {
+        var positionsPath = fixture.CreateTempFilePath("refresh_submitted_positions");
+        var portfoliosPath = fixture.CreateTempFilePath("refresh_submitted_portfolios");
+        var ordersPath = fixture.CreateTempFilePath("refresh_submitted_orders");
+        var transactionCoordinator = new IntelliTrader.Infrastructure.Transactions.JsonTransactionCoordinator();
+
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(transactionCoordinator).SingleInstance();
+
+        builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
+            .As<IPositionRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonPortfolioRepository(portfoliosPath, transactionCoordinator))
+            .As<IPortfolioRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(c => new JsonOrderRepository(ordersPath, transactionCoordinator))
+            .As<IOrderRepository>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterInstance(_exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        builder.RegisterInstance(_auditServiceMock.Object)
+            .As<IAuditService>()
+            .SingleInstance();
+
+        _container = builder.Build();
+        SeedDefaultPortfolioAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        _container.Dispose();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSubmittedOrdersExist_RefreshesThemInBatch()
+    {
+        // Given
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var openCommand = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, openCommand.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreateSubmittedOrder(pair, "batch-refresh-order-1")));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+
+        // When
+        var submitResult = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(openCommand);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, "batch-refresh-order-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateFilledOrderInfo(pair, "batch-refresh-order-1")));
+
+        var refreshResult = await dispatcher.DispatchAsync<RefreshSubmittedOrdersCommand, RefreshSubmittedOrdersResult>(
+            new RefreshSubmittedOrdersCommand { Limit = 10 });
+
+        // Then
+        submitResult.IsFailure.Should().BeTrue();
+        refreshResult.IsSuccess.Should().BeTrue();
+        refreshResult.Value.TotalSubmitted.Should().Be(1);
+        refreshResult.Value.AttemptedCount.Should().Be(1);
+        refreshResult.Value.RefreshedCount.Should().Be(1);
+        refreshResult.Value.AppliedDomainEffectsCount.Should().Be(1);
+        refreshResult.Value.FailedCount.Should().Be(0);
+
+        var position = await positionRepository.GetByPairAsync(pair);
+        position.Should().NotBeNull();
+    }
+
+    private async Task SeedDefaultPortfolioAsync()
+    {
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+        await portfolioRepository.SaveAsync(Portfolio.Create("Default", "USDT", 10000m, 5, 10m));
+    }
+
+    private static TradingPairRules CreateTradingRules(TradingPair pair)
+    {
+        return new TradingPairRules
+        {
+            Pair = pair,
+            MinOrderValue = 10m,
+            MinQuantity = 0.00001m,
+            MaxQuantity = 10000m,
+            QuantityStepSize = 0.00001m,
+            PricePrecision = 2,
+            QuantityPrecision = 5,
+            MinPrice = 0.01m,
+            MaxPrice = 1000000m,
+            IsTradingEnabled = true
+        };
+    }
+
+    private static ExchangeOrderResult CreateSubmittedOrder(TradingPair pair, string orderId)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = orderId,
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.New,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Zero,
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Zero,
+            Cost = Money.Zero("USDT"),
+            Fees = Money.Zero("USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderInfo CreateFilledOrderInfo(TradingPair pair, string orderId)
+    {
+        return new ExchangeOrderInfo
+        {
+            OrderId = orderId,
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.Filled,
+            OriginalQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Create(0.02m),
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Fees = Money.Create(1m, "USDT"),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
@@ -4,8 +4,10 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Ports.Driving;
 using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Application.Trading.Queries;
 using IntelliTrader.Core;
 using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
 using Moq;
@@ -112,6 +114,91 @@ public sealed class RefreshSubmittedOrdersCommandDispatchIntegrationTests : ICla
         position.Should().NotBeNull();
     }
 
+    [Fact]
+    public async Task DispatchAsync_WhenPartiallyFilledOpenOrderCompletes_RefreshesItInBatchAndAppliesOnlyRemainingFill()
+    {
+        // Given
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var orderId = "batch-refresh-partial-open-1";
+        var openCommand = new OpenPositionCommand
+        {
+            Pair = pair,
+            Cost = Money.Create(1000m, "USDT"),
+            SignalRule = "MomentumBreakout"
+        };
+
+        _exchangePortMock
+            .Setup(x => x.GetTradingRulesAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TradingPairRules>.Success(CreateTradingRules(pair)));
+
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(50000m)));
+
+        _exchangePortMock
+            .Setup(x => x.PlaceMarketBuyAsync(pair, openCommand.Cost, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderResult>.Success(CreatePartiallyFilledOrder(pair, orderId)));
+
+        var dispatcher = _container.Resolve<ICommandDispatcher>();
+        var queryDispatcher = _container.Resolve<IQueryDispatcher>();
+        var positionRepository = _container.Resolve<IPositionRepository>();
+        var portfolioRepository = _container.Resolve<IPortfolioRepository>();
+
+        var openResult = await dispatcher.DispatchAsync<OpenPositionCommand, OpenPositionResult>(openCommand);
+        openResult.IsSuccess.Should().BeTrue();
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, orderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateFilledOrderInfo(pair, orderId)));
+
+        // When
+        var refreshResult = await dispatcher.DispatchAsync<RefreshActiveOrdersCommand, RefreshActiveOrdersResult>(
+            new RefreshActiveOrdersCommand { Limit = 10 });
+
+        // Then
+        refreshResult.IsSuccess.Should().BeTrue();
+        refreshResult.Value.TotalActive.Should().Be(1);
+        refreshResult.Value.AttemptedCount.Should().Be(1);
+        refreshResult.Value.RefreshedCount.Should().Be(1);
+        refreshResult.Value.AppliedDomainEffectsCount.Should().Be(1);
+        refreshResult.Value.FailedCount.Should().Be(0);
+
+        var persistedOrder = await queryDispatcher.DispatchAsync<GetOrderQuery, OrderView>(
+            new GetOrderQuery { OrderId = OrderId.From(orderId) });
+
+        persistedOrder.IsSuccess.Should().BeTrue();
+        persistedOrder.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
+
+        var position = await positionRepository.GetByPairAsync(pair);
+        position.Should().NotBeNull();
+        position!.Id.Should().Be(openResult.Value.PositionId);
+        position.TotalQuantity.Value.Should().Be(0.02m);
+        position.TotalCost.Amount.Should().Be(1000m);
+        position.TotalFees.Amount.Should().Be(1m);
+        position.Entries.Should().ContainSingle();
+
+        var portfolio = await portfolioRepository.GetDefaultAsync();
+        portfolio.Should().NotBeNull();
+        portfolio!.GetPositionId(pair).Should().Be(position.Id);
+        portfolio.GetTotalInvestedCost().Amount.Should().Be(1000m);
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "OrderFilled",
+                It.Is<string>(details => details.Contains(orderId, StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Exactly(2));
+
+        _auditServiceMock.Verify(
+            x => x.LogAudit(
+                "PositionOpened",
+                It.Is<string>(details => details.Contains(pair.Symbol, StringComparison.Ordinal)),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
     private async Task SeedDefaultPortfolioAsync()
     {
         var portfolioRepository = _container.Resolve<IPortfolioRepository>();
@@ -150,6 +237,25 @@ public sealed class RefreshSubmittedOrdersCommandDispatchIntegrationTests : ICla
             AveragePrice = Price.Zero,
             Cost = Money.Zero("USDT"),
             Fees = Money.Zero("USDT"),
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ExchangeOrderResult CreatePartiallyFilledOrder(TradingPair pair, string orderId)
+    {
+        return new ExchangeOrderResult
+        {
+            OrderId = orderId,
+            Pair = pair,
+            Side = IntelliTrader.Application.Ports.Driven.OrderSide.Buy,
+            Type = IntelliTrader.Application.Ports.Driven.OrderType.Market,
+            Status = IntelliTrader.Application.Ports.Driven.OrderStatus.PartiallyFilled,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Create(0.01m),
+            Price = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Cost = Money.Create(500m, "USDT"),
+            Fees = Money.Create(0.5m, "USDT"),
             Timestamp = DateTimeOffset.UtcNow
         };
     }

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/TradingUseCaseRegistrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/TradingUseCaseRegistrationTests.cs
@@ -1,0 +1,29 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Ports.Driving;
+using IntelliTrader.Application.Trading;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class TradingUseCaseRegistrationTests
+{
+    [Fact]
+    public void BuildContainer_ResolvesTradingUseCasePrimaryPort()
+    {
+        var exchangePortMock = new Mock<IExchangePort>();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+        builder.RegisterInstance(exchangePortMock.Object)
+            .As<IExchangePort>()
+            .SingleInstance();
+
+        using var container = builder.Build();
+
+        var useCase = container.Resolve<ITradingUseCase>();
+
+        useCase.Should().BeOfType<TradingUseCase>();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a transactional order lifecycle foundation for submitted, active, partially filled, filled, canceled, and rejected orders.
- Reworks the refresh pipeline around active orders, including CQRS handlers, background refresh service, JSON persistence, domain events, and audit handlers.
- Hardens the implementation with TDD coverage across domain state machines, application handlers, dispatching, and JSON transaction rollback/commit paths.

## Acceptance Criteria
- Given an active order is refreshed from the exchange, when the exchange reports a new terminal or partial status, then the order lifecycle transitions through the domain state machine and persists consistently.
- Given a partial open, DCA, or close order is refreshed repeatedly, when cumulative fills grow, then only the unapplied delta affects position and portfolio state.
- Given JSON-backed repositories participate in a transaction, when commit succeeds or rollback/failure occurs, then persisted files and in-memory caches remain consistent.
- Given active order refresh runs in the background, when it dispatches the CQRS batch command, then submitted and partially filled orders are included while terminal orders are ignored.

## Changes
- Added order lifecycle CQRS commands/handlers, active order queries, and refresh result models.
- Added `ActiveOrderRefreshService` and kept the legacy submitted refresh contract as a compatible alias.
- Added JSON persistence and transaction support for order lifecycles and portfolio defaults.
- Hardened `InMemoryCommandDispatcher` transaction cleanup and exception unwrapping.
- Added extensive TDD coverage for order lifecycle, position fill deltas, refresh handler negative paths, JSON repositories, and background refresh behavior.

## Testing
- `dotnet test tests/IntelliTrader.Application.Tests/IntelliTrader.Application.Tests.csproj --configuration Release`
- `dotnet test tests/IntelliTrader.Infrastructure.Tests/IntelliTrader.Infrastructure.Tests.csproj --configuration Release`
- `dotnet test tests/IntelliTrader.Core.Tests/IntelliTrader.Core.Tests.csproj --configuration Release`
- `dotnet test tests/IntelliTrader.Domain.Tests/IntelliTrader.Domain.Tests.csproj --configuration Release`
- `dotnet build IntelliTrader.sln --configuration Release --no-restore`

## Checklist
- [x] Tests pass
- [x] Coverage maintained
- [ ] Linter clean
- [x] Documentation not required for this internal architecture slice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive order lifecycle tracking and persistence with status reconciliation
  * Added portfolio and order query capabilities with filtering and sorting
  * Added automatic background reconciliation of active orders with exchange
  * Added trading use case facade providing unified interface for position and portfolio operations
  * Added detailed trading history and statistics calculations

* **Infrastructure**
  * Enhanced data persistence layer with transactional support
  * Improved trading service startup/shutdown lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->