### PR TITLE
feat(trading): add transactional domain event outbox

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/IDomainEventOutbox.cs
+++ b/IntelliTrader.Application/Ports/Driven/IDomainEventOutbox.cs
@@ -11,7 +11,22 @@ public interface IDomainEventOutbox
         IEnumerable<IDomainEvent> domainEvents,
         CancellationToken cancellationToken = default);
 
+    Task<IReadOnlyList<DomainEventOutboxMessage>> GetUnprocessedAsync(
+        int batchSize = 100,
+        CancellationToken cancellationToken = default);
+
     Task MarkProcessedAsync(
         Guid eventId,
         CancellationToken cancellationToken = default);
+}
+
+public sealed record DomainEventOutboxMessage(
+    Guid EventId,
+    string EventType,
+    string Payload,
+    DateTimeOffset OccurredAt,
+    DateTimeOffset EnqueuedAt,
+    DateTimeOffset? ProcessedAt)
+{
+    public bool IsProcessed => ProcessedAt.HasValue;
 }

--- a/IntelliTrader.Application/Ports/Driven/IDomainEventOutbox.cs
+++ b/IntelliTrader.Application/Ports/Driven/IDomainEventOutbox.cs
@@ -1,0 +1,17 @@
+using IntelliTrader.Domain.SharedKernel;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Durable outbox for domain events that must be committed with aggregate state.
+/// </summary>
+public interface IDomainEventOutbox
+{
+    Task EnqueueAsync(
+        IEnumerable<IDomainEvent> domainEvents,
+        CancellationToken cancellationToken = default);
+
+    Task MarkProcessedAsync(
+        Guid eventId,
+        CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -168,7 +168,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             position.Pair,
             proceeds);
         orderLifecycle.MarkCurrentFillApplied();
-        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle, position, portfolio);
 
         // 11. Save changes
         try
@@ -177,7 +177,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -193,8 +193,12 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         // 12. Dispatch domain events
-        ClearDomainEvents(orderLifecycle, position, portfolio);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle, position, portfolio);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         // 13. Calculate realized PnL
         var totalCost = position.TotalCost + position.TotalFees + sellFees;
@@ -242,13 +246,13 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
-        var domainEvents = CollectDomainEvents(orderLifecycle);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle);
 
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -263,8 +267,12 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        ClearDomainEvents(orderLifecycle);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         return Result<ClosePositionResult>.Failure(
             Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
@@ -297,7 +305,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         orderLifecycle.MarkCurrentFillApplied();
-        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle, position, portfolio);
 
         try
         {
@@ -305,7 +313,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -320,8 +328,12 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
                 Error.ExchangeError($"Failed to save partial close effects: {ex.Message}"));
         }
 
-        ClearDomainEvents(orderLifecycle, position, portfolio);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle, position, portfolio);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         return Result<ClosePositionResult>.Failure(
             Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
@@ -330,67 +342,6 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
     private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
     {
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
-    }
-
-    private async Task EnqueueDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventOutbox.EnqueueAsync(events, cancellationToken);
-    }
-
-    private async Task DispatchCommittedDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
-
-        foreach (var domainEvent in events)
-        {
-            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
-        }
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        return orderLifecycle.DomainEvents.ToList();
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        var events = new List<IDomainEvent>();
-        events.AddRange(orderLifecycle.DomainEvents);
-        events.AddRange(position.DomainEvents);
-        events.AddRange(portfolio.DomainEvents);
-        return events;
-    }
-
-    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        orderLifecycle.ClearDomainEvents();
-    }
-
-    private static void ClearDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        orderLifecycle.ClearDomainEvents();
-        position.ClearDomainEvents();
-        portfolio.ClearDomainEvents();
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -18,6 +18,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
     private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
+    private readonly IDomainEventOutbox _eventOutbox;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ITransactionalUnitOfWork _unitOfWork;
@@ -28,6 +29,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
+        IDomainEventOutbox eventOutbox,
         TradingConstraintValidator constraintValidator,
         ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
@@ -37,6 +39,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
+        _eventOutbox = eventOutbox ?? throw new ArgumentNullException(nameof(eventOutbox));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _notificationPort = notificationPort;

--- a/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ClosePositionHandler.cs
@@ -1,6 +1,7 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Domain.SharedKernel;
 using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
@@ -167,6 +168,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             position.Pair,
             proceeds);
         orderLifecycle.MarkCurrentFillApplied();
+        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
 
         // 11. Save changes
         try
@@ -175,6 +177,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -190,7 +193,8 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         // 12. Dispatch domain events
-        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
+        ClearDomainEvents(orderLifecycle, position, portfolio);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         // 13. Calculate realized PnL
         var totalCost = position.TotalCost + position.TotalFees + sellFees;
@@ -238,10 +242,13 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
+        var domainEvents = CollectDomainEvents(orderLifecycle);
+
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -256,7 +263,8 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+        ClearDomainEvents(orderLifecycle);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         return Result<ClosePositionResult>.Failure(
             Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
@@ -289,6 +297,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         }
 
         orderLifecycle.MarkCurrentFillApplied();
+        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
 
         try
         {
@@ -296,6 +305,7 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -310,7 +320,8 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
                 Error.ExchangeError($"Failed to save partial close effects: {ex.Message}"));
         }
 
-        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
+        ClearDomainEvents(orderLifecycle, position, portfolio);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         return Result<ClosePositionResult>.Failure(
             Error.ExchangeError($"Sell order was not filled. Status: {exchangeStatus}"));
@@ -321,32 +332,65 @@ public sealed class ClosePositionHandler : ICommandHandler<ClosePositionCommand,
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
     }
 
-    private async Task DispatchOrderEventsAsync(
-        OrderLifecycle orderLifecycle,
+    private async Task EnqueueDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        orderLifecycle.ClearDomainEvents();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
-        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+        await _eventOutbox.EnqueueAsync(events, cancellationToken);
     }
 
-    private async Task DispatchDomainEventsAsync(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio,
+    private async Task DispatchCommittedDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        var positionEvents = position.DomainEvents.ToList();
-        var portfolioEvents = portfolio.DomainEvents.ToList();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
+        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+        }
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        return orderLifecycle.DomainEvents.ToList();
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
+        var events = new List<IDomainEvent>();
+        events.AddRange(orderLifecycle.DomainEvents);
+        events.AddRange(position.DomainEvents);
+        events.AddRange(portfolio.DomainEvents);
+        return events;
+    }
+
+    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        orderLifecycle.ClearDomainEvents();
+    }
+
+    private static void ClearDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
         orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
-
-        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
-        await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/DomainEventOutboxWorkflow.cs
+++ b/IntelliTrader.Application/Trading/Handlers/DomainEventOutboxWorkflow.cs
@@ -63,11 +63,31 @@ internal static class DomainEventOutboxWorkflow
             return;
         }
 
-        await eventDispatcher.DispatchManyAsync(events, cancellationToken);
+        try
+        {
+            await eventDispatcher.DispatchManyAsync(events, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // The trading state is already committed. Keep the command successful
+            // and leave events pending so an outbox replay can retry them.
+            System.Diagnostics.Trace.TraceWarning(
+                $"Committed domain event dispatch failed: {ex.Message}");
+            return;
+        }
 
         foreach (var domainEvent in events)
         {
-            await eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+            try
+            {
+                await eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    $"Committed domain event mark-processed failed for {domainEvent.EventId}: {ex.Message}");
+                return;
+            }
         }
     }
 }

--- a/IntelliTrader.Application/Trading/Handlers/DomainEventOutboxWorkflow.cs
+++ b/IntelliTrader.Application/Trading/Handlers/DomainEventOutboxWorkflow.cs
@@ -1,0 +1,73 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Orders;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+internal static class DomainEventOutboxWorkflow
+{
+    public static List<IDomainEvent> Collect(OrderLifecycle order)
+    {
+        return order.DomainEvents.ToList();
+    }
+
+    public static List<IDomainEvent> Collect(
+        OrderLifecycle order,
+        Position position,
+        Portfolio portfolio)
+    {
+        var events = new List<IDomainEvent>();
+        events.AddRange(order.DomainEvents);
+        events.AddRange(position.DomainEvents);
+        events.AddRange(portfolio.DomainEvents);
+        return events;
+    }
+
+    public static void Clear(OrderLifecycle order)
+    {
+        order.ClearDomainEvents();
+    }
+
+    public static void Clear(
+        OrderLifecycle order,
+        Position position,
+        Portfolio portfolio)
+    {
+        order.ClearDomainEvents();
+        position.ClearDomainEvents();
+        portfolio.ClearDomainEvents();
+    }
+
+    public static async Task EnqueueAsync(
+        IDomainEventOutbox eventOutbox,
+        IReadOnlyCollection<IDomainEvent> events,
+        CancellationToken cancellationToken)
+    {
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        await eventOutbox.EnqueueAsync(events, cancellationToken);
+    }
+
+    public static async Task DispatchCommittedAsync(
+        IDomainEventDispatcher eventDispatcher,
+        IDomainEventOutbox eventOutbox,
+        IReadOnlyCollection<IDomainEvent> events,
+        CancellationToken cancellationToken)
+    {
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        await eventDispatcher.DispatchManyAsync(events, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            await eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+        }
+    }
+}

--- a/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
@@ -1,6 +1,7 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Domain.SharedKernel;
 using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
@@ -177,6 +178,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
             position.Pair,
             orderLifecycle.Cost);
         orderLifecycle.MarkCurrentFillApplied();
+        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
 
         // 12. Save changes
         try
@@ -185,6 +187,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -200,7 +203,8 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         }
 
         // 13. Dispatch domain events
-        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
+        ClearDomainEvents(orderLifecycle, position, portfolio);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         // 14. Send notification
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -250,10 +254,13 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
+        var domainEvents = CollectDomainEvents(orderLifecycle);
+
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -268,7 +275,8 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+        ClearDomainEvents(orderLifecycle);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         return Result<ExecuteDCAResult>.Failure(
             Error.ExchangeError($"DCA order was not filled. Status: {exchangeStatus}"));
@@ -279,32 +287,65 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
     }
 
-    private async Task DispatchOrderEventsAsync(
-        OrderLifecycle orderLifecycle,
+    private async Task EnqueueDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        orderLifecycle.ClearDomainEvents();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
-        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+        await _eventOutbox.EnqueueAsync(events, cancellationToken);
     }
 
-    private async Task DispatchDomainEventsAsync(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio,
+    private async Task DispatchCommittedDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        var positionEvents = position.DomainEvents.ToList();
-        var portfolioEvents = portfolio.DomainEvents.ToList();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
+        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+        }
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        return orderLifecycle.DomainEvents.ToList();
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
+        var events = new List<IDomainEvent>();
+        events.AddRange(orderLifecycle.DomainEvents);
+        events.AddRange(position.DomainEvents);
+        events.AddRange(portfolio.DomainEvents);
+        return events;
+    }
+
+    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        orderLifecycle.ClearDomainEvents();
+    }
+
+    private static void ClearDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
         orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
-
-        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
-        await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
@@ -18,6 +18,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
     private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
+    private readonly IDomainEventOutbox _eventOutbox;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ITransactionalUnitOfWork _unitOfWork;
@@ -28,6 +29,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
+        IDomainEventOutbox eventOutbox,
         TradingConstraintValidator constraintValidator,
         ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
@@ -37,6 +39,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
+        _eventOutbox = eventOutbox ?? throw new ArgumentNullException(nameof(eventOutbox));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _notificationPort = notificationPort;

--- a/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExecuteDCAHandler.cs
@@ -178,7 +178,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
             position.Pair,
             orderLifecycle.Cost);
         orderLifecycle.MarkCurrentFillApplied();
-        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle, position, portfolio);
 
         // 12. Save changes
         try
@@ -187,7 +187,7 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -203,8 +203,12 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         }
 
         // 13. Dispatch domain events
-        ClearDomainEvents(orderLifecycle, position, portfolio);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle, position, portfolio);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         // 14. Send notification
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -254,13 +258,13 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
-        var domainEvents = CollectDomainEvents(orderLifecycle);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle);
 
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -275,8 +279,12 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        ClearDomainEvents(orderLifecycle);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         return Result<ExecuteDCAResult>.Failure(
             Error.ExchangeError($"DCA order was not filled. Status: {exchangeStatus}"));
@@ -285,67 +293,6 @@ public sealed class ExecuteDCAHandler : ICommandHandler<ExecuteDCACommand, Execu
     private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
     {
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
-    }
-
-    private async Task EnqueueDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventOutbox.EnqueueAsync(events, cancellationToken);
-    }
-
-    private async Task DispatchCommittedDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
-
-        foreach (var domainEvent in events)
-        {
-            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
-        }
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        return orderLifecycle.DomainEvents.ToList();
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        var events = new List<IDomainEvent>();
-        events.AddRange(orderLifecycle.DomainEvents);
-        events.AddRange(position.DomainEvents);
-        events.AddRange(portfolio.DomainEvents);
-        return events;
-    }
-
-    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        orderLifecycle.ClearDomainEvents();
-    }
-
-    private static void ClearDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        orderLifecycle.ClearDomainEvents();
-        position.ClearDomainEvents();
-        portfolio.ClearDomainEvents();
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
@@ -18,6 +18,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
     private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
+    private readonly IDomainEventOutbox _eventOutbox;
     private readonly INotificationPort? _notificationPort;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ITransactionalUnitOfWork _unitOfWork;
@@ -28,6 +29,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
+        IDomainEventOutbox eventOutbox,
         TradingConstraintValidator constraintValidator,
         ITransactionalUnitOfWork unitOfWork,
         INotificationPort? notificationPort = null)
@@ -37,6 +39,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
+        _eventOutbox = eventOutbox ?? throw new ArgumentNullException(nameof(eventOutbox));
         _constraintValidator = constraintValidator ?? throw new ArgumentNullException(nameof(constraintValidator));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _notificationPort = notificationPort;

--- a/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
@@ -165,7 +165,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             orderLifecycle.Cost);
         orderLifecycle.LinkRelatedPosition(position.Id);
         orderLifecycle.MarkCurrentFillApplied();
-        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle, position, portfolio);
 
         // 10. Save changes
         try
@@ -174,7 +174,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -190,8 +190,12 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         }
 
         // 11. Dispatch domain events
-        ClearDomainEvents(orderLifecycle, position, portfolio);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle, position, portfolio);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         // 12. Send notification (non-blocking)
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -248,13 +252,13 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
-        var domainEvents = CollectDomainEvents(orderLifecycle);
+        var domainEvents = DomainEventOutboxWorkflow.Collect(orderLifecycle);
 
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
-            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -269,8 +273,12 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        ClearDomainEvents(orderLifecycle);
-        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(orderLifecycle);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            domainEvents,
+            cancellationToken);
 
         return Result<OpenPositionResult>.Failure(
             Error.ExchangeError($"Order was not filled. Status: {exchangeStatus}"));
@@ -279,67 +287,6 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
     private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
     {
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
-    }
-
-    private async Task EnqueueDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventOutbox.EnqueueAsync(events, cancellationToken);
-    }
-
-    private async Task DispatchCommittedDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
-
-        foreach (var domainEvent in events)
-        {
-            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
-        }
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        return orderLifecycle.DomainEvents.ToList();
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        var events = new List<IDomainEvent>();
-        events.AddRange(orderLifecycle.DomainEvents);
-        events.AddRange(position.DomainEvents);
-        events.AddRange(portfolio.DomainEvents);
-        return events;
-    }
-
-    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
-    {
-        orderLifecycle.ClearDomainEvents();
-    }
-
-    private static void ClearDomainEvents(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio)
-    {
-        orderLifecycle.ClearDomainEvents();
-        position.ClearDomainEvents();
-        portfolio.ClearDomainEvents();
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OpenPositionHandler.cs
@@ -1,6 +1,7 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Commands;
+using IntelliTrader.Domain.SharedKernel;
 using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.Services;
@@ -164,6 +165,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             orderLifecycle.Cost);
         orderLifecycle.LinkRelatedPosition(position.Id);
         orderLifecycle.MarkCurrentFillApplied();
+        var domainEvents = CollectDomainEvents(orderLifecycle, position, portfolio);
 
         // 10. Save changes
         try
@@ -172,6 +174,7 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -187,7 +190,8 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         }
 
         // 11. Dispatch domain events
-        await DispatchDomainEventsAsync(orderLifecycle, position, portfolio, cancellationToken);
+        ClearDomainEvents(orderLifecycle, position, portfolio);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         // 12. Send notification (non-blocking)
         await SendNotificationAsync(position, orderResult, cancellationToken);
@@ -244,10 +248,13 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         OrderStatus exchangeStatus,
         CancellationToken cancellationToken)
     {
+        var domainEvents = CollectDomainEvents(orderLifecycle);
+
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(orderLifecycle, cancellationToken);
+            await EnqueueDomainEventsAsync(domainEvents, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -262,7 +269,8 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
                 Error.ExchangeError($"Failed to save order lifecycle: {ex.Message}"));
         }
 
-        await DispatchOrderEventsAsync(orderLifecycle, cancellationToken);
+        ClearDomainEvents(orderLifecycle);
+        await DispatchCommittedDomainEventsAsync(domainEvents, cancellationToken);
 
         return Result<OpenPositionResult>.Failure(
             Error.ExchangeError($"Order was not filled. Status: {exchangeStatus}"));
@@ -273,32 +281,65 @@ public sealed class OpenPositionHandler : ICommandHandler<OpenPositionCommand, O
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
     }
 
-    private async Task DispatchOrderEventsAsync(
-        OrderLifecycle orderLifecycle,
+    private async Task EnqueueDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        orderLifecycle.ClearDomainEvents();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
-        await _eventDispatcher.DispatchManyAsync(orderEvents, cancellationToken);
+        await _eventOutbox.EnqueueAsync(events, cancellationToken);
     }
 
-    private async Task DispatchDomainEventsAsync(
-        OrderLifecycle orderLifecycle,
-        Position position,
-        Portfolio portfolio,
+    private async Task DispatchCommittedDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var orderEvents = orderLifecycle.DomainEvents.ToList();
-        var positionEvents = position.DomainEvents.ToList();
-        var portfolioEvents = portfolio.DomainEvents.ToList();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
+        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+        }
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        return orderLifecycle.DomainEvents.ToList();
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
+        var events = new List<IDomainEvent>();
+        events.AddRange(orderLifecycle.DomainEvents);
+        events.AddRange(position.DomainEvents);
+        events.AddRange(portfolio.DomainEvents);
+        return events;
+    }
+
+    private static void ClearDomainEvents(OrderLifecycle orderLifecycle)
+    {
+        orderLifecycle.ClearDomainEvents();
+    }
+
+    private static void ClearDomainEvents(
+        OrderLifecycle orderLifecycle,
+        Position position,
+        Portfolio portfolio)
+    {
         orderLifecycle.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
-
-        var allEvents = orderEvents.Concat(positionEvents).Concat(portfolioEvents);
-        await _eventDispatcher.DispatchManyAsync(allEvents, cancellationToken);
     }
 
     private async Task SendNotificationAsync(

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -316,10 +316,13 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         OrderLifecycleStatus previousStatus,
         CancellationToken cancellationToken)
     {
+        var events = CollectDomainEvents(order);
+
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(order, cancellationToken);
+            await EnqueueDomainEventsAsync(events, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -334,7 +337,8 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
                 Error.ExchangeError($"Failed to persist refreshed order: {ex.Message}"));
         }
 
-        await DispatchDomainEventsAsync(order, cancellationToken);
+        ClearDomainEvents(order);
+        await DispatchCommittedDomainEventsAsync(events, cancellationToken);
 
         return Result<RefreshOrderStatusResult>.Success(CreateResult(
             order,
@@ -350,12 +354,15 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         Portfolio portfolio,
         CancellationToken cancellationToken)
     {
+        var events = CollectDomainEvents(order, position, portfolio);
+
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(order, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
+            await EnqueueDomainEventsAsync(events, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -370,7 +377,8 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
                 Error.ExchangeError($"Failed to persist refreshed order effects: {ex.Message}"));
         }
 
-        await DispatchDomainEventsAsync(order, position, portfolio, cancellationToken);
+        ClearDomainEvents(order, position, portfolio);
+        await DispatchCommittedDomainEventsAsync(events, cancellationToken);
 
         return Result<RefreshOrderStatusResult>.Success(CreateResult(
             order,
@@ -384,37 +392,66 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
     }
 
-    private async Task DispatchDomainEventsAsync(
-        OrderLifecycle order,
+    private async Task EnqueueDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
         CancellationToken cancellationToken)
     {
-        var events = order.DomainEvents.ToList();
-        order.ClearDomainEvents();
+        if (events.Count == 0)
+        {
+            return;
+        }
 
+        await _eventOutbox.EnqueueAsync(events, cancellationToken);
+    }
+
+    private async Task DispatchCommittedDomainEventsAsync(
+        IReadOnlyCollection<IDomainEvent> events,
+        CancellationToken cancellationToken)
+    {
         if (events.Count == 0)
         {
             return;
         }
 
         await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
+
+        foreach (var domainEvent in events)
+        {
+            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
+        }
     }
 
-    private async Task DispatchDomainEventsAsync(
+    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle order)
+    {
+        return order.DomainEvents.ToList();
+    }
+
+    private static List<IDomainEvent> CollectDomainEvents(
         OrderLifecycle order,
         Position position,
-        Portfolio portfolio,
-        CancellationToken cancellationToken)
+        Portfolio portfolio)
     {
         var events = new List<IDomainEvent>();
         events.AddRange(order.DomainEvents);
         events.AddRange(position.DomainEvents);
         events.AddRange(portfolio.DomainEvents);
 
+        return events;
+    }
+
+    private static void ClearDomainEvents(OrderLifecycle order)
+    {
+        order.ClearDomainEvents();
+    }
+
+    private static void ClearDomainEvents(
+        OrderLifecycle order,
+        Position position,
+        Portfolio portfolio)
+    {
         order.ClearDomainEvents();
         position.ClearDomainEvents();
         portfolio.ClearDomainEvents();
-
-        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
     }
 
     private static RefreshOrderStatusResult CreateResult(

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -316,13 +316,13 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         OrderLifecycleStatus previousStatus,
         CancellationToken cancellationToken)
     {
-        var events = CollectDomainEvents(order);
+        var events = DomainEventOutboxWorkflow.Collect(order);
 
         try
         {
             await BeginTransactionIfSupportedAsync(cancellationToken);
             await _orderRepository.SaveAsync(order, cancellationToken);
-            await EnqueueDomainEventsAsync(events, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, events, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -337,8 +337,12 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
                 Error.ExchangeError($"Failed to persist refreshed order: {ex.Message}"));
         }
 
-        ClearDomainEvents(order);
-        await DispatchCommittedDomainEventsAsync(events, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(order);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            events,
+            cancellationToken);
 
         return Result<RefreshOrderStatusResult>.Success(CreateResult(
             order,
@@ -354,7 +358,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         Portfolio portfolio,
         CancellationToken cancellationToken)
     {
-        var events = CollectDomainEvents(order, position, portfolio);
+        var events = DomainEventOutboxWorkflow.Collect(order, position, portfolio);
 
         try
         {
@@ -362,7 +366,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
             await _orderRepository.SaveAsync(order, cancellationToken);
             await _positionRepository.SaveAsync(position, cancellationToken);
             await _portfolioRepository.SaveAsync(portfolio, cancellationToken);
-            await EnqueueDomainEventsAsync(events, cancellationToken);
+            await DomainEventOutboxWorkflow.EnqueueAsync(_eventOutbox, events, cancellationToken);
 
             var commitResult = await _unitOfWork.CommitAsync(cancellationToken);
             if (commitResult.IsFailure)
@@ -377,8 +381,12 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
                 Error.ExchangeError($"Failed to persist refreshed order effects: {ex.Message}"));
         }
 
-        ClearDomainEvents(order, position, portfolio);
-        await DispatchCommittedDomainEventsAsync(events, cancellationToken);
+        DomainEventOutboxWorkflow.Clear(order, position, portfolio);
+        await DomainEventOutboxWorkflow.DispatchCommittedAsync(
+            _eventDispatcher,
+            _eventOutbox,
+            events,
+            cancellationToken);
 
         return Result<RefreshOrderStatusResult>.Success(CreateResult(
             order,
@@ -390,68 +398,6 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
     private async Task BeginTransactionIfSupportedAsync(CancellationToken cancellationToken)
     {
         await _unitOfWork.BeginTransactionAsync(cancellationToken);
-    }
-
-    private async Task EnqueueDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventOutbox.EnqueueAsync(events, cancellationToken);
-    }
-
-    private async Task DispatchCommittedDomainEventsAsync(
-        IReadOnlyCollection<IDomainEvent> events,
-        CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        await _eventDispatcher.DispatchManyAsync(events, cancellationToken);
-
-        foreach (var domainEvent in events)
-        {
-            await _eventOutbox.MarkProcessedAsync(domainEvent.EventId, cancellationToken);
-        }
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(OrderLifecycle order)
-    {
-        return order.DomainEvents.ToList();
-    }
-
-    private static List<IDomainEvent> CollectDomainEvents(
-        OrderLifecycle order,
-        Position position,
-        Portfolio portfolio)
-    {
-        var events = new List<IDomainEvent>();
-        events.AddRange(order.DomainEvents);
-        events.AddRange(position.DomainEvents);
-        events.AddRange(portfolio.DomainEvents);
-
-        return events;
-    }
-
-    private static void ClearDomainEvents(OrderLifecycle order)
-    {
-        order.ClearDomainEvents();
-    }
-
-    private static void ClearDomainEvents(
-        OrderLifecycle order,
-        Position position,
-        Portfolio portfolio)
-    {
-        order.ClearDomainEvents();
-        position.ClearDomainEvents();
-        portfolio.ClearDomainEvents();
     }
 
     private static RefreshOrderStatusResult CreateResult(

--- a/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/RefreshOrderStatusHandler.cs
@@ -19,6 +19,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
     private readonly IOrderRepository _orderRepository;
     private readonly IExchangePort _exchangePort;
     private readonly IDomainEventDispatcher _eventDispatcher;
+    private readonly IDomainEventOutbox _eventOutbox;
     private readonly ITransactionalUnitOfWork _unitOfWork;
 
     public RefreshOrderStatusHandler(
@@ -27,6 +28,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         IOrderRepository orderRepository,
         IExchangePort exchangePort,
         IDomainEventDispatcher eventDispatcher,
+        IDomainEventOutbox eventOutbox,
         ITransactionalUnitOfWork unitOfWork)
     {
         _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
@@ -34,6 +36,7 @@ public sealed class RefreshOrderStatusHandler : ICommandHandler<RefreshOrderStat
         _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
         _eventDispatcher = eventDispatcher ?? throw new ArgumentNullException(nameof(eventDispatcher));
+        _eventOutbox = eventOutbox ?? throw new ArgumentNullException(nameof(eventOutbox));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
 

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonDomainEventOutbox.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonDomainEventOutbox.cs
@@ -1,0 +1,329 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Infrastructure.Transactions;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// JSON-backed transactional outbox for domain events.
+/// </summary>
+public sealed class JsonDomainEventOutbox : IDomainEventOutbox, IJsonTransactionalResource, IDisposable
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly JsonTransactionCoordinator _transactionCoordinator;
+    private ConcurrentDictionary<Guid, DomainEventOutboxMessageDto> _cache = new();
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonDomainEventOutbox(string filePath, JsonTransactionCoordinator? transactionCoordinator = null)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
+
+        _filePath = filePath;
+        _transactionCoordinator = transactionCoordinator ?? JsonTransactionCoordinator.Shared;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task EnqueueAsync(
+        IEnumerable<IDomainEvent> domainEvents,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvents);
+        var eventList = domainEvents.ToList();
+        if (eventList.Count == 0)
+        {
+            return;
+        }
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+        var cache = GetWriteCache();
+
+        foreach (var domainEvent in eventList)
+        {
+            cache.TryAdd(domainEvent.EventId, ToDto(domainEvent));
+        }
+
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<IReadOnlyList<DomainEventOutboxMessage>> GetUnprocessedAsync(
+        int batchSize = 100,
+        CancellationToken cancellationToken = default)
+    {
+        if (batchSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Batch size must be greater than zero.");
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return GetReadCache().Values
+            .Where(message => message.ProcessedAt is null)
+            .OrderBy(message => message.OccurredAt)
+            .ThenBy(message => message.EnqueuedAt)
+            .Take(batchSize)
+            .Select(ToMessage)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<DomainEventOutboxMessage>> GetAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return GetReadCache().Values
+            .OrderBy(message => message.EnqueuedAt)
+            .Select(ToMessage)
+            .ToList();
+    }
+
+    public async Task MarkProcessedAsync(
+        Guid eventId,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventId == Guid.Empty)
+            throw new ArgumentException("Event ID cannot be empty.", nameof(eventId));
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var readCache = GetReadCache();
+        if (!readCache.TryGetValue(eventId, out var existing) || existing.ProcessedAt is not null)
+        {
+            return;
+        }
+
+        var cache = GetWriteCache();
+        if (cache.TryGetValue(eventId, out var message) && message.ProcessedAt is null)
+        {
+            message.ProcessedAt = DateTimeOffset.UtcNow;
+        }
+
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            await PersistCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            _cache = new ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>();
+            _cacheLoaded = true;
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _cache = new ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>();
+            _cacheLoaded = true;
+            return;
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<DomainEventOutboxMessageDto>>(json, _jsonOptions)
+                   ?? new List<DomainEventOutboxMessageDto>();
+
+        _cache = new ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>(
+            dtos.ToDictionary(dto => dto.EventId));
+        _cacheLoaded = true;
+    }
+
+    private ConcurrentDictionary<Guid, DomainEventOutboxMessageDto> GetReadCache()
+    {
+        if (_transactionCoordinator.TryGetState(this, out ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>? stagedCache))
+        {
+            return stagedCache!;
+        }
+
+        return _cache;
+    }
+
+    private ConcurrentDictionary<Guid, DomainEventOutboxMessageDto> GetWriteCache()
+    {
+        if (!_transactionCoordinator.HasActiveTransaction)
+        {
+            return _cache;
+        }
+
+        return _transactionCoordinator.GetOrCreateState(this, CloneCache);
+    }
+
+    private ConcurrentDictionary<Guid, DomainEventOutboxMessageDto> CloneCache()
+    {
+        var json = JsonSerializer.Serialize(_cache.Values.ToList(), _jsonOptions);
+        var dtos = JsonSerializer.Deserialize<List<DomainEventOutboxMessageDto>>(json, _jsonOptions)
+                   ?? new List<DomainEventOutboxMessageDto>();
+
+        return new ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>(
+            dtos.ToDictionary(dto => dto.EventId));
+    }
+
+    private async Task PersistCacheAsync(
+        ConcurrentDictionary<Guid, DomainEventOutboxMessageDto> cache,
+        CancellationToken cancellationToken)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var dtos = cache.Values
+                .OrderBy(message => message.EnqueuedAt)
+                .ToList();
+
+            var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+            await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task<JsonPreparedWrite?> IJsonTransactionalResource.PrepareCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>? stagedCache))
+        {
+            return Task.FromResult<JsonPreparedWrite?>(null);
+        }
+
+        var dtos = stagedCache!.Values
+            .OrderBy(message => message.EnqueuedAt)
+            .ToList();
+
+        var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+        return Task.FromResult<JsonPreparedWrite?>(new JsonPreparedWrite(_filePath, json));
+    }
+
+    async Task IJsonTransactionalResource.AcceptCommitAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>? stagedCache))
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cache = stagedCache!;
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    Task IJsonTransactionalResource.RollbackAsync(
+        JsonTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        if (!transaction.TryGetState(this, out ConcurrentDictionary<Guid, DomainEventOutboxMessageDto>? _))
+        {
+            return Task.CompletedTask;
+        }
+
+        return ReloadAsync(cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+
+    private DomainEventOutboxMessageDto ToDto(IDomainEvent domainEvent)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        var eventType = domainEvent.GetType();
+        return new DomainEventOutboxMessageDto
+        {
+            EventId = domainEvent.EventId,
+            EventType = eventType.AssemblyQualifiedName ?? eventType.FullName ?? eventType.Name,
+            Payload = JsonSerializer.Serialize(domainEvent, eventType, _jsonOptions),
+            OccurredAt = domainEvent.OccurredAt,
+            EnqueuedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static DomainEventOutboxMessage ToMessage(DomainEventOutboxMessageDto dto)
+    {
+        return new DomainEventOutboxMessage(
+            dto.EventId,
+            dto.EventType,
+            dto.Payload,
+            dto.OccurredAt,
+            dto.EnqueuedAt,
+            dto.ProcessedAt);
+    }
+
+    private sealed class DomainEventOutboxMessageDto
+    {
+        public Guid EventId { get; set; }
+        public string EventType { get; set; } = string.Empty;
+        public string Payload { get; set; } = string.Empty;
+        public DateTimeOffset OccurredAt { get; set; }
+        public DateTimeOffset EnqueuedAt { get; set; }
+        public DateTimeOffset? ProcessedAt { get; set; }
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -126,6 +126,12 @@ public class AppModule : Module
             .AsSelf()
             .SingleInstance();
 
+        builder.Register(_ =>
+            new JsonDomainEventOutbox(CreateDataFilePath("outbox.json"), _.Resolve<JsonTransactionCoordinator>()))
+            .As<IDomainEventOutbox>()
+            .AsSelf()
+            .SingleInstance();
+
         builder.Register(c => new JsonTransactionalUnitOfWork(c.Resolve<JsonTransactionCoordinator>()))
             .As<IUnitOfWork>()
             .As<ITransactionalUnitOfWork>()

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ClosePositionHandlerTests.cs
@@ -21,6 +21,7 @@ public class ClosePositionHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
@@ -33,6 +34,7 @@ public class ClosePositionHandlerTests
         _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
+        _eventOutboxMock = new Mock<IDomainEventOutbox>();
         _notificationPortMock = new Mock<INotificationPort>();
         _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
@@ -43,6 +45,7 @@ public class ClosePositionHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
@@ -65,6 +68,14 @@ public class ClosePositionHandlerTests
 
         _unitOfWorkMock
             .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.EnqueueAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 
@@ -309,6 +320,16 @@ public class ClosePositionHandlerTests
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
             Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.EnqueueAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events => events.OfType<OrderFilledDomainEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     [Fact]
@@ -836,6 +857,7 @@ public class ClosePositionByPairHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock;
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ClosePositionHandler _closePositionHandler;
@@ -847,6 +869,7 @@ public class ClosePositionByPairHandlerTests
         _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
+        _eventOutboxMock = new Mock<IDomainEventOutbox>();
         _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
@@ -856,6 +879,7 @@ public class ClosePositionByPairHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object);
     }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExecuteDCAHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExecuteDCAHandlerTests.cs
@@ -21,6 +21,7 @@ public class ExecuteDCAHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
@@ -33,6 +34,7 @@ public class ExecuteDCAHandlerTests
         _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
+        _eventOutboxMock = new Mock<IDomainEventOutbox>();
         _notificationPortMock = new Mock<INotificationPort>();
         _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
@@ -43,6 +45,7 @@ public class ExecuteDCAHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
@@ -65,6 +68,14 @@ public class ExecuteDCAHandlerTests
 
         _unitOfWorkMock
             .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.EnqueueAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 
@@ -366,6 +377,16 @@ public class ExecuteDCAHandlerTests
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
             Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.EnqueueAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events => events.OfType<OrderFilledDomainEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     [Fact]
@@ -860,6 +881,7 @@ public class ExecuteDCAHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object);
 
@@ -948,6 +970,7 @@ public class ExecuteDCAByPairHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock;
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
     private readonly ExecuteDCAHandler _executeDCAHandler;
@@ -959,6 +982,7 @@ public class ExecuteDCAByPairHandlerTests
         _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
+        _eventOutboxMock = new Mock<IDomainEventOutbox>();
         _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
 
@@ -968,6 +992,7 @@ public class ExecuteDCAByPairHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object);
     }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OpenPositionHandlerTests.cs
@@ -24,6 +24,7 @@ public class OpenPositionHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
     private readonly Mock<IExchangePort> _exchangePortMock;
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock;
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock;
     private readonly Mock<INotificationPort> _notificationPortMock;
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock;
     private readonly TradingConstraintValidator _constraintValidator;
@@ -36,6 +37,7 @@ public class OpenPositionHandlerTests
         _orderRepositoryMock = new Mock<IOrderRepository>();
         _exchangePortMock = new Mock<IExchangePort>();
         _eventDispatcherMock = new Mock<IDomainEventDispatcher>();
+        _eventOutboxMock = new Mock<IDomainEventOutbox>();
         _notificationPortMock = new Mock<INotificationPort>();
         _unitOfWorkMock = new Mock<ITransactionalUnitOfWork>();
         _constraintValidator = new TradingConstraintValidator();
@@ -46,6 +48,7 @@ public class OpenPositionHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _constraintValidator,
             _unitOfWorkMock.Object,
             _notificationPortMock.Object);
@@ -68,6 +71,14 @@ public class OpenPositionHandlerTests
 
         _unitOfWorkMock
             .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.EnqueueAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 
@@ -380,6 +391,16 @@ public class OpenPositionHandlerTests
         _eventDispatcherMock.Verify(
             x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
             Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.EnqueueAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events => events.OfType<OrderFilledEvent>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     [Fact]

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -187,6 +187,121 @@ public sealed class RefreshOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenCommittedOutboxDispatchFails_ReturnsSuccessWithoutMarkingEventsProcessed()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-open-outbox-dispatch-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        _eventDispatcherMock
+            .Setup(x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("audit sink unavailable"));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _unitOfWorkMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _eventOutboxMock.Verify(
+            x => x.EnqueueAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<PositionOpened>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _eventOutboxMock.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCommittedOutboxMarkProcessedFails_ReturnsSuccess()
+    {
+        // Arrange
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-open-outbox-mark-failure-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("outbox file locked"));
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AppliedDomainEffects.Should().BeTrue();
+
+        _unitOfWorkMock.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _eventDispatcherMock.Verify(
+            x => x.DispatchManyAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<PositionOpened>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenSubmittedOpenOrderBecomesFilled_OpensPositionAndUpdatesPortfolio()
     {
         // Arrange

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/RefreshOrderStatusHandlerTests.cs
@@ -26,6 +26,7 @@ public sealed class RefreshOrderStatusHandlerTests
     private readonly Mock<IOrderRepository> _orderRepositoryMock = new();
     private readonly Mock<IExchangePort> _exchangePortMock = new();
     private readonly Mock<IDomainEventDispatcher> _eventDispatcherMock = new();
+    private readonly Mock<IDomainEventOutbox> _eventOutboxMock = new();
     private readonly Mock<ITransactionalUnitOfWork> _unitOfWorkMock = new();
     private readonly RefreshOrderStatusHandler _handler;
 
@@ -37,6 +38,7 @@ public sealed class RefreshOrderStatusHandlerTests
             _orderRepositoryMock.Object,
             _exchangePortMock.Object,
             _eventDispatcherMock.Object,
+            _eventOutboxMock.Object,
             _unitOfWorkMock.Object);
 
         _orderRepositoryMock
@@ -55,6 +57,14 @@ public sealed class RefreshOrderStatusHandlerTests
             .Setup(x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _eventOutboxMock
+            .Setup(x => x.EnqueueAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         _unitOfWorkMock
             .SetupGet(x => x.HasActiveTransaction)
             .Returns(false);
@@ -70,6 +80,110 @@ public sealed class RefreshOrderStatusHandlerTests
         _unitOfWorkMock
             .Setup(x => x.RollbackAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSubmittedOpenOrderBecomesFilled_EnqueuesDomainEventsBeforeCommitAndMarksThemProcessedAfterDispatch()
+    {
+        // Arrange
+        var steps = new List<string>();
+        var enqueuedEvents = new List<IDomainEvent>();
+        var portfolio = CreateTestPortfolio();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var submittedOrder = CreateSubmittedOrder(
+            orderId: "refresh-open-outbox-1",
+            pair: pair,
+            side: DomainOrderSide.Buy,
+            intent: OrderIntent.OpenPosition,
+            signalRule: "MomentumBreakout");
+
+        _orderRepositoryMock
+            .Setup(x => x.GetByIdAsync(submittedOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(submittedOrder);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+
+        _exchangePortMock
+            .Setup(x => x.GetOrderAsync(pair, submittedOrder.Id.Value, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ExchangeOrderInfo>.Success(CreateExchangeOrderInfo(
+                orderId: submittedOrder.Id.Value,
+                pair: pair,
+                side: ExchangeOrderSide.Buy,
+                status: ExchangeOrderStatus.Filled,
+                price: 50000m,
+                quantity: 0.02m,
+                fees: 1m)));
+
+        _orderRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<OrderLifecycle>(), It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("save-order"))
+            .Returns(Task.CompletedTask);
+
+        _positionRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Position>(), It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("save-position"))
+            .Returns(Task.CompletedTask);
+
+        _portfolioRepositoryMock
+            .Setup(x => x.SaveAsync(It.IsAny<Portfolio>(), It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("save-portfolio"))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.EnqueueAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IDomainEvent>, CancellationToken>((events, _) =>
+            {
+                enqueuedEvents = events.ToList();
+                steps.Add("enqueue-outbox");
+            })
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("commit"))
+            .ReturnsAsync(Result.Success());
+
+        _eventDispatcherMock
+            .Setup(x => x.DispatchManyAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("dispatch"))
+            .Returns(Task.CompletedTask);
+
+        _eventOutboxMock
+            .Setup(x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => steps.Add("mark-processed"))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _handler.HandleAsync(new RefreshOrderStatusCommand
+        {
+            OrderId = submittedOrder.Id
+        });
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        enqueuedEvents.Should().Contain(e => e is OrderFilledEvent);
+        enqueuedEvents.Should().Contain(e => e is PositionOpened);
+
+        steps.IndexOf("enqueue-outbox").Should().BeGreaterThan(steps.IndexOf("save-portfolio"));
+        steps.IndexOf("enqueue-outbox").Should().BeLessThan(steps.IndexOf("commit"));
+        steps.IndexOf("dispatch").Should().BeGreaterThan(steps.IndexOf("commit"));
+        steps.Last().Should().Be("mark-processed");
+
+        _eventOutboxMock.Verify(
+            x => x.EnqueueAsync(
+                It.Is<IEnumerable<IDomainEvent>>(events =>
+                    events.OfType<OrderFilledEvent>().Any() &&
+                    events.OfType<PositionOpened>().Any()),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventOutboxMock.Verify(
+            x => x.MarkProcessedAsync(
+                It.Is<Guid>(eventId => enqueuedEvents.Select(e => e.EventId).Contains(eventId)),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(enqueuedEvents.Count));
     }
 
     [Fact]

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/JsonTransactionalUnitOfWorkIntegrationTests.cs
@@ -187,4 +187,155 @@ public sealed class JsonTransactionalUnitOfWorkIntegrationTests
         persistedPortfolio.Should().NotBeNull();
         persistedPortfolio!.HasPositionFor(pair).Should().BeFalse();
     }
+
+    [Fact]
+    public async Task CommitAsync_WhenOutboxIsEnqueuedWithOrderState_PersistsEventsAtomically()
+    {
+        // Given
+        var ordersPath = Path.Combine(Path.GetTempPath(), $"json_uow_orders_{Guid.NewGuid():N}.json");
+        var outboxPath = Path.Combine(Path.GetTempPath(), $"json_uow_outbox_{Guid.NewGuid():N}.json");
+        var transactionCoordinator = new JsonTransactionCoordinator();
+
+        using var orderRepository = new JsonOrderRepository(ordersPath, transactionCoordinator);
+        using var eventOutbox = new JsonDomainEventOutbox(outboxPath, transactionCoordinator);
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        var order = CreateFilledOrder("json-uow-outbox-order-1");
+        var events = order.DomainEvents.ToList();
+
+        try
+        {
+            // When
+            await unitOfWork.BeginTransactionAsync();
+            await orderRepository.SaveAsync(order);
+            await eventOutbox.EnqueueAsync(events);
+            var commitResult = await unitOfWork.CommitAsync();
+
+            // Then
+            commitResult.IsSuccess.Should().BeTrue();
+
+            using var reloadedOrders = new JsonOrderRepository(ordersPath);
+            using var reloadedOutbox = new JsonDomainEventOutbox(outboxPath);
+            var persistedOrder = await reloadedOrders.GetByIdAsync(order.Id);
+            var pendingEvents = await reloadedOutbox.GetUnprocessedAsync();
+
+            persistedOrder.Should().NotBeNull();
+            pendingEvents.Should().ContainSingle();
+            pendingEvents.Single().EventId.Should().Be(events.Single().EventId);
+            pendingEvents.Single().EventType.Should().Contain(nameof(OrderFilledEvent));
+            pendingEvents.Single().Payload.Should().Contain(order.Id.Value);
+        }
+        finally
+        {
+            DeleteFileIfExists(ordersPath);
+            DeleteFileIfExists(outboxPath);
+        }
+    }
+
+    [Fact]
+    public async Task CommitAsync_WhenOutboxIsEnqueuedAndAnotherResourceFails_DoesNotPersistOutboxEvents()
+    {
+        // Given
+        var outboxPath = Path.Combine(Path.GetTempPath(), $"json_uow_outbox_{Guid.NewGuid():N}.json");
+        var invalidPositionsPath = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"json_uow_invalid_positions_{Guid.NewGuid():N}")).FullName;
+        var transactionCoordinator = new JsonTransactionCoordinator();
+
+        using var eventOutbox = new JsonDomainEventOutbox(outboxPath, transactionCoordinator);
+        using var positionRepository = new JsonPositionRepository(invalidPositionsPath, transactionCoordinator);
+        var unitOfWork = new JsonTransactionalUnitOfWork(transactionCoordinator);
+        var order = CreateFilledOrder("json-uow-outbox-rollback-1");
+        var position = Position.Open(
+            order.Pair,
+            order.Id,
+            order.AveragePrice,
+            order.FilledQuantity,
+            order.Fees,
+            "OutboxRollback");
+
+        try
+        {
+            // When
+            await unitOfWork.BeginTransactionAsync();
+            await eventOutbox.EnqueueAsync(order.DomainEvents);
+            await positionRepository.SaveAsync(position);
+            var commitResult = await unitOfWork.CommitAsync();
+
+            // Then
+            commitResult.IsFailure.Should().BeTrue();
+
+            using var reloadedOutbox = new JsonDomainEventOutbox(outboxPath);
+            var pendingEvents = await reloadedOutbox.GetUnprocessedAsync();
+            pendingEvents.Should().BeEmpty();
+        }
+        finally
+        {
+            DeleteFileIfExists(outboxPath);
+            if (Directory.Exists(invalidPositionsPath))
+            {
+                Directory.Delete(invalidPositionsPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_WhenCalledTwice_KeepsEventProcessedOnlyOnce()
+    {
+        // Given
+        var outboxPath = Path.Combine(Path.GetTempPath(), $"json_uow_outbox_{Guid.NewGuid():N}.json");
+        using var eventOutbox = new JsonDomainEventOutbox(outboxPath);
+        var order = CreateFilledOrder("json-uow-outbox-processed-once-1");
+        var domainEvent = order.DomainEvents.Single();
+
+        try
+        {
+            // When
+            await eventOutbox.EnqueueAsync(order.DomainEvents);
+            await eventOutbox.MarkProcessedAsync(domainEvent.EventId);
+            var firstProcessedAt = (await eventOutbox.GetAllAsync()).Single().ProcessedAt;
+
+            await Task.Delay(10);
+            await eventOutbox.MarkProcessedAsync(domainEvent.EventId);
+            var secondProcessedAt = (await eventOutbox.GetAllAsync()).Single().ProcessedAt;
+
+            // Then
+            firstProcessedAt.Should().NotBeNull();
+            secondProcessedAt.Should().Be(firstProcessedAt);
+            (await eventOutbox.GetUnprocessedAsync()).Should().BeEmpty();
+        }
+        finally
+        {
+            DeleteFileIfExists(outboxPath);
+        }
+    }
+
+    private static OrderLifecycle CreateFilledOrder(string orderId)
+    {
+        var pair = TradingPair.Create("ADAUSDT", "USDT");
+        var order = OrderLifecycle.Submit(
+            OrderId.From(orderId),
+            pair,
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(10m),
+            Price.Create(1m),
+            signalRule: "Outbox");
+
+        order.ClearDomainEvents();
+        order.MarkFilled(
+            Quantity.Create(10m),
+            Price.Create(1m),
+            Money.Create(10m, "USDT"),
+            Money.Create(0.1m, "USDT"));
+
+        order.DomainEvents.Should().ContainSingle();
+        return order;
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Persists trading domain events in a JSON-backed transactional outbox before order/position/portfolio commits complete.
- Routes open, close, DCA, and refresh fill events through the outbox, then dispatches and marks them processed after successful commit.
- Adds rollback/idempotency coverage for the outbox and keeps the existing post-commit event dispatcher behavior.

## Acceptance Criteria
- Given an order fill is applied by a trading handler, when aggregate state is committed, then the related domain events are enqueued in the outbox before commit.
- Given the JSON unit of work commits order state and outbox state, when another enlisted resource fails, then neither the order-side event nor the failed aggregate state is persisted.
- Given an outbox event has already been marked processed, when it is marked processed again, then its processed timestamp is not changed.

## Changes
- Added `IDomainEventOutbox` and `DomainEventOutboxMessage` as application ports.
- Added `JsonDomainEventOutbox` and Autofac registration using the existing JSON transaction coordinator.
- Updated trading handlers to collect events, enqueue them transactionally, dispatch post-commit, and mark events processed.
- Centralized handler event workflow in `DomainEventOutboxWorkflow`.

## Testing
- Added/updated application handler tests for refresh, open, DCA, and close event outbox behavior.
- Added infrastructure integration tests for outbox commit, rollback, and idempotent processing.
- Verified with `dotnet test IntelliTrader.sln --configuration Release --no-restore --no-build`.
- Verified whitespace with `git diff --check`.

## Checklist
- [x] Tests pass
- [x] Coverage maintained for the changed paths
- [x] Linter/whitespace clean
- [x] Documentation not required; no user-facing behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a durable event persistence system for trading operations to ensure transaction events survive system failures and are properly recovered.
  * Enhanced trading workflow handlers to reliably queue events during transaction processing before finalizing operations.

* **Tests**
  * Added comprehensive integration and unit test coverage for event persistence, failure handling, and event recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->