### PR TITLE
feat(events): add idempotent domain event handlers

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/IDomainEventHandlerInbox.cs
+++ b/IntelliTrader.Application/Ports/Driven/IDomainEventHandlerInbox.cs
@@ -1,0 +1,17 @@
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Tracks processed domain events per handler to make event handling idempotent.
+/// </summary>
+public interface IDomainEventHandlerInbox
+{
+    Task<bool> HasProcessedAsync(
+        Guid eventId,
+        string handlerName,
+        CancellationToken cancellationToken = default);
+
+    Task MarkProcessedAsync(
+        Guid eventId,
+        string handlerName,
+        CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Domain/Events/OrderFilledEvent.cs
+++ b/IntelliTrader.Domain/Events/OrderFilledEvent.cs
@@ -65,10 +65,12 @@ public sealed record OrderFilledEvent : IDomainEvent
         decimal cost,
         decimal fees = 0,
         bool isPartialFill = false,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         OrderId = orderId;
         Pair = pair;

--- a/IntelliTrader.Domain/Events/OrderPlacedEvent.cs
+++ b/IntelliTrader.Domain/Events/OrderPlacedEvent.cs
@@ -65,10 +65,12 @@ public sealed record OrderPlacedEvent : IDomainEvent
         OrderType orderType = OrderType.Limit,
         bool isManual = false,
         string? signalRule = null,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         OrderId = orderId;
         Pair = pair;

--- a/IntelliTrader.Domain/Events/RiskLimitBreachedEvent.cs
+++ b/IntelliTrader.Domain/Events/RiskLimitBreachedEvent.cs
@@ -53,10 +53,12 @@ public sealed record RiskLimitBreachedEvent : IDomainEvent
         string? description = null,
         RiskSeverity severity = RiskSeverity.Warning,
         string? pair = null,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         LimitType = limitType;
         CurrentValue = currentValue;

--- a/IntelliTrader.Domain/Events/SignalReceivedEvent.cs
+++ b/IntelliTrader.Domain/Events/SignalReceivedEvent.cs
@@ -71,10 +71,12 @@ public sealed record SignalReceivedEvent : IDomainEvent
         decimal? priceChange = null,
         long? volume = null,
         double? volatility = null,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         SignalName = signalName;
         Pair = pair;

--- a/IntelliTrader.Domain/Events/StopLossTriggeredEvent.cs
+++ b/IntelliTrader.Domain/Events/StopLossTriggeredEvent.cs
@@ -65,10 +65,12 @@ public sealed record StopLossTriggeredEvent : IDomainEvent
         decimal estimatedLoss = 0,
         StopLossType stopLossType = StopLossType.Fixed,
         int dcaLevel = 0,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         Pair = pair;
         TriggerPrice = triggerPrice;

--- a/IntelliTrader.Domain/Events/TradingResumedEvent.cs
+++ b/IntelliTrader.Domain/Events/TradingResumedEvent.cs
@@ -41,10 +41,12 @@ public sealed record TradingResumedEvent : IDomainEvent
         bool wasForced = false,
         TimeSpan? suspensionDuration = null,
         SuspensionReason? previousSuspensionReason = null,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         ResumedBy = resumedBy;
         WasForced = wasForced;

--- a/IntelliTrader.Domain/Events/TradingSuspendedEvent.cs
+++ b/IntelliTrader.Domain/Events/TradingSuspendedEvent.cs
@@ -53,10 +53,12 @@ public sealed record TradingSuspendedEvent : IDomainEvent
         int openPositions = 0,
         int pendingOrders = 0,
         string? details = null,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
-        OccurredAt = DateTimeOffset.UtcNow;
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
         Reason = reason;
         SuspendedBy = suspendedBy;

--- a/IntelliTrader.Domain/Trading/Events/DCAExecuted.cs
+++ b/IntelliTrader.Domain/Trading/Events/DCAExecuted.cs
@@ -35,9 +35,11 @@ public sealed record DCAExecuted : IDomainEvent
         Price newAveragePrice,
         Quantity newTotalQuantity,
         Money newTotalCost,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PositionId = positionId;
         Pair = pair;
         OrderId = orderId;
@@ -49,7 +51,7 @@ public sealed record DCAExecuted : IDomainEvent
         NewAveragePrice = newAveragePrice;
         NewTotalQuantity = newTotalQuantity;
         NewTotalCost = newTotalCost;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/MaxPositionsReached.cs
+++ b/IntelliTrader.Domain/Trading/Events/MaxPositionsReached.cs
@@ -19,13 +19,15 @@ public sealed record MaxPositionsReached : IDomainEvent
         PortfolioId portfolioId,
         int maxPositions,
         int currentPositions,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PortfolioId = portfolioId;
         MaxPositions = maxPositions;
         CurrentPositions = currentPositions;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/PortfolioBalanceChanged.cs
+++ b/IntelliTrader.Domain/Trading/Events/PortfolioBalanceChanged.cs
@@ -25,16 +25,18 @@ public sealed record PortfolioBalanceChanged : IDomainEvent
         Money previousAvailable,
         Money newAvailable,
         string reason,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PortfolioId = portfolioId;
         PreviousTotal = previousTotal;
         NewTotal = newTotal;
         PreviousAvailable = previousAvailable;
         NewAvailable = newAvailable;
         Reason = reason;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/PositionAddedToPortfolio.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionAddedToPortfolio.cs
@@ -23,15 +23,17 @@ public sealed record PositionAddedToPortfolio : IDomainEvent
         TradingPair pair,
         Money cost,
         int activePositionCount,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PortfolioId = portfolioId;
         PositionId = positionId;
         Pair = pair;
         Cost = cost;
         ActivePositionCount = activePositionCount;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/PositionClosed.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionClosed.cs
@@ -35,9 +35,11 @@ public sealed record PositionClosed : IDomainEvent
         Margin finalMargin,
         int dcaLevel,
         TimeSpan duration,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PositionId = positionId;
         Pair = pair;
         SellOrderId = sellOrderId;
@@ -49,7 +51,7 @@ public sealed record PositionClosed : IDomainEvent
         FinalMargin = finalMargin;
         DCALevel = dcaLevel;
         Duration = duration;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/PositionOpened.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionOpened.cs
@@ -29,9 +29,11 @@ public sealed record PositionOpened : IDomainEvent
         Money cost,
         Money fees,
         string? signalRule,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PositionId = positionId;
         Pair = pair;
         OrderId = orderId;
@@ -40,7 +42,7 @@ public sealed record PositionOpened : IDomainEvent
         Cost = cost;
         Fees = fees;
         SignalRule = signalRule;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
@@ -8,8 +8,8 @@ namespace IntelliTrader.Domain.Trading.Events;
 /// </summary>
 public sealed record PositionPartiallyClosed : IDomainEvent
 {
-    public Guid EventId { get; } = Guid.NewGuid();
-    public DateTimeOffset OccurredAt { get; } = DateTimeOffset.UtcNow;
+    public Guid EventId { get; }
+    public DateTimeOffset OccurredAt { get; }
     public string? CorrelationId { get; }
     public PositionId PositionId { get; }
     public TradingPair Pair { get; }
@@ -31,8 +31,12 @@ public sealed record PositionPartiallyClosed : IDomainEvent
         Money proceeds,
         Money releasedCost,
         Money sellFees,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         PositionId = positionId;
         Pair = pair;
         SellOrderId = sellOrderId;

--- a/IntelliTrader.Domain/Trading/Events/PositionRemovedFromPortfolio.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionRemovedFromPortfolio.cs
@@ -25,16 +25,18 @@ public sealed record PositionRemovedFromPortfolio : IDomainEvent
         Money proceeds,
         Money pnl,
         int activePositionCount,
-        string? correlationId = null)
+        string? correlationId = null,
+        Guid eventId = default,
+        DateTimeOffset occurredAt = default)
     {
-        EventId = Guid.NewGuid();
+        EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         PortfolioId = portfolioId;
         PositionId = positionId;
         Pair = pair;
         Proceeds = proceeds;
         PnL = pnl;
         ActivePositionCount = activePositionCount;
-        OccurredAt = DateTimeOffset.UtcNow;
+        OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
         CorrelationId = correlationId;
     }
 }

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonDomainEventHandlerInbox.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/Json/JsonDomainEventHandlerInbox.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+/// <summary>
+/// JSON-backed inbox that records which domain event handlers processed each event.
+/// </summary>
+public sealed class JsonDomainEventHandlerInbox : IDomainEventHandlerInbox, IAsyncDisposable
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private ConcurrentDictionary<string, DomainEventHandlerInboxEntryDto> _cache = new();
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonDomainEventHandlerInbox(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+
+        _filePath = filePath;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<bool> HasProcessedAsync(
+        Guid eventId,
+        string handlerName,
+        CancellationToken cancellationToken = default)
+    {
+        Validate(eventId, handlerName);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+        return _cache.ContainsKey(CreateKey(eventId, handlerName));
+    }
+
+    public async Task MarkProcessedAsync(
+        Guid eventId,
+        string handlerName,
+        CancellationToken cancellationToken = default)
+    {
+        Validate(eventId, handlerName);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        var key = CreateKey(eventId, handlerName);
+        if (!_cache.TryAdd(
+                key,
+                new DomainEventHandlerInboxEntryDto
+                {
+                    EventId = eventId,
+                    HandlerName = handlerName,
+                    ProcessedAt = DateTimeOffset.UtcNow
+                }))
+        {
+            return;
+        }
+
+        await PersistCacheAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cacheLoaded)
+            {
+                return;
+            }
+
+            if (!File.Exists(_filePath))
+            {
+                _cache = new ConcurrentDictionary<string, DomainEventHandlerInboxEntryDto>();
+                _cacheLoaded = true;
+                return;
+            }
+
+            var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _cache = new ConcurrentDictionary<string, DomainEventHandlerInboxEntryDto>();
+                _cacheLoaded = true;
+                return;
+            }
+
+            var entries = JsonSerializer.Deserialize<List<DomainEventHandlerInboxEntryDto>>(json, _jsonOptions)
+                          ?? new List<DomainEventHandlerInboxEntryDto>();
+
+            _cache = new ConcurrentDictionary<string, DomainEventHandlerInboxEntryDto>(
+                entries.ToDictionary(entry => CreateKey(entry.EventId, entry.HandlerName)));
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task PersistCacheAsync(CancellationToken cancellationToken)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var entries = _cache.Values
+                .OrderBy(entry => entry.ProcessedAt)
+                .ToList();
+            var json = JsonSerializer.Serialize(entries, _jsonOptions);
+            await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private static void Validate(Guid eventId, string handlerName)
+    {
+        if (eventId == Guid.Empty)
+            throw new ArgumentException("Event ID cannot be empty.", nameof(eventId));
+
+        if (string.IsNullOrWhiteSpace(handlerName))
+            throw new ArgumentException("Handler name cannot be null or empty.", nameof(handlerName));
+    }
+
+    private static string CreateKey(Guid eventId, string handlerName)
+    {
+        return $"{eventId:N}:{handlerName}";
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        _fileLock.Dispose();
+        _disposed = true;
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed class DomainEventHandlerInboxEntryDto
+    {
+        public Guid EventId { get; set; }
+        public string HandlerName { get; set; } = string.Empty;
+        public DateTimeOffset ProcessedAt { get; set; }
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -63,7 +63,8 @@ public class AppModule : Module
             {
                 return new InMemoryDomainEventDispatcher(
                     c.Resolve<IServiceProvider>(),
-                    NullLogger<InMemoryDomainEventDispatcher>.Instance);
+                    NullLogger<InMemoryDomainEventDispatcher>.Instance,
+                    c.Resolve<IDomainEventHandlerInbox>());
             })
             .As<IDomainEventDispatcher>()
             .SingleInstance();
@@ -129,6 +130,12 @@ public class AppModule : Module
         builder.Register(_ =>
             new JsonDomainEventOutbox(CreateDataFilePath("outbox.json"), _.Resolve<JsonTransactionCoordinator>()))
             .As<IDomainEventOutbox>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
+            new JsonDomainEventHandlerInbox(CreateDataFilePath("handler-inbox.json")))
+            .As<IDomainEventHandlerInbox>()
             .AsSelf()
             .SingleInstance();
 

--- a/IntelliTrader.Infrastructure/Events/InMemoryDomainEventDispatcher.cs
+++ b/IntelliTrader.Infrastructure/Events/InMemoryDomainEventDispatcher.cs
@@ -13,14 +13,17 @@ public class InMemoryDomainEventDispatcher : IDomainEventDispatcher
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<InMemoryDomainEventDispatcher> _logger;
+    private readonly IDomainEventHandlerInbox? _handlerInbox;
     private readonly ConcurrentDictionary<Type, List<object>> _handlers = new();
 
     public InMemoryDomainEventDispatcher(
         IServiceProvider serviceProvider,
-        ILogger<InMemoryDomainEventDispatcher> logger)
+        ILogger<InMemoryDomainEventDispatcher> logger,
+        IDomainEventHandlerInbox? handlerInbox = null)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _handlerInbox = handlerInbox;
     }
 
     /// <summary>
@@ -164,10 +167,22 @@ public class InMemoryDomainEventDispatcher : IDomainEventDispatcher
         var eventType = domainEvent.GetType();
         var handlerType = typeof(IDomainEventHandler<>).MakeGenericType(eventType);
         var handleMethod = handlerType.GetMethod("HandleAsync");
+        var handlerName = ResolveHandlerName(handler);
 
         if (handleMethod == null)
         {
             _logger.LogWarning("Could not find HandleAsync method on handler {HandlerType}", handler.GetType().Name);
+            return;
+        }
+
+        if (_handlerInbox is not null &&
+            await _handlerInbox.HasProcessedAsync(domainEvent.EventId, handlerName, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogDebug(
+                "Skipping already processed event {EventType} with ID {EventId} for handler {HandlerName}",
+                eventType.Name,
+                domainEvent.EventId,
+                handlerName);
             return;
         }
 
@@ -177,5 +192,17 @@ public class InMemoryDomainEventDispatcher : IDomainEventDispatcher
         {
             await task.ConfigureAwait(false);
         }
+
+        if (_handlerInbox is not null)
+        {
+            await _handlerInbox.MarkProcessedAsync(domainEvent.EventId, handlerName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static string ResolveHandlerName(object handler)
+    {
+        var handlerType = handler.GetType();
+        return handlerType.AssemblyQualifiedName ?? handlerType.FullName ?? handlerType.Name;
     }
 }

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonDomainEventHandlerInboxTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/JsonDomainEventHandlerInboxTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class JsonDomainEventHandlerInboxTests
+{
+    [Fact]
+    public async Task MarkProcessedAsync_WhenReloaded_RemembersEventPerHandler()
+    {
+        var inboxPath = CreateInboxPath();
+        var eventId = Guid.NewGuid();
+
+        try
+        {
+            await using (var inbox = new JsonDomainEventHandlerInbox(inboxPath))
+            {
+                await inbox.MarkProcessedAsync(eventId, "HandlerA");
+            }
+
+            await using var reloadedInbox = new JsonDomainEventHandlerInbox(inboxPath);
+
+            (await reloadedInbox.HasProcessedAsync(eventId, "HandlerA")).Should().BeTrue();
+            (await reloadedInbox.HasProcessedAsync(eventId, "HandlerB")).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteFileIfExists(inboxPath);
+        }
+    }
+
+    private static string CreateInboxPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"domain_event_handler_inbox_{Guid.NewGuid():N}.json");
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Events/DomainEventOutboxProcessorTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Events/DomainEventOutboxProcessorTests.cs
@@ -35,6 +35,7 @@ public sealed class DomainEventOutboxProcessorTests
             result.ProcessedCount.Should().Be(1);
             result.FailedCount.Should().Be(0);
             dispatchedEvents.Should().ContainSingle();
+            dispatchedEvents.Single().EventId.Should().Be(domainEvent.EventId);
             dispatchedEvents.Single().Should().BeOfType<OrderFilledEvent>()
                 .Which.Should().Match<OrderFilledEvent>(evt =>
                     evt.OrderId == "outbox-fill-1" &&

--- a/tests/IntelliTrader.Infrastructure.Tests/Events/InMemoryDomainEventDispatcherIdempotencyTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Events/InMemoryDomainEventDispatcherIdempotencyTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Infrastructure.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Events;
+
+public sealed class InMemoryDomainEventDispatcherIdempotencyTests
+{
+    [Fact]
+    public async Task DispatchAsync_WhenHandlerAlreadyProcessedEvent_SkipsHandler()
+    {
+        var domainEvent = new TestDomainEvent();
+        var handler = new CountingDomainEventHandler();
+        var inboxMock = new Mock<IDomainEventHandlerInbox>();
+        inboxMock
+            .Setup(x => x.HasProcessedAsync(
+                domainEvent.EventId,
+                It.Is<string>(handlerName => handlerName.Contains(nameof(CountingDomainEventHandler))),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var dispatcher = new InMemoryDomainEventDispatcher(
+            Mock.Of<IServiceProvider>(),
+            NullLogger<InMemoryDomainEventDispatcher>.Instance,
+            inboxMock.Object);
+        dispatcher.RegisterHandler(handler);
+
+        await dispatcher.DispatchAsync(domainEvent);
+
+        handler.HandleCount.Should().Be(0);
+        inboxMock.Verify(
+            x => x.MarkProcessedAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed record TestDomainEvent : DomainEvent;
+
+    private sealed class CountingDomainEventHandler : IDomainEventHandler<TestDomainEvent>
+    {
+        public int HandleCount { get; private set; }
+
+        public Task HandleAsync(TestDomainEvent domainEvent, CancellationToken cancellationToken = default)
+        {
+            HandleCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/DomainEventHandlerInboxRegistrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/DomainEventHandlerInboxRegistrationTests.cs
@@ -1,0 +1,60 @@
+using Autofac;
+using FluentAssertions;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Infrastructure.Events;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Integration;
+
+public sealed class DomainEventHandlerInboxRegistrationTests
+{
+    [Fact]
+    public async Task BuildContainer_DispatcherSkipsDuplicateEventForSameHandler()
+    {
+        var inboxPath = Path.Combine(Directory.GetCurrentDirectory(), "data", "handler-inbox.json");
+        var handler = new CountingDomainEventHandler();
+        var domainEvent = new TestDomainEvent();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
+
+        try
+        {
+            DeleteFileIfExists(inboxPath);
+            using var container = builder.Build();
+            var dispatcher = container.Resolve<IDomainEventDispatcher>();
+            var inMemoryDispatcher = dispatcher.Should().BeOfType<InMemoryDomainEventDispatcher>().Subject;
+            inMemoryDispatcher.RegisterHandler(handler);
+
+            await dispatcher.DispatchAsync(domainEvent);
+            await dispatcher.DispatchAsync(domainEvent);
+
+            handler.HandleCount.Should().Be(1);
+        }
+        finally
+        {
+            DeleteFileIfExists(inboxPath);
+        }
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private sealed record TestDomainEvent : DomainEvent;
+
+    private sealed class CountingDomainEventHandler : IDomainEventHandler<TestDomainEvent>
+    {
+        public int HandleCount { get; private set; }
+
+        public Task HandleAsync(TestDomainEvent domainEvent, CancellationToken cancellationToken = default)
+        {
+            HandleCount++;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a durable domain event handler inbox so each handler processes a given event ID at most once.
- Wires the inbox into the infrastructure dispatcher and persists processed event/handler pairs to JSON storage.
- Preserves domain event identity during outbox replay so retries can be deduplicated correctly.

## Acceptance Criteria
- Given the same event is replayed multiple times, when a handler receives it, then side effects apply once per handler.
- Given a new event is handled successfully, when dispatch completes, then the handler execution is recorded as processed.
- Given an event is already processed for one handler but not another, when dispatch runs, then only the already processed handler is skipped.
- Given the handler inbox is reloaded, when a processed event/handler pair is queried, then it is remembered durably.
- Given an outbox event is serialized and replayed, when it is dispatched, then the replayed domain event keeps the original EventId.

## Changes
- Adds `IDomainEventHandlerInbox` and `JsonDomainEventHandlerInbox`.
- Updates `InMemoryDomainEventDispatcher` to skip already processed event/handler pairs and mark successful handler executions.
- Registers the handler inbox and idempotent dispatcher wiring in `AppModule`.
- Updates concrete domain events to accept replayed `EventId`/`OccurredAt` values while still generating fresh values for new events.
- Adds unit/integration coverage for dispatcher idempotency, durable inbox behavior, Autofac wiring, and outbox replay identity.

## Testing
- `dotnet test tests/IntelliTrader.Infrastructure.Tests/IntelliTrader.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~DomainEventOutboxProcessorTests|FullyQualifiedName~InMemoryDomainEventDispatcherIdempotencyTests|FullyQualifiedName~JsonDomainEventHandlerInboxTests|FullyQualifiedName~DomainEventHandlerInboxRegistrationTests"`
- `dotnet test IntelliTrader.sln --no-restore -c Release`
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Coverage maintained by new targeted tests
- [x] Linter/whitespace clean via `git diff --check`
- [x] Documentation not required; behavior is internal infrastructure
