### PR TITLE
feat(cqrs): route order queries through read model

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/IOrderReadModel.cs
+++ b/IntelliTrader.Application/Ports/Driven/IOrderReadModel.cs
@@ -1,0 +1,37 @@
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Read-side port for order query models.
+/// </summary>
+public interface IOrderReadModel
+{
+    Task<OrderView?> GetByIdAsync(
+        OrderId id,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OrderView>> GetRecentAsync(
+        TradingPair? pair,
+        OrderLifecycleStatus? status,
+        DomainOrderSide? side,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<OrderView>> GetActiveAsync(
+        TradingPair? pair,
+        DomainOrderSide? side,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<TradeHistoryEntry>> GetTradingHistoryAsync(
+        TradingPair? pair,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        int offset,
+        int limit,
+        CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/OrderQueryHandlers.cs
@@ -1,7 +1,6 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Domain.Trading.Orders;
 
 namespace IntelliTrader.Application.Trading.Handlers;
 
@@ -10,11 +9,11 @@ namespace IntelliTrader.Application.Trading.Handlers;
 /// </summary>
 public sealed class GetOrderHandler : IQueryHandler<GetOrderQuery, OrderView>
 {
-    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderReadModel _orderReadModel;
 
-    public GetOrderHandler(IOrderRepository orderRepository)
+    public GetOrderHandler(IOrderReadModel orderReadModel)
     {
-        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _orderReadModel = orderReadModel ?? throw new ArgumentNullException(nameof(orderReadModel));
     }
 
     public async Task<Result<OrderView>> HandleAsync(
@@ -23,37 +22,13 @@ public sealed class GetOrderHandler : IQueryHandler<GetOrderQuery, OrderView>
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var order = await _orderRepository.GetByIdAsync(query.OrderId, cancellationToken);
-        if (order is null)
+        var orderView = await _orderReadModel.GetByIdAsync(query.OrderId, cancellationToken);
+        if (orderView is null)
         {
             return Result<OrderView>.Failure(Error.NotFound("Order", query.OrderId.Value));
         }
 
-        return Result<OrderView>.Success(Map(order));
-    }
-
-    internal static OrderView Map(OrderLifecycle order)
-    {
-        ArgumentNullException.ThrowIfNull(order);
-
-        return new OrderView
-        {
-            Id = order.Id,
-            Pair = order.Pair,
-            Side = order.Side,
-            Type = order.Type,
-            Status = order.Status,
-            RequestedQuantity = order.RequestedQuantity,
-            FilledQuantity = order.FilledQuantity,
-            SubmittedPrice = order.SubmittedPrice,
-            AveragePrice = order.AveragePrice,
-            Cost = order.Cost,
-            Fees = order.Fees,
-            SignalRule = order.SignalRule,
-            SubmittedAt = order.SubmittedAt,
-            CanAffectPosition = order.CanAffectPosition,
-            IsTerminal = order.IsTerminal
-        };
+        return Result<OrderView>.Success(orderView);
     }
 }
 
@@ -62,11 +37,11 @@ public sealed class GetOrderHandler : IQueryHandler<GetOrderQuery, OrderView>
 /// </summary>
 public sealed class GetRecentOrdersHandler : IQueryHandler<GetRecentOrdersQuery, IReadOnlyList<OrderView>>
 {
-    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderReadModel _orderReadModel;
 
-    public GetRecentOrdersHandler(IOrderRepository orderRepository)
+    public GetRecentOrdersHandler(IOrderReadModel orderReadModel)
     {
-        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _orderReadModel = orderReadModel ?? throw new ArgumentNullException(nameof(orderReadModel));
     }
 
     public async Task<Result<IReadOnlyList<OrderView>>> HandleAsync(
@@ -76,16 +51,12 @@ public sealed class GetRecentOrdersHandler : IQueryHandler<GetRecentOrdersQuery,
         ArgumentNullException.ThrowIfNull(query);
 
         var limit = query.Limit <= 0 ? 50 : query.Limit;
-        var orders = await _orderRepository.GetAllAsync(cancellationToken);
-
-        var filtered = orders
-            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
-            .Where(order => query.Status is null || order.Status == query.Status)
-            .Where(order => query.Side is null || order.Side == query.Side)
-            .OrderByDescending(order => order.SubmittedAt)
-            .Take(limit)
-            .Select(GetOrderHandler.Map)
-            .ToList();
+        var filtered = await _orderReadModel.GetRecentAsync(
+            query.Pair,
+            query.Status,
+            query.Side,
+            limit,
+            cancellationToken);
 
         return Result<IReadOnlyList<OrderView>>.Success(filtered);
     }
@@ -96,11 +67,11 @@ public sealed class GetRecentOrdersHandler : IQueryHandler<GetRecentOrdersQuery,
 /// </summary>
 public sealed class GetActiveOrdersHandler : IQueryHandler<GetActiveOrdersQuery, IReadOnlyList<OrderView>>
 {
-    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderReadModel _orderReadModel;
 
-    public GetActiveOrdersHandler(IOrderRepository orderRepository)
+    public GetActiveOrdersHandler(IOrderReadModel orderReadModel)
     {
-        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _orderReadModel = orderReadModel ?? throw new ArgumentNullException(nameof(orderReadModel));
     }
 
     public async Task<Result<IReadOnlyList<OrderView>>> HandleAsync(
@@ -110,16 +81,11 @@ public sealed class GetActiveOrdersHandler : IQueryHandler<GetActiveOrdersQuery,
         ArgumentNullException.ThrowIfNull(query);
 
         var limit = query.Limit <= 0 ? 50 : query.Limit;
-        var orders = await _orderRepository.GetAllAsync(cancellationToken);
-
-        var filtered = orders
-            .Where(order => !order.IsTerminal)
-            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
-            .Where(order => query.Side is null || order.Side == query.Side)
-            .OrderByDescending(order => order.SubmittedAt)
-            .Take(limit)
-            .Select(GetOrderHandler.Map)
-            .ToList();
+        var filtered = await _orderReadModel.GetActiveAsync(
+            query.Pair,
+            query.Side,
+            limit,
+            cancellationToken);
 
         return Result<IReadOnlyList<OrderView>>.Success(filtered);
     }
@@ -130,11 +96,11 @@ public sealed class GetActiveOrdersHandler : IQueryHandler<GetActiveOrdersQuery,
 /// </summary>
 public sealed class GetTradingHistoryHandler : IQueryHandler<GetTradingHistoryQuery, IReadOnlyList<TradeHistoryEntry>>
 {
-    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderReadModel _orderReadModel;
 
-    public GetTradingHistoryHandler(IOrderRepository orderRepository)
+    public GetTradingHistoryHandler(IOrderReadModel orderReadModel)
     {
-        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _orderReadModel = orderReadModel ?? throw new ArgumentNullException(nameof(orderReadModel));
     }
 
     public async Task<Result<IReadOnlyList<TradeHistoryEntry>>> HandleAsync(
@@ -151,46 +117,14 @@ public sealed class GetTradingHistoryHandler : IQueryHandler<GetTradingHistoryQu
 
         var limit = query.Limit <= 0 ? 100 : query.Limit;
         var offset = Math.Max(0, query.Offset);
-        var orders = await _orderRepository.GetAllAsync(cancellationToken);
-
-        var history = orders
-            .Where(order => order.Status == OrderLifecycleStatus.Filled)
-            .Where(order => order.RelatedPositionId is not null)
-            .Where(order => order.SubmittedAt >= query.From && order.SubmittedAt <= query.To)
-            .Where(order => query.Pair is null || order.Pair.Equals(query.Pair))
-            .OrderByDescending(order => order.SubmittedAt)
-            .Skip(offset)
-            .Take(limit)
-            .Select(MapTradeHistoryEntry)
-            .ToList();
+        var history = await _orderReadModel.GetTradingHistoryAsync(
+            query.Pair,
+            query.From,
+            query.To,
+            offset,
+            limit,
+            cancellationToken);
 
         return Result<IReadOnlyList<TradeHistoryEntry>>.Success(history);
-    }
-
-    private static TradeHistoryEntry MapTradeHistoryEntry(OrderLifecycle order)
-    {
-        return new TradeHistoryEntry
-        {
-            PositionId = order.RelatedPositionId!,
-            Pair = order.Pair,
-            Type = ResolveTradeType(order),
-            Price = order.AveragePrice,
-            Quantity = order.FilledQuantity,
-            Cost = order.Cost,
-            Fees = order.Fees,
-            Timestamp = order.SubmittedAt,
-            OrderId = order.Id.Value,
-            Note = order.Intent.ToString()
-        };
-    }
-
-    private static TradeType ResolveTradeType(OrderLifecycle order)
-    {
-        if (order.Side == IntelliTrader.Domain.Events.OrderSide.Sell)
-        {
-            return TradeType.Sell;
-        }
-
-        return order.Intent == OrderIntent.ExecuteDca ? TradeType.DCA : TradeType.Buy;
     }
 }

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/RepositoryOrderReadModel.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/RepositoryOrderReadModel.cs
@@ -1,0 +1,142 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+/// <summary>
+/// Initial order read-model adapter backed by the persisted order lifecycle store.
+/// </summary>
+public sealed class RepositoryOrderReadModel : IOrderReadModel
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public RepositoryOrderReadModel(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<OrderView?> GetByIdAsync(
+        OrderId id,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var order = await _orderRepository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        return order is null ? null : MapOrderView(order);
+    }
+
+    public async Task<IReadOnlyList<OrderView>> GetRecentAsync(
+        TradingPair? pair,
+        OrderLifecycleStatus? status,
+        DomainOrderSide? side,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        var safeLimit = limit <= 0 ? 50 : limit;
+        var orders = await _orderRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return orders
+            .Where(order => pair is null || order.Pair.Equals(pair))
+            .Where(order => status is null || order.Status == status)
+            .Where(order => side is null || order.Side == side)
+            .OrderByDescending(order => order.SubmittedAt)
+            .Take(safeLimit)
+            .Select(MapOrderView)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<OrderView>> GetActiveAsync(
+        TradingPair? pair,
+        DomainOrderSide? side,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        var safeLimit = limit <= 0 ? 50 : limit;
+        var orders = await _orderRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return orders
+            .Where(order => !order.IsTerminal)
+            .Where(order => pair is null || order.Pair.Equals(pair))
+            .Where(order => side is null || order.Side == side)
+            .OrderByDescending(order => order.SubmittedAt)
+            .Take(safeLimit)
+            .Select(MapOrderView)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<TradeHistoryEntry>> GetTradingHistoryAsync(
+        TradingPair? pair,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        int offset,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        var safeLimit = limit <= 0 ? 100 : limit;
+        var safeOffset = Math.Max(0, offset);
+        var orders = await _orderRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return orders
+            .Where(order => order.Status == OrderLifecycleStatus.Filled)
+            .Where(order => order.RelatedPositionId is not null)
+            .Where(order => order.SubmittedAt >= from && order.SubmittedAt <= to)
+            .Where(order => pair is null || order.Pair.Equals(pair))
+            .OrderByDescending(order => order.SubmittedAt)
+            .Skip(safeOffset)
+            .Take(safeLimit)
+            .Select(MapTradeHistoryEntry)
+            .ToList();
+    }
+
+    private static OrderView MapOrderView(OrderLifecycle order)
+    {
+        return new OrderView
+        {
+            Id = order.Id,
+            Pair = order.Pair,
+            Side = order.Side,
+            Type = order.Type,
+            Status = order.Status,
+            RequestedQuantity = order.RequestedQuantity,
+            FilledQuantity = order.FilledQuantity,
+            SubmittedPrice = order.SubmittedPrice,
+            AveragePrice = order.AveragePrice,
+            Cost = order.Cost,
+            Fees = order.Fees,
+            SignalRule = order.SignalRule,
+            SubmittedAt = order.SubmittedAt,
+            CanAffectPosition = order.CanAffectPosition,
+            IsTerminal = order.IsTerminal
+        };
+    }
+
+    private static TradeHistoryEntry MapTradeHistoryEntry(OrderLifecycle order)
+    {
+        return new TradeHistoryEntry
+        {
+            PositionId = order.RelatedPositionId!,
+            Pair = order.Pair,
+            Type = ResolveTradeType(order),
+            Price = order.AveragePrice,
+            Quantity = order.FilledQuantity,
+            Cost = order.Cost,
+            Fees = order.Fees,
+            Timestamp = order.SubmittedAt,
+            OrderId = order.Id.Value,
+            Note = order.Intent.ToString()
+        };
+    }
+
+    private static TradeType ResolveTradeType(OrderLifecycle order)
+    {
+        if (order.Side == DomainOrderSide.Sell)
+        {
+            return TradeType.Sell;
+        }
+
+        return order.Intent == OrderIntent.ExecuteDca ? TradeType.DCA : TradeType.Buy;
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -9,6 +9,7 @@ using IntelliTrader.Domain.Trading.Services;
 using IntelliTrader.Infrastructure.Adapters.Exchange;
 using IntelliTrader.Infrastructure.Adapters.Legacy;
 using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
 using IntelliTrader.Infrastructure.BackgroundServices;
 using IntelliTrader.Infrastructure.Dispatching;
 using IntelliTrader.Infrastructure.Events;
@@ -125,6 +126,10 @@ public class AppModule : Module
             new JsonOrderRepository(CreateDataFilePath("orders.json"), _.Resolve<JsonTransactionCoordinator>()))
             .As<IOrderRepository>()
             .AsSelf()
+            .SingleInstance();
+
+        builder.RegisterType<RepositoryOrderReadModel>()
+            .As<IOrderReadModel>()
             .SingleInstance();
 
         builder.Register(_ =>

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderQueryHandlerTests.cs
@@ -3,7 +3,6 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Domain.Events;
 using IntelliTrader.Domain.Trading.Orders;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using Moq;
@@ -14,261 +13,141 @@ namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
 public class OrderQueryHandlerTests
 {
-    private readonly Mock<IOrderRepository> _orderRepositoryMock = new();
+    private readonly Mock<IOrderReadModel> _orderReadModelMock = new();
 
     [Fact]
-    public async Task HandleAsync_WithExistingOrder_ReturnsMappedOrderView()
+    public async Task GetOrderHandler_WithMissingOrder_ReturnsNotFound()
     {
-        // Arrange
-        var order = CreateFilledOrder("order-1");
-        var handler = new GetOrderHandler(_orderRepositoryMock.Object);
+        var orderId = OrderId.From("missing-order");
+        var handler = new GetOrderHandler(_orderReadModelMock.Object);
 
-        _orderRepositoryMock
-            .Setup(x => x.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(order);
+        _orderReadModelMock
+            .Setup(x => x.GetByIdAsync(orderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrderView?)null);
 
-        var query = new GetOrderQuery { OrderId = order.Id };
+        var result = await handler.HandleAsync(new GetOrderQuery { OrderId = orderId });
 
-        // Act
-        var result = await handler.HandleAsync(query);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Id.Should().Be(order.Id);
-        result.Value.Pair.Should().Be(order.Pair);
-        result.Value.Status.Should().Be(OrderLifecycleStatus.Filled);
-        result.Value.CanAffectPosition.Should().BeTrue();
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+        result.Error.Message.Should().Contain(orderId.Value);
     }
 
     [Fact]
-    public async Task HandleAsync_WithFilters_ReturnsRecentMatchingOrdersOnly()
+    public async Task GetActiveOrdersHandler_DelegatesFiltersToReadModel()
     {
-        // Arrange
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var matching = CreateSubmittedOrder("order-2", pair, DateTimeOffset.UtcNow.AddMinutes(-1));
-        var nonMatchingStatus = CreateFilledOrder("order-3", pair, DateTimeOffset.UtcNow.AddMinutes(-2));
-        var nonMatchingPair = CreateSubmittedOrder(
-            "order-4",
-            TradingPair.Create("ETHUSDT", "USDT"),
-            DateTimeOffset.UtcNow);
+        var activeOrder = CreateOrderView("active-order-1", pair, OrderLifecycleStatus.PartiallyFilled);
+        var handler = new GetActiveOrdersHandler(_orderReadModelMock.Object);
 
-        var handler = new GetRecentOrdersHandler(_orderRepositoryMock.Object);
+        _orderReadModelMock
+            .Setup(x => x.GetActiveAsync(
+                pair,
+                DomainOrderSide.Buy,
+                10,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([activeOrder]);
 
-        _orderRepositoryMock
-            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { nonMatchingStatus, matching, nonMatchingPair });
-
-        var query = new GetRecentOrdersQuery
-        {
-            Pair = pair,
-            Status = OrderLifecycleStatus.Submitted,
-            Side = DomainOrderSide.Buy,
-            Limit = 10
-        };
-
-        // Act
-        var result = await handler.HandleAsync(query);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Should().ContainSingle();
-        result.Value[0].Id.Should().Be(matching.Id);
-        result.Value[0].Status.Should().Be(OrderLifecycleStatus.Submitted);
-    }
-
-    [Fact]
-    public async Task HandleAsync_WithActiveOrdersQuery_ReturnsOnlyNonTerminalOrders()
-    {
-        // Arrange
-        var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var newestPartial = CreatePartiallyFilledOrder("order-5", pair, DateTimeOffset.UtcNow);
-        var olderSubmitted = CreateSubmittedOrder("order-6", pair, DateTimeOffset.UtcNow.AddMinutes(-1));
-        var filled = CreateFilledOrder("order-7", pair, DateTimeOffset.UtcNow.AddMinutes(-2));
-        var otherPair = CreateSubmittedOrder(
-            "order-8",
-            TradingPair.Create("ETHUSDT", "USDT"),
-            DateTimeOffset.UtcNow.AddMinutes(-3));
-
-        var handler = new GetActiveOrdersHandler(_orderRepositoryMock.Object);
-
-        _orderRepositoryMock
-            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { olderSubmitted, otherPair, filled, newestPartial });
-
-        var query = new GetActiveOrdersQuery
+        var result = await handler.HandleAsync(new GetActiveOrdersQuery
         {
             Pair = pair,
             Side = DomainOrderSide.Buy,
-            Limit = 10
-        };
-
-        // Act
-        var result = await handler.HandleAsync(query);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Select(order => order.Id).Should().Equal(newestPartial.Id, olderSubmitted.Id);
-        result.Value.Should().OnlyContain(order => !order.IsTerminal);
-    }
-
-    [Fact]
-    public async Task HandleAsync_WithTradingHistoryQuery_ReturnsFilledOrdersMappedAsTrades()
-    {
-        // Arrange
-        var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var positionId = PositionId.Create();
-        var initialBuy = CreateFilledOrder(
-            "order-buy-1",
-            pair,
-            DateTimeOffset.UtcNow.AddMinutes(-30),
-            OrderIntent.OpenPosition,
-            positionId);
-        var dcaBuy = CreateFilledOrder(
-            "order-dca-1",
-            pair,
-            DateTimeOffset.UtcNow.AddMinutes(-20),
-            OrderIntent.ExecuteDca,
-            positionId);
-        var sell = CreateFilledOrder(
-            "order-sell-1",
-            pair,
-            DateTimeOffset.UtcNow.AddMinutes(-10),
-            OrderIntent.ClosePosition,
-            positionId,
-            DomainOrderSide.Sell);
-        var pending = CreateSubmittedOrder(
-            "order-pending-1",
-            pair,
-            DateTimeOffset.UtcNow.AddMinutes(-5));
-
-        var handler = new GetTradingHistoryHandler(_orderRepositoryMock.Object);
-
-        _orderRepositoryMock
-            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { pending, initialBuy, sell, dcaBuy });
-
-        // Act
-        var result = await handler.HandleAsync(new GetTradingHistoryQuery
-        {
-            Pair = pair,
             Limit = 10
         });
 
-        // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Select(entry => entry.OrderId).Should().Equal("order-sell-1", "order-dca-1", "order-buy-1");
-        result.Value.Select(entry => entry.Type).Should().Equal(TradeType.Sell, TradeType.DCA, TradeType.Buy);
-        result.Value.Should().OnlyContain(entry => entry.PositionId == positionId);
-        result.Value.Should().OnlyContain(entry => entry.Pair == pair);
+        result.Value.Should().ContainSingle().Which.Should().Be(activeOrder);
     }
 
     [Fact]
-    public async Task HandleAsync_WithTradingHistoryQuery_SkipsFilledOrdersWithoutPositionLink()
+    public async Task GetTradingHistoryHandler_DelegatesRangeAndPaginationToReadModel()
     {
-        // Arrange
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var unlinkedFilledOrder = CreateFilledOrder(
-            "order-unlinked-1",
-            pair,
-            DateTimeOffset.UtcNow.AddMinutes(-10),
-            OrderIntent.OpenPosition,
-            relatedPositionId: null);
-
-        var handler = new GetTradingHistoryHandler(_orderRepositoryMock.Object);
-
-        _orderRepositoryMock
-            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { unlinkedFilledOrder });
-
-        // Act
-        var result = await handler.HandleAsync(new GetTradingHistoryQuery { Pair = pair });
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Should().BeEmpty();
-    }
-
-    private static OrderLifecycle CreateSubmittedOrder(
-        string orderId,
-        TradingPair? pair = null,
-        DateTimeOffset? submittedAt = null)
-    {
-        var order = OrderLifecycle.Submit(
-            OrderId.From(orderId),
-            pair ?? TradingPair.Create("BTCUSDT", "USDT"),
-            DomainOrderSide.Buy,
-            DomainOrderType.Market,
-            Quantity.Create(0.02m),
-            Price.Create(50000m),
-            "MomentumBreakout",
-            submittedAt ?? DateTimeOffset.UtcNow);
-
-        order.ClearDomainEvents();
-        return order;
-    }
-
-    private static OrderLifecycle CreateFilledOrder(
-        string orderId,
-        TradingPair? pair = null,
-        DateTimeOffset? submittedAt = null)
-    {
-        return CreateFilledOrder(
-            orderId,
-            pair,
-            submittedAt,
-            OrderIntent.OpenPosition,
-            PositionId.Create());
-    }
-
-    private static OrderLifecycle CreateFilledOrder(
-        string orderId,
-        TradingPair? pair,
-        DateTimeOffset? submittedAt,
-        OrderIntent intent,
-        PositionId? relatedPositionId,
-        DomainOrderSide side = DomainOrderSide.Buy)
-    {
-        var tradingPair = pair ?? TradingPair.Create("BTCUSDT", "USDT");
-        var submittedRelatedPositionId = intent == OrderIntent.OpenPosition ? null : relatedPositionId;
-        var order = OrderLifecycle.Submit(
-            OrderId.From(orderId),
-            tradingPair,
-            side,
-            DomainOrderType.Market,
-            Quantity.Create(0.02m),
-            Price.Create(50000m),
-            "MomentumBreakout",
-            submittedAt ?? DateTimeOffset.UtcNow,
-            intent,
-            submittedRelatedPositionId);
-
-        order.ClearDomainEvents();
-        order.MarkFilled(
-            Quantity.Create(0.02m),
-            Price.Create(50000m),
-            Money.Create(1000m, "USDT"),
-            Money.Create(1m, "USDT"));
-        if (intent == OrderIntent.OpenPosition && relatedPositionId is not null)
+        var from = DateTimeOffset.UtcNow.AddDays(-7);
+        var to = DateTimeOffset.UtcNow;
+        var history = new TradeHistoryEntry
         {
-            order.LinkRelatedPosition(relatedPositionId);
-        }
+            PositionId = PositionId.Create(),
+            Pair = pair,
+            Type = TradeType.Buy,
+            Price = Price.Create(50000m),
+            Quantity = Quantity.Create(0.02m),
+            Cost = Money.Create(1000m, "USDT"),
+            Fees = Money.Create(1m, "USDT"),
+            Timestamp = DateTimeOffset.UtcNow,
+            OrderId = "history-order-1",
+            Note = "OpenPosition"
+        };
+        var handler = new GetTradingHistoryHandler(_orderReadModelMock.Object);
 
-        order.ClearDomainEvents();
-        return order;
+        _orderReadModelMock
+            .Setup(x => x.GetTradingHistoryAsync(
+                pair,
+                from,
+                to,
+                5,
+                20,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([history]);
+
+        var result = await handler.HandleAsync(new GetTradingHistoryQuery
+        {
+            Pair = pair,
+            From = from,
+            To = to,
+            Offset = 5,
+            Limit = 20
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle().Which.Should().Be(history);
     }
 
-    private static OrderLifecycle CreatePartiallyFilledOrder(
-        string orderId,
-        TradingPair? pair = null,
-        DateTimeOffset? submittedAt = null)
+    [Fact]
+    public async Task GetTradingHistoryHandler_WhenRangeIsInvalid_ReturnsValidationWithoutReadingModel()
     {
-        var order = CreateSubmittedOrder(orderId, pair, submittedAt);
-        order.MarkPartiallyFilled(
-            Quantity.Create(0.01m),
-            Price.Create(50000m),
-            Money.Create(500m, "USDT"),
-            Money.Create(0.5m, "USDT"));
-        order.ClearDomainEvents();
-        return order;
+        var handler = new GetTradingHistoryHandler(_orderReadModelMock.Object);
+
+        var result = await handler.HandleAsync(new GetTradingHistoryQuery
+        {
+            From = DateTimeOffset.UtcNow,
+            To = DateTimeOffset.UtcNow.AddDays(-1)
+        });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Validation");
+        _orderReadModelMock.Verify(
+            x => x.GetTradingHistoryAsync(
+                It.IsAny<TradingPair?>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static OrderView CreateOrderView(
+        string orderId,
+        TradingPair pair,
+        OrderLifecycleStatus status)
+    {
+        return new OrderView
+        {
+            Id = OrderId.From(orderId),
+            Pair = pair,
+            Side = DomainOrderSide.Buy,
+            Type = DomainOrderType.Market,
+            Status = status,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = Quantity.Create(0.01m),
+            SubmittedPrice = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Cost = Money.Create(500m, "USDT"),
+            Fees = Money.Create(0.5m, "USDT"),
+            SignalRule = "MomentumBreakout",
+            SubmittedAt = DateTimeOffset.UtcNow,
+            CanAffectPosition = true,
+            IsTerminal = false
+        };
     }
 }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderReadModelQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/OrderReadModelQueryHandlerTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class OrderReadModelQueryHandlerTests
+{
+    private readonly Mock<IOrderReadModel> _orderReadModelMock = new();
+
+    [Fact]
+    public async Task GetOrderHandler_WithExistingReadModelOrder_ReturnsOrderView()
+    {
+        var orderView = CreateOrderView("order-read-1");
+        var handler = new GetOrderHandler(_orderReadModelMock.Object);
+
+        _orderReadModelMock
+            .Setup(x => x.GetByIdAsync(orderView.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orderView);
+
+        var result = await handler.HandleAsync(new GetOrderQuery { OrderId = orderView.Id });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(orderView);
+        _orderReadModelMock.Verify(
+            x => x.GetByIdAsync(orderView.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRecentOrdersHandler_DelegatesFiltersToReadModel()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var orderView = CreateOrderView("order-read-2", pair, OrderLifecycleStatus.Submitted);
+        var handler = new GetRecentOrdersHandler(_orderReadModelMock.Object);
+
+        _orderReadModelMock
+            .Setup(x => x.GetRecentAsync(
+                pair,
+                OrderLifecycleStatus.Submitted,
+                DomainOrderSide.Buy,
+                25,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([orderView]);
+
+        var result = await handler.HandleAsync(new GetRecentOrdersQuery
+        {
+            Pair = pair,
+            Status = OrderLifecycleStatus.Submitted,
+            Side = DomainOrderSide.Buy,
+            Limit = 25
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle().Which.Should().Be(orderView);
+        _orderReadModelMock.Verify(
+            x => x.GetRecentAsync(
+                pair,
+                OrderLifecycleStatus.Submitted,
+                DomainOrderSide.Buy,
+                25,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static OrderView CreateOrderView(
+        string orderId,
+        TradingPair? pair = null,
+        OrderLifecycleStatus status = OrderLifecycleStatus.Filled)
+    {
+        var tradingPair = pair ?? TradingPair.Create("BTCUSDT", "USDT");
+        return new OrderView
+        {
+            Id = OrderId.From(orderId),
+            Pair = tradingPair,
+            Side = DomainOrderSide.Buy,
+            Type = DomainOrderType.Market,
+            Status = status,
+            RequestedQuantity = Quantity.Create(0.02m),
+            FilledQuantity = status == OrderLifecycleStatus.Submitted ? Quantity.Zero : Quantity.Create(0.02m),
+            SubmittedPrice = Price.Create(50000m),
+            AveragePrice = status == OrderLifecycleStatus.Submitted ? Price.Zero : Price.Create(50000m),
+            Cost = status == OrderLifecycleStatus.Submitted ? Money.Zero("USDT") : Money.Create(1000m, "USDT"),
+            Fees = status == OrderLifecycleStatus.Submitted ? Money.Zero("USDT") : Money.Create(1m, "USDT"),
+            SignalRule = "MomentumBreakout",
+            SubmittedAt = DateTimeOffset.UtcNow,
+            CanAffectPosition = status is OrderLifecycleStatus.PartiallyFilled or OrderLifecycleStatus.Filled,
+            IsTerminal = status is OrderLifecycleStatus.Filled or OrderLifecycleStatus.Canceled or OrderLifecycleStatus.Rejected
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an `IOrderReadModel` application port for order query flows.
- Routes order query handlers through the read-side port instead of the command-side repository.
- Provides an initial repository-backed read-model adapter to preserve current persistence behavior while making the read side replaceable.

## Acceptance Criteria
- Given an order query, when it is handled, then it reads from `IOrderReadModel`, not `IOrderRepository`.
- Given recent, active, or history query filters, when handled, then filtering is delegated to the read-model port.
- Given runtime DI resolves order queries, when integration tests execute, then existing persisted-order query flows still work.

## Changes
- Added `IOrderReadModel` under application driven ports.
- Updated order query handlers to validate query shape and delegate reads to the read model.
- Added a repository-backed infrastructure read model for compatibility with existing JSON persistence.
- Updated application tests to lock query-handler dependency direction.

## Testing
- Added/updated order query handler tests for read-model delegation.
- `dotnet test tests/IntelliTrader.Application.Tests/IntelliTrader.Application.Tests.csproj --no-restore --filter "FullyQualifiedName~OrderReadModelQueryHandlerTests|FullyQualifiedName~OrderQueryHandlerTests"`
- `dotnet test tests/IntelliTrader.Infrastructure.Tests/IntelliTrader.Infrastructure.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenPositionCommandDispatchIntegrationTests|FullyQualifiedName~OrderLifecycleCommandDispatchIntegrationTests|FullyQualifiedName~RefreshOrderStatusCommandDispatchIntegrationTests|FullyQualifiedName~RefreshSubmittedOrdersCommandDispatchIntegrationTests"`
- `dotnet test IntelliTrader.sln --no-restore -c Release`
- `git diff --check main...HEAD`

## Checklist
- [x] Tests pass
- [x] Coverage maintained
- [x] Linter clean
- [x] Documentation updated or not required
