### PR TITLE
fix(orders): record late fills on canceled orders

### DIFF
--- a/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
+++ b/IntelliTrader.Application/Trading/Handlers/ExchangeOrderLifecycleFactory.cs
@@ -94,6 +94,19 @@ internal static class ExchangeOrderLifecycleFactory
                 return true;
             }
 
+            if (targetStatus == OrderLifecycleStatus.Canceled &&
+                HasFillChanged(lifecycle, orderInfo) &&
+                !orderInfo.FilledQuantity.IsZero)
+            {
+                ApplyCanceledFillIfPresent(
+                    lifecycle,
+                    orderInfo.FilledQuantity,
+                    orderInfo.AveragePrice,
+                    CalculateCost(orderInfo),
+                    orderInfo.Fees);
+                return true;
+            }
+
             return false;
         }
 
@@ -195,7 +208,15 @@ internal static class ExchangeOrderLifecycleFactory
             return;
         }
 
-        lifecycle.MarkPartiallyFilled(filledQuantity, averagePrice, cost, fees);
+        if (lifecycle.Status == OrderLifecycleStatus.Canceled)
+        {
+            lifecycle.RecordCanceledFill(filledQuantity, averagePrice, cost, fees);
+        }
+        else
+        {
+            lifecycle.MarkPartiallyFilled(filledQuantity, averagePrice, cost, fees);
+        }
+
     }
 
     private static bool HasFillChanged(OrderLifecycle lifecycle, ExchangeOrderInfo orderInfo)

--- a/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
+++ b/IntelliTrader.Domain/Trading/Orders/OrderLifecycle.cs
@@ -132,6 +132,44 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
         TransitionTo(OrderLifecycleStatus.Canceled);
     }
 
+    public void RecordCanceledFill(
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees)
+    {
+        if (Status != OrderLifecycleStatus.Canceled)
+        {
+            throw new InvalidOperationException(
+                $"Cannot record canceled fill for order {Id.Value} because status is {Status}.");
+        }
+
+        ValidateFillSnapshot(filledQuantity, averagePrice, cost, fees);
+
+        if (filledQuantity < FilledQuantity)
+        {
+            throw new InvalidOperationException("Cumulative filled quantity cannot be lower than the current filled quantity.");
+        }
+
+        if (filledQuantity == FilledQuantity && averagePrice == AveragePrice && cost == Cost && fees == Fees)
+            return;
+
+        FilledQuantity = filledQuantity;
+        AveragePrice = averagePrice;
+        Cost = cost;
+        Fees = fees;
+
+        AddDomainEvent(new OrderFilledEvent(
+            Id.Value,
+            Pair.Symbol,
+            Side,
+            filledQuantity.Value,
+            averagePrice.Value,
+            cost.Amount,
+            fees.Amount,
+            isPartialFill: filledQuantity < RequestedQuantity));
+    }
+
     public void Reject()
     {
         TransitionTo(OrderLifecycleStatus.Rejected);
@@ -180,19 +218,7 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
         Money fees,
         bool isPartialFill)
     {
-        ArgumentNullException.ThrowIfNull(filledQuantity);
-        ArgumentNullException.ThrowIfNull(averagePrice);
-        ArgumentNullException.ThrowIfNull(cost);
-        ArgumentNullException.ThrowIfNull(fees);
-
-        if (filledQuantity.IsZero)
-            throw new ArgumentException("Filled quantity cannot be zero", nameof(filledQuantity));
-
-        if (filledQuantity > RequestedQuantity)
-            throw new ArgumentException("Filled quantity cannot exceed requested quantity.", nameof(filledQuantity));
-
-        if (averagePrice.IsZero)
-            throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
+        ValidateFillSnapshot(filledQuantity, averagePrice, cost, fees);
 
         if (Status == OrderLifecycleStatus.PartiallyFilled &&
             targetStatus is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled &&
@@ -225,6 +251,27 @@ public sealed class OrderLifecycle : AggregateRoot<OrderId>
             cost.Amount,
             fees.Amount,
             isPartialFill));
+    }
+
+    private void ValidateFillSnapshot(
+        Quantity filledQuantity,
+        Price averagePrice,
+        Money cost,
+        Money fees)
+    {
+        ArgumentNullException.ThrowIfNull(filledQuantity);
+        ArgumentNullException.ThrowIfNull(averagePrice);
+        ArgumentNullException.ThrowIfNull(cost);
+        ArgumentNullException.ThrowIfNull(fees);
+
+        if (filledQuantity.IsZero)
+            throw new ArgumentException("Filled quantity cannot be zero", nameof(filledQuantity));
+
+        if (filledQuantity > RequestedQuantity)
+            throw new ArgumentException("Filled quantity cannot exceed requested quantity.", nameof(filledQuantity));
+
+        if (averagePrice.IsZero)
+            throw new ArgumentException("Average price cannot be zero", nameof(averagePrice));
     }
 
     private void TransitionTo(OrderLifecycleStatus nextStatus)

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/ExchangeOrderLifecycleFactoryTests.cs
@@ -223,6 +223,35 @@ public sealed class ExchangeOrderLifecycleFactoryTests
     }
 
     [Fact]
+    public void Refresh_WhenCanceledLifecycleLaterReportsExecutedQuantity_CapturesFillWithoutReopeningOrder()
+    {
+        // Arrange
+        var lifecycle = CreateSubmittedLifecycle();
+        lifecycle.Cancel();
+        lifecycle.ClearDomainEvents();
+
+        var orderInfo = CreateExchangeOrderInfo(
+            status: ExchangeOrderStatus.Canceled,
+            filledQuantity: 0.01m,
+            averagePrice: 50100m,
+            fees: 0.5m);
+
+        // Act
+        var changed = InvokeRefresh(lifecycle, orderInfo);
+
+        // Assert
+        changed.Should().BeTrue();
+        lifecycle.Status.Should().Be(OrderLifecycleStatus.Canceled);
+        lifecycle.FilledQuantity.Value.Should().Be(0.01m);
+        lifecycle.AveragePrice.Value.Should().Be(50100m);
+        lifecycle.Cost.Amount.Should().Be(501m);
+        lifecycle.Fees.Amount.Should().Be(0.5m);
+        lifecycle.HasUnappliedFill.Should().BeTrue();
+        lifecycle.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+    }
+
+    [Fact]
     public void Refresh_WhenStatusIsUnsupported_ThrowsArgumentOutOfRangeException()
     {
         // Arrange

--- a/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Orders/OrderLifecycleTests.cs
@@ -370,6 +370,36 @@ public class OrderLifecycleTests
     }
 
     [Fact]
+    public void RecordCanceledFill_WhenCanceledOrderReceivesLateExecutedQuantity_PreservesCanceledStatus()
+    {
+        // Arrange
+        var order = OrderLifecycle.Submit(
+            CreateOrderId(),
+            CreatePair(),
+            OrderSide.Buy,
+            OrderType.Market,
+            Quantity.Create(0.05m),
+            CreatePrice());
+        order.Cancel();
+        order.ClearDomainEvents();
+
+        // Act
+        order.RecordCanceledFill(
+            Quantity.Create(0.02m),
+            Price.Create(50000m),
+            CreateMoney(1000m),
+            CreateMoney(1m));
+
+        // Assert
+        order.Status.Should().Be(OrderLifecycleStatus.Canceled);
+        order.IsTerminal.Should().BeTrue();
+        order.FilledQuantity.Value.Should().Be(0.02m);
+        order.HasUnappliedFill.Should().BeTrue();
+        order.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<OrderFilledEvent>();
+    }
+
+    [Fact]
     public void Reject_AfterPartialFill_ThrowsInvalidOperationException()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Handles a real exchange lifecycle edge case where a canceled order later reports executed quantity.
- Adds an explicit domain transition for recording late fills while preserving terminal `Canceled` status.
- Keeps refresh behavior from dropping accounting-relevant fills when Binance updates canceled snapshots asynchronously.

## Acceptance Criteria
- Given an order is already `Canceled` with no fill, when the exchange later reports the same canceled status with executed quantity, then the lifecycle records the fill and remains `Canceled`.
- Given a canceled lifecycle receives a late fill through refresh, when the factory applies the exchange snapshot, then refresh returns changed and emits one `OrderFilledEvent`.

## Changes
- Adds `OrderLifecycle.RecordCanceledFill(...)` with validation shared with normal fill transitions.
- Updates `ExchangeOrderLifecycleFactory.Refresh(...)` to detect changed fill data even when the status is already `Canceled`.
- Adds domain and application tests for the late canceled-fill scenario.

## Testing
- `dotnet test tests/IntelliTrader.Domain.Tests/IntelliTrader.Domain.Tests.csproj --no-restore --filter FullyQualifiedName~OrderLifecycleTests`
- `dotnet test tests/IntelliTrader.Application.Tests/IntelliTrader.Application.Tests.csproj --no-restore --filter FullyQualifiedName~ExchangeOrderLifecycleFactoryTests`
- `dotnet test IntelliTrader.sln --no-restore -c Release`
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Coverage maintained by new targeted tests
- [x] Linter/whitespace clean via `git diff --check`
- [x] Documentation not required; behavior is internal domain/application flow
