### PR TITLE
feat(cqrs): add projected position read model

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/IPositionReadModel.cs
+++ b/IntelliTrader.Application/Ports/Driven/IPositionReadModel.cs
@@ -1,0 +1,45 @@
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Read-side port for position query models.
+/// </summary>
+public interface IPositionReadModel
+{
+    Task<PositionReadModelEntry?> GetByIdAsync(
+        PositionId id,
+        CancellationToken cancellationToken = default);
+
+    Task<PositionReadModelEntry?> GetByPairAsync(
+        TradingPair pair,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<PositionReadModelEntry>> GetActiveAsync(
+        string? market,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<PositionReadModelEntry>> GetClosedAsync(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        TradingPair? pair,
+        int limit,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record PositionReadModelEntry
+{
+    public PositionId Id { get; init; } = null!;
+    public TradingPair Pair { get; init; } = null!;
+    public Price AveragePrice { get; init; } = Price.Zero;
+    public Quantity TotalQuantity { get; init; } = Quantity.Zero;
+    public Money TotalCost { get; init; } = null!;
+    public Money TotalFees { get; init; } = null!;
+    public int DCALevel { get; init; }
+    public int EntryCount { get; init; }
+    public DateTimeOffset OpenedAt { get; init; }
+    public string? SignalRule { get; init; }
+    public bool IsClosed { get; init; }
+    public DateTimeOffset? ClosedAt { get; init; }
+    public Money? RealizedPnL { get; init; }
+}

--- a/IntelliTrader.Application/Trading/Handlers/PositionQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/PositionQueryHandlers.cs
@@ -1,7 +1,6 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.ValueObjects;
 
 namespace IntelliTrader.Application.Trading.Handlers;
@@ -11,12 +10,12 @@ namespace IntelliTrader.Application.Trading.Handlers;
 /// </summary>
 public sealed class GetPositionHandler : IQueryHandler<GetPositionQuery, PositionView>
 {
-    private readonly IPositionRepository _positionRepository;
+    private readonly IPositionReadModel _positionReadModel;
     private readonly IExchangePort _exchangePort;
 
-    public GetPositionHandler(IPositionRepository positionRepository, IExchangePort exchangePort)
+    public GetPositionHandler(IPositionReadModel positionReadModel, IExchangePort exchangePort)
     {
-        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _positionReadModel = positionReadModel ?? throw new ArgumentNullException(nameof(positionReadModel));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
     }
 
@@ -33,8 +32,8 @@ public sealed class GetPositionHandler : IQueryHandler<GetPositionQuery, Positio
         }
 
         var position = query.PositionId is not null
-            ? await _positionRepository.GetByIdAsync(query.PositionId, cancellationToken)
-            : await _positionRepository.GetByPairAsync(query.Pair!, cancellationToken);
+            ? await _positionReadModel.GetByIdAsync(query.PositionId, cancellationToken)
+            : await _positionReadModel.GetByPairAsync(query.Pair!, cancellationToken);
 
         if (position is null)
         {
@@ -52,7 +51,7 @@ public sealed class GetPositionHandler : IQueryHandler<GetPositionQuery, Positio
     }
 
     private async Task<Result<Price>> ResolveCurrentPriceAsync(
-        Position position,
+        PositionReadModelEntry position,
         CancellationToken cancellationToken)
     {
         if (position.IsClosed)
@@ -69,12 +68,12 @@ public sealed class GetPositionHandler : IQueryHandler<GetPositionQuery, Positio
 /// </summary>
 public sealed class GetActivePositionsHandler : IQueryHandler<GetActivePositionsQuery, IReadOnlyList<PositionView>>
 {
-    private readonly IPositionRepository _positionRepository;
+    private readonly IPositionReadModel _positionReadModel;
     private readonly IExchangePort _exchangePort;
 
-    public GetActivePositionsHandler(IPositionRepository positionRepository, IExchangePort exchangePort)
+    public GetActivePositionsHandler(IPositionReadModel positionReadModel, IExchangePort exchangePort)
     {
-        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _positionReadModel = positionReadModel ?? throw new ArgumentNullException(nameof(positionReadModel));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
     }
 
@@ -84,10 +83,7 @@ public sealed class GetActivePositionsHandler : IQueryHandler<GetActivePositions
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var positions = await _positionRepository.GetAllActiveAsync(cancellationToken);
-        var filteredPositions = positions
-            .Where(position => query.Market is null || position.Pair.IsInMarket(query.Market))
-            .ToList();
+        var filteredPositions = await _positionReadModel.GetActiveAsync(query.Market, cancellationToken);
 
         var views = new List<PositionView>(filteredPositions.Count);
         foreach (var position in filteredPositions)
@@ -146,11 +142,11 @@ public sealed class GetActivePositionsHandler : IQueryHandler<GetActivePositions
 /// </summary>
 public sealed class GetClosedPositionsHandler : IQueryHandler<GetClosedPositionsQuery, IReadOnlyList<PositionView>>
 {
-    private readonly IPositionRepository _positionRepository;
+    private readonly IPositionReadModel _positionReadModel;
 
-    public GetClosedPositionsHandler(IPositionRepository positionRepository)
+    public GetClosedPositionsHandler(IPositionReadModel positionReadModel)
     {
-        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _positionReadModel = positionReadModel ?? throw new ArgumentNullException(nameof(positionReadModel));
     }
 
     public async Task<Result<IReadOnlyList<PositionView>>> HandleAsync(
@@ -172,11 +168,9 @@ public sealed class GetClosedPositionsHandler : IQueryHandler<GetClosedPositions
         }
 
         var limit = query.Limit <= 0 ? 100 : query.Limit;
-        var positions = await _positionRepository.GetClosedPositionsAsync(query.From, query.To, cancellationToken);
+        var positions = await _positionReadModel.GetClosedAsync(query.From, query.To, query.Pair, limit, cancellationToken);
 
         var views = positions
-            .Where(position => position.IsClosed)
-            .Where(position => query.Pair is null || position.Pair.Equals(query.Pair))
             .OrderByDescending(position => position.ClosedAt ?? position.OpenedAt)
             .Take(limit)
             .Select(position => PositionQueryMapper.Map(position, position.AveragePrice))
@@ -188,10 +182,17 @@ public sealed class GetClosedPositionsHandler : IQueryHandler<GetClosedPositions
 
 internal static class PositionQueryMapper
 {
-    public static PositionView Map(Position position, Price currentPrice)
+    public static PositionView Map(PositionReadModelEntry position, Price currentPrice)
     {
         ArgumentNullException.ThrowIfNull(position);
         ArgumentNullException.ThrowIfNull(currentPrice);
+
+        var currentValue = Money.Create(currentPrice.Value * position.TotalQuantity.Value, position.TotalCost.Currency);
+        var costBasis = position.TotalCost + position.TotalFees;
+        var unrealizedPnL = currentValue - costBasis;
+        var currentMargin = costBasis.Amount == 0m
+            ? Margin.Zero
+            : Margin.Calculate(costBasis.Amount, currentValue.Amount);
 
         return new PositionView
         {
@@ -202,17 +203,17 @@ internal static class PositionQueryMapper
             TotalQuantity = position.TotalQuantity,
             TotalCost = position.TotalCost,
             TotalFees = position.TotalFees,
-            CurrentValue = position.CalculateCurrentValue(currentPrice),
-            UnrealizedPnL = position.CalculateUnrealizedPnL(currentPrice),
-            CurrentMargin = position.CalculateMargin(currentPrice),
+            CurrentValue = currentValue,
+            UnrealizedPnL = unrealizedPnL,
+            CurrentMargin = currentMargin,
             DCALevel = position.DCALevel,
-            EntryCount = position.Entries.Count,
+            EntryCount = position.EntryCount,
             OpenedAt = position.OpenedAt,
             HoldingPeriod = (position.ClosedAt ?? DateTimeOffset.UtcNow) - position.OpenedAt,
             SignalRule = position.SignalRule,
             IsClosed = position.IsClosed,
             ClosedAt = position.ClosedAt,
-            RealizedPnL = null
+            RealizedPnL = position.RealizedPnL
         };
     }
 }

--- a/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
+++ b/IntelliTrader.Domain/Trading/Aggregates/Position/Position.cs
@@ -400,7 +400,11 @@ public sealed class Position : AggregateRoot<PositionId>
             TotalQuantity,
             proceeds,
             releasedCost,
-            sellFees));
+            sellFees,
+            remainingCost: TotalCost,
+            remainingFees: TotalFees,
+            newAveragePrice: AveragePrice,
+            remainingEntryCount: _entries.Count));
 
         return new PositionCloseFillDelta(soldQuantity, proceeds, releasedCost, sellFees, PositionClosed: false);
     }

--- a/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
+++ b/IntelliTrader.Domain/Trading/Events/PositionPartiallyClosed.cs
@@ -20,6 +20,10 @@ public sealed record PositionPartiallyClosed : IDomainEvent
     public Money Proceeds { get; }
     public Money ReleasedCost { get; }
     public Money SellFees { get; }
+    public Money? RemainingCost { get; }
+    public Money? RemainingFees { get; }
+    public Price? NewAveragePrice { get; }
+    public int? RemainingEntryCount { get; }
 
     public PositionPartiallyClosed(
         PositionId positionId,
@@ -33,7 +37,11 @@ public sealed record PositionPartiallyClosed : IDomainEvent
         Money sellFees,
         string? correlationId = null,
         Guid eventId = default,
-        DateTimeOffset occurredAt = default)
+        DateTimeOffset occurredAt = default,
+        Money? remainingCost = null,
+        Money? remainingFees = null,
+        Price? newAveragePrice = null,
+        int? remainingEntryCount = null)
     {
         EventId = eventId == Guid.Empty ? Guid.NewGuid() : eventId;
         OccurredAt = occurredAt == default ? DateTimeOffset.UtcNow : occurredAt;
@@ -47,5 +55,9 @@ public sealed record PositionPartiallyClosed : IDomainEvent
         ReleasedCost = releasedCost;
         SellFees = sellFees;
         CorrelationId = correlationId;
+        RemainingCost = remainingCost;
+        RemainingFees = remainingFees;
+        NewAveragePrice = newAveragePrice;
+        RemainingEntryCount = remainingEntryCount;
     }
 }

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/IPositionReadModelProjectionWriter.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/IPositionReadModelProjectionWriter.cs
@@ -1,0 +1,14 @@
+using IntelliTrader.Domain.Trading.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public interface IPositionReadModelProjectionWriter
+{
+    Task ProjectAsync(PositionOpened domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(DCAExecuted domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(PositionPartiallyClosed domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(PositionClosed domainEvent, CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonPositionReadModel.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonPositionReadModel.cs
@@ -1,0 +1,453 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Events;
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+/// <summary>
+/// Durable read-side projection for position queries.
+/// </summary>
+public sealed class JsonPositionReadModel : IPositionReadModel, IPositionReadModelProjectionWriter, IDisposable
+{
+    private static readonly string[] KnownQuoteCurrencies =
+    [
+        "USDT",
+        "USDC",
+        "BUSD",
+        "TUSD",
+        "FDUSD",
+        "USD",
+        "EUR",
+        "BTC",
+        "ETH",
+        "BNB",
+        "TRY",
+        "GBP"
+    ];
+
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private ConcurrentDictionary<string, PositionReadModelDto> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonPositionReadModel(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+
+        _filePath = filePath;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<PositionReadModelEntry?> GetByIdAsync(
+        PositionId id,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.TryGetValue(id.ToString(), out var dto) ? MapEntry(dto) : null;
+    }
+
+    public async Task<PositionReadModelEntry?> GetByPairAsync(
+        TradingPair pair,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.Values
+            .Where(dto => !dto.IsClosed)
+            .Where(dto => dto.Pair.Equals(pair.Symbol, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(dto => dto.OpenedAt)
+            .Select(MapEntry)
+            .FirstOrDefault();
+    }
+
+    public async Task<IReadOnlyList<PositionReadModelEntry>> GetActiveAsync(
+        string? market,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.Values
+            .Where(dto => !dto.IsClosed)
+            .Where(dto => string.IsNullOrWhiteSpace(market) ||
+                          dto.QuoteCurrency.Equals(market, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(dto => dto.OpenedAt)
+            .Select(MapEntry)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<PositionReadModelEntry>> GetClosedAsync(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        TradingPair? pair,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+        var safeLimit = limit <= 0 ? 100 : limit;
+
+        return _cache.Values
+            .Where(dto => dto.IsClosed)
+            .Where(dto => dto.ClosedAt is not null && dto.ClosedAt >= from && dto.ClosedAt <= to)
+            .Where(dto => pair is null || dto.Pair.Equals(pair.Symbol, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(dto => dto.ClosedAt ?? dto.OpenedAt)
+            .Take(safeLimit)
+            .Select(MapEntry)
+            .ToList();
+    }
+
+    public Task ProjectAsync(PositionOpened domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var id = domainEvent.PositionId.ToString();
+            var dto = cache.GetValueOrDefault(id) ?? CreateDto(
+                domainEvent.PositionId,
+                domainEvent.Pair,
+                domainEvent.OccurredAt);
+
+            dto.Pair = domainEvent.Pair.Symbol;
+            dto.QuoteCurrency = domainEvent.Pair.QuoteCurrency;
+            dto.AveragePrice = domainEvent.Price.Value;
+            dto.TotalQuantity = domainEvent.Quantity.Value;
+            dto.TotalCost = domainEvent.Cost.Amount;
+            dto.CostCurrency = domainEvent.Cost.Currency;
+            dto.TotalFees = domainEvent.Fees.Amount;
+            dto.FeesCurrency = domainEvent.Fees.Currency;
+            dto.DCALevel = 0;
+            dto.OpenedAt = domainEvent.OccurredAt;
+            dto.SignalRule = domainEvent.SignalRule;
+            dto.IsClosed = false;
+            dto.ClosedAt = null;
+            AddEntryOrderId(dto, domainEvent.OrderId.Value);
+            dto.EntryCount = ResolveEntryCount(dto);
+            dto.UpdatedAt = domainEvent.OccurredAt;
+
+            cache[id] = dto;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(DCAExecuted domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var id = domainEvent.PositionId.ToString();
+            var dto = cache.GetValueOrDefault(id) ?? CreateDto(
+                domainEvent.PositionId,
+                domainEvent.Pair,
+                domainEvent.OccurredAt);
+
+            dto.Pair = domainEvent.Pair.Symbol;
+            dto.QuoteCurrency = domainEvent.Pair.QuoteCurrency;
+            dto.AveragePrice = domainEvent.NewAveragePrice.Value;
+            dto.TotalQuantity = domainEvent.NewTotalQuantity.Value;
+            dto.TotalCost = domainEvent.NewTotalCost.Amount;
+            dto.CostCurrency = domainEvent.NewTotalCost.Currency;
+            dto.TotalFees += domainEvent.Fees.Amount;
+            dto.FeesCurrency = domainEvent.Fees.Currency;
+            dto.DCALevel = domainEvent.NewDCALevel;
+            AddEntryOrderId(dto, domainEvent.OrderId.Value);
+            dto.EntryCount = Math.Max(ResolveEntryCount(dto), domainEvent.NewDCALevel + 1);
+            dto.UpdatedAt = domainEvent.OccurredAt;
+
+            cache[id] = dto;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(PositionPartiallyClosed domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var id = domainEvent.PositionId.ToString();
+            var dto = cache.GetValueOrDefault(id) ?? CreateDto(
+                domainEvent.PositionId,
+                domainEvent.Pair,
+                domainEvent.OccurredAt);
+
+            var previousCost = dto.TotalCost;
+            var previousFees = dto.TotalFees;
+            var releasedFeeRatio = previousCost == 0m
+                ? 0m
+                : Math.Clamp(domainEvent.ReleasedCost.Amount / previousCost, 0m, 1m);
+
+            dto.Pair = domainEvent.Pair.Symbol;
+            dto.QuoteCurrency = domainEvent.Pair.QuoteCurrency;
+            dto.TotalQuantity = domainEvent.RemainingQuantity.Value;
+            dto.TotalCost = domainEvent.RemainingCost?.Amount
+                ?? Math.Max(0m, previousCost - domainEvent.ReleasedCost.Amount);
+            dto.TotalFees = domainEvent.RemainingFees?.Amount
+                ?? Math.Max(0m, previousFees - previousFees * releasedFeeRatio);
+            dto.CostCurrency = domainEvent.RemainingCost?.Currency ?? domainEvent.ReleasedCost.Currency;
+            dto.FeesCurrency = domainEvent.RemainingFees?.Currency ?? dto.FeesCurrency;
+            dto.AveragePrice = domainEvent.NewAveragePrice?.Value
+                ?? (dto.TotalQuantity == 0m ? dto.AveragePrice : dto.TotalCost / dto.TotalQuantity);
+            dto.EntryCount = domainEvent.RemainingEntryCount ?? dto.EntryCount;
+            dto.IsClosed = false;
+            dto.ClosedAt = null;
+            dto.UpdatedAt = domainEvent.OccurredAt;
+
+            cache[id] = dto;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(PositionClosed domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var id = domainEvent.PositionId.ToString();
+            var dto = cache.GetValueOrDefault(id) ?? CreateDto(
+                domainEvent.PositionId,
+                domainEvent.Pair,
+                domainEvent.OccurredAt - domainEvent.Duration);
+
+            dto.Pair = domainEvent.Pair.Symbol;
+            dto.QuoteCurrency = domainEvent.Pair.QuoteCurrency;
+            dto.TotalQuantity = domainEvent.SoldQuantity.Value;
+            dto.TotalCost = domainEvent.TotalCost.Amount;
+            dto.CostCurrency = domainEvent.TotalCost.Currency;
+            dto.TotalFees = domainEvent.TotalFees.Amount;
+            dto.FeesCurrency = domainEvent.TotalFees.Currency;
+            dto.AveragePrice = domainEvent.SoldQuantity.IsZero
+                ? dto.AveragePrice
+                : domainEvent.TotalCost.Amount / domainEvent.SoldQuantity.Value;
+            dto.DCALevel = domainEvent.DCALevel;
+            dto.IsClosed = true;
+            dto.ClosedAt = domainEvent.OccurredAt;
+            dto.RealizedPnL = domainEvent.Proceeds.Amount - domainEvent.TotalCost.Amount - domainEvent.TotalFees.Amount;
+            dto.RealizedPnLCurrency = domainEvent.Proceeds.Currency;
+            dto.UpdatedAt = domainEvent.OccurredAt;
+
+            cache[id] = dto;
+        }, cancellationToken);
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task MutateAsync(
+        Action<ConcurrentDictionary<string, PositionReadModelDto>> mutate,
+        CancellationToken cancellationToken)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            mutate(_cache);
+            await PersistCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            _cache = new ConcurrentDictionary<string, PositionReadModelDto>(StringComparer.OrdinalIgnoreCase);
+            _cacheLoaded = true;
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _cache = new ConcurrentDictionary<string, PositionReadModelDto>(StringComparer.OrdinalIgnoreCase);
+            _cacheLoaded = true;
+            return;
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<PositionReadModelDto>>(json, _jsonOptions)
+                   ?? new List<PositionReadModelDto>();
+        _cache = new ConcurrentDictionary<string, PositionReadModelDto>(
+            dtos.ToDictionary(dto => dto.Id, StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+        _cacheLoaded = true;
+    }
+
+    private async Task PersistCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var dtos = _cache.Values
+            .OrderByDescending(dto => dto.UpdatedAt == default ? dto.OpenedAt : dto.UpdatedAt)
+            .ToList();
+        var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+        await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static PositionReadModelDto CreateDto(
+        PositionId positionId,
+        TradingPair pair,
+        DateTimeOffset openedAt)
+    {
+        return new PositionReadModelDto
+        {
+            Id = positionId.ToString(),
+            Pair = pair.Symbol,
+            QuoteCurrency = pair.QuoteCurrency,
+            CostCurrency = pair.QuoteCurrency,
+            FeesCurrency = pair.QuoteCurrency,
+            OpenedAt = openedAt,
+            UpdatedAt = openedAt
+        };
+    }
+
+    private static PositionReadModelEntry MapEntry(PositionReadModelDto dto)
+    {
+        var pair = TradingPair.Create(dto.Pair, ResolveQuoteCurrency(dto.Pair, dto.QuoteCurrency));
+        var costCurrency = ResolveCurrency(dto.CostCurrency, pair.QuoteCurrency);
+        var feesCurrency = ResolveCurrency(dto.FeesCurrency, pair.QuoteCurrency);
+
+        return new PositionReadModelEntry
+        {
+            Id = PositionId.From(dto.Id),
+            Pair = pair,
+            AveragePrice = Price.Create(dto.AveragePrice),
+            TotalQuantity = Quantity.Create(dto.TotalQuantity),
+            TotalCost = Money.Create(dto.TotalCost, costCurrency),
+            TotalFees = Money.Create(dto.TotalFees, feesCurrency),
+            DCALevel = dto.DCALevel,
+            EntryCount = ResolveEntryCount(dto),
+            OpenedAt = dto.OpenedAt,
+            SignalRule = dto.SignalRule,
+            IsClosed = dto.IsClosed,
+            ClosedAt = dto.ClosedAt,
+            RealizedPnL = dto.RealizedPnL.HasValue
+                ? Money.Create(dto.RealizedPnL.Value, ResolveCurrency(dto.RealizedPnLCurrency, pair.QuoteCurrency))
+                : null
+        };
+    }
+
+    private static void AddEntryOrderId(PositionReadModelDto dto, string orderId)
+    {
+        if (string.IsNullOrWhiteSpace(orderId))
+        {
+            return;
+        }
+
+        if (!dto.EntryOrderIds.Contains(orderId, StringComparer.OrdinalIgnoreCase))
+        {
+            dto.EntryOrderIds.Add(orderId);
+        }
+    }
+
+    private static int ResolveEntryCount(PositionReadModelDto dto)
+    {
+        return dto.EntryCount > 0 ? dto.EntryCount : dto.EntryOrderIds.Count;
+    }
+
+    private static string ResolveCurrency(string? currency, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(currency) ? fallback : currency.ToUpperInvariant();
+    }
+
+    private static string ResolveQuoteCurrency(string pair, string? explicitQuoteCurrency)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitQuoteCurrency))
+        {
+            return explicitQuoteCurrency.ToUpperInvariant();
+        }
+
+        var symbol = pair.ToUpperInvariant();
+        var knownQuote = KnownQuoteCurrencies.FirstOrDefault(quote =>
+            symbol.EndsWith(quote, StringComparison.Ordinal) && symbol.Length > quote.Length);
+        if (knownQuote is not null)
+        {
+            return knownQuote;
+        }
+
+        return symbol.Length > 3 ? symbol[^3..] : symbol;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+
+    private sealed class PositionReadModelDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Pair { get; set; } = string.Empty;
+        public string QuoteCurrency { get; set; } = string.Empty;
+        public decimal AveragePrice { get; set; }
+        public decimal TotalQuantity { get; set; }
+        public decimal TotalCost { get; set; }
+        public string CostCurrency { get; set; } = string.Empty;
+        public decimal TotalFees { get; set; }
+        public string FeesCurrency { get; set; } = string.Empty;
+        public int DCALevel { get; set; }
+        public int EntryCount { get; set; }
+        public List<string> EntryOrderIds { get; set; } = new();
+        public DateTimeOffset OpenedAt { get; set; }
+        public string? SignalRule { get; set; }
+        public bool IsClosed { get; set; }
+        public DateTimeOffset? ClosedAt { get; set; }
+        public decimal? RealizedPnL { get; set; }
+        public string? RealizedPnLCurrency { get; set; }
+        public DateTimeOffset UpdatedAt { get; set; }
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/PositionReadModelProjectionHandler.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/PositionReadModelProjectionHandler.cs
@@ -1,0 +1,38 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public sealed class PositionReadModelProjectionHandler :
+    IDomainEventHandler<PositionOpened>,
+    IDomainEventHandler<DCAExecuted>,
+    IDomainEventHandler<PositionPartiallyClosed>,
+    IDomainEventHandler<PositionClosed>
+{
+    private readonly IPositionReadModelProjectionWriter _projectionWriter;
+
+    public PositionReadModelProjectionHandler(IPositionReadModelProjectionWriter projectionWriter)
+    {
+        _projectionWriter = projectionWriter ?? throw new ArgumentNullException(nameof(projectionWriter));
+    }
+
+    public Task HandleAsync(PositionOpened domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(DCAExecuted domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(PositionPartiallyClosed domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(PositionClosed domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -136,6 +136,13 @@ public class AppModule : Module
             .SingleInstance();
 
         builder.Register(_ =>
+            new JsonPositionReadModel(CreateDataFilePath("position-read-model.json")))
+            .As<IPositionReadModel>()
+            .As<IPositionReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
             new JsonDomainEventOutbox(CreateDataFilePath("outbox.json"), _.Resolve<JsonTransactionCoordinator>()))
             .As<IDomainEventOutbox>()
             .AsSelf()

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionQueryHandlerTests.cs
@@ -3,7 +3,6 @@ using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using Moq;
 
@@ -11,7 +10,7 @@ namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
 public sealed class PositionQueryHandlerTests
 {
-    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IPositionReadModel> _positionReadModelMock = new();
     private readonly Mock<IExchangePort> _exchangePortMock = new();
 
     [Fact]
@@ -19,17 +18,16 @@ public sealed class PositionQueryHandlerTests
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
         var openedAt = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m, openedAt);
+        var position = CreatePosition(pair, 50000m, 0.02m, 1m, openedAt: openedAt);
 
-        _positionRepositoryMock
+        _positionReadModelMock
             .Setup(x => x.GetByPairAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(position);
-
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
 
-        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPositionQuery { Pair = pair });
 
@@ -47,7 +45,7 @@ public sealed class PositionQueryHandlerTests
     [Fact]
     public async Task GetPosition_WithoutIdentifier_ReturnsValidationFailure()
     {
-        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPositionQuery());
 
@@ -60,11 +58,11 @@ public sealed class PositionQueryHandlerTests
     public async Task GetPosition_WithMissingPositionId_ReturnsNotFound()
     {
         var positionId = PositionId.Create();
-        _positionRepositoryMock
+        _positionReadModelMock
             .Setup(x => x.GetByIdAsync(positionId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Position?)null);
+            .ReturnsAsync((PositionReadModelEntry?)null);
 
-        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPositionQuery { PositionId = positionId });
 
@@ -77,22 +75,13 @@ public sealed class PositionQueryHandlerTests
     public async Task GetPosition_WithClosedPosition_UsesAveragePriceWithoutExchangeLookup()
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var position = CreateClosedPosition(
-            pair,
-            "order-btc-1",
-            "sell-btc-1",
-            50000m,
-            0.02m,
-            1m,
-            55000m,
-            1m,
-            DateTimeOffset.UtcNow);
+        var position = CreateClosedPosition(pair, 50000m, 0.02m, 1m, DateTimeOffset.UtcNow);
 
-        _positionRepositoryMock
+        _positionReadModelMock
             .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(position);
 
-        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPositionQuery { PositionId = position.Id });
 
@@ -108,16 +97,16 @@ public sealed class PositionQueryHandlerTests
     public async Task GetPosition_WhenActivePositionPriceLookupFails_ReturnsFailure()
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m);
+        var position = CreatePosition(pair, 50000m, 0.02m, 1m);
 
-        _positionRepositoryMock
+        _positionReadModelMock
             .Setup(x => x.GetByIdAsync(position.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(position);
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
 
-        var handler = new GetPositionHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPositionQuery { PositionId = position.Id });
 
@@ -130,25 +119,20 @@ public sealed class PositionQueryHandlerTests
     {
         var btc = TradingPair.Create("BTCUSDT", "USDT");
         var eth = TradingPair.Create("ETHUSDT", "USDT");
-        var adaBtc = TradingPair.Create("ADABTC", "BTC");
+        var btcPosition = CreatePosition(btc, 50000m, 0.02m, 1m);
+        var ethPosition = CreatePosition(eth, 2500m, 0.4m, 1m);
 
-        var btcPosition = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m);
-        var ethPosition = CreatePosition(eth, "order-eth-1", 2500m, 0.4m, 1m);
-        var adaPosition = CreatePosition(adaBtc, "order-ada-1", 0.00001m, 1000m, 0.000001m);
-
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { ethPosition, adaPosition, btcPosition });
-
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ethPosition, btcPosition });
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
-
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(eth, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(2400m)));
 
-        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetActivePositionsHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetActivePositionsQuery
         {
@@ -161,23 +145,23 @@ public sealed class PositionQueryHandlerTests
         result.Value.Select(position => position.Pair).Should().Equal(btc, eth);
         result.Value.Should().OnlyContain(position => position.Pair.QuoteCurrency == "USDT");
         result.Value[0].CurrentMargin.Percentage.Should().BeGreaterThan(result.Value[1].CurrentMargin.Percentage);
+        _positionReadModelMock.Verify(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetActivePositions_WhenPriceLookupFails_ReturnsFailure()
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var position = CreatePosition(pair, "order-btc-1", 50000m, 0.02m, 1m);
+        var position = CreatePosition(pair, 50000m, 0.02m, 1m);
 
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync((string?)null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { position });
-
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
 
-        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetActivePositionsHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetActivePositionsQuery());
 
@@ -203,17 +187,19 @@ public sealed class PositionQueryHandlerTests
     {
         var btc = TradingPair.Create("BTCUSDT", "USDT");
         var ada = TradingPair.Create("ADAUSDT", "USDT");
-        var newerBtc = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m, DateTimeOffset.UtcNow);
-        newerBtc.AddDCAEntry(
-            OrderId.From("order-btc-dca-1"),
-            Price.Create(49000m),
-            Quantity.Create(0.01m),
-            Money.Create(0.5m, "USDT"));
-        newerBtc.ClearDomainEvents();
-        var olderAda = CreatePosition(ada, "order-ada-1", 1m, 100m, 1m, DateTimeOffset.UtcNow.AddHours(-1));
+        var newerBtc = CreatePosition(
+            btc,
+            price: 49666.666666666666666666666667m,
+            quantity: 0.03m,
+            fees: 1.5m,
+            totalCost: 1490m,
+            dcaLevel: 1,
+            entryCount: 2,
+            openedAt: DateTimeOffset.UtcNow);
+        var olderAda = CreatePosition(ada, 1m, 100m, 1m, openedAt: DateTimeOffset.UtcNow.AddHours(-1));
 
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync((string?)null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { newerBtc, olderAda });
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
@@ -222,7 +208,7 @@ public sealed class PositionQueryHandlerTests
             .Setup(x => x.GetCurrentPriceAsync(ada, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(1.01m)));
 
-        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetActivePositionsHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetActivePositionsQuery
         {
@@ -239,11 +225,11 @@ public sealed class PositionQueryHandlerTests
     {
         var btc = TradingPair.Create("BTCUSDT", "USDT");
         var eth = TradingPair.Create("ETHUSDT", "USDT");
-        var btcPosition = CreatePosition(btc, "order-btc-1", 50000m, 0.02m, 1m);
-        var ethPosition = CreatePosition(eth, "order-eth-1", 2500m, 0.4m, 1m);
+        var btcPosition = CreatePosition(btc, 50000m, 0.02m, 1m);
+        var ethPosition = CreatePosition(eth, 2500m, 0.4m, 1m);
 
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync((string?)null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { btcPosition, ethPosition });
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(btc, It.IsAny<CancellationToken>()))
@@ -252,7 +238,7 @@ public sealed class PositionQueryHandlerTests
             .Setup(x => x.GetCurrentPriceAsync(eth, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(2400m)));
 
-        var handler = new GetActivePositionsHandler(_positionRepositoryMock.Object, _exchangePortMock.Object);
+        var handler = new GetActivePositionsHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetActivePositionsQuery
         {
@@ -269,19 +255,19 @@ public sealed class PositionQueryHandlerTests
     public async Task GetClosedPositions_FiltersByPairAndLimitsResults()
     {
         var btc = TradingPair.Create("BTCUSDT", "USDT");
-        var eth = TradingPair.Create("ETHUSDT", "USDT");
-        var newerBtc = CreateClosedPosition(btc, "order-btc-1", "sell-btc-1", 50000m, 0.02m, 1m, 55000m, 1m, DateTimeOffset.UtcNow);
-        var olderBtc = CreateClosedPosition(btc, "order-btc-2", "sell-btc-2", 51000m, 0.02m, 1m, 52000m, 1m, DateTimeOffset.UtcNow.AddMinutes(-10));
-        var otherPair = CreateClosedPosition(eth, "order-eth-1", "sell-eth-1", 2500m, 0.4m, 1m, 2600m, 1m, DateTimeOffset.UtcNow);
+        var newerBtc = CreateClosedPosition(btc, 50000m, 0.02m, 1m, DateTimeOffset.UtcNow);
+        var olderBtc = CreateClosedPosition(btc, 51000m, 0.02m, 1m, DateTimeOffset.UtcNow.AddMinutes(-10));
 
-        _positionRepositoryMock
-            .Setup(x => x.GetClosedPositionsAsync(
+        _positionReadModelMock
+            .Setup(x => x.GetClosedAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
+                btc,
+                1,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { olderBtc, otherPair, newerBtc });
+            .ReturnsAsync(new[] { olderBtc, newerBtc });
 
-        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+        var handler = new GetClosedPositionsHandler(_positionReadModelMock.Object);
 
         var result = await handler.HandleAsync(new GetClosedPositionsQuery
         {
@@ -303,7 +289,7 @@ public sealed class PositionQueryHandlerTests
     [Fact]
     public async Task GetClosedPositions_WithProfitableOnlyFilter_ReturnsValidationFailure()
     {
-        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+        var handler = new GetClosedPositionsHandler(_positionReadModelMock.Object);
 
         var result = await handler.HandleAsync(new GetClosedPositionsQuery { ProfitableOnly = true });
 
@@ -315,7 +301,7 @@ public sealed class PositionQueryHandlerTests
     [Fact]
     public async Task GetClosedPositions_WithInvalidRange_ReturnsValidationFailure()
     {
-        var handler = new GetClosedPositionsHandler(_positionRepositoryMock.Object);
+        var handler = new GetClosedPositionsHandler(_positionReadModelMock.Object);
 
         var result = await handler.HandleAsync(new GetClosedPositionsQuery
         {
@@ -327,41 +313,50 @@ public sealed class PositionQueryHandlerTests
         result.Error.Code.Should().Be("Validation");
     }
 
-    private static Position CreatePosition(
+    private static PositionReadModelEntry CreatePosition(
         TradingPair pair,
-        string orderId,
         decimal price,
         decimal quantity,
         decimal fees,
+        decimal? totalCost = null,
+        int dcaLevel = 0,
+        int entryCount = 1,
         DateTimeOffset? openedAt = null)
     {
-        var position = Position.Open(
-            pair,
-            OrderId.From(orderId),
-            Price.Create(price),
-            Quantity.Create(quantity),
-            Money.Create(fees, pair.QuoteCurrency),
-            "MomentumBreakout",
-            openedAt);
+        var effectiveCost = totalCost ?? price * quantity;
+        var averagePrice = quantity == 0m ? price : effectiveCost / quantity;
 
-        position.ClearDomainEvents();
-        return position;
+        return new PositionReadModelEntry
+        {
+            Id = PositionId.Create(),
+            Pair = pair,
+            AveragePrice = Price.Create(averagePrice),
+            TotalQuantity = Quantity.Create(quantity),
+            TotalCost = Money.Create(effectiveCost, pair.QuoteCurrency),
+            TotalFees = Money.Create(fees, pair.QuoteCurrency),
+            DCALevel = dcaLevel,
+            EntryCount = entryCount,
+            OpenedAt = openedAt ?? DateTimeOffset.UtcNow,
+            SignalRule = "MomentumBreakout"
+        };
     }
 
-    private static Position CreateClosedPosition(
+    private static PositionReadModelEntry CreateClosedPosition(
         TradingPair pair,
-        string orderId,
-        string sellOrderId,
         decimal entryPrice,
         decimal quantity,
         decimal entryFees,
-        decimal sellPrice,
-        decimal sellFees,
         DateTimeOffset closedAt)
     {
-        var position = CreatePosition(pair, orderId, entryPrice, quantity, entryFees, closedAt.AddHours(-4));
-        position.Close(OrderId.From(sellOrderId), Price.Create(sellPrice), Money.Create(sellFees, pair.QuoteCurrency), closedAt);
-        position.ClearDomainEvents();
-        return position;
+        return CreatePosition(
+            pair,
+            entryPrice,
+            quantity,
+            entryFees,
+            openedAt: closedAt.AddHours(-4)) with
+        {
+            IsClosed = true,
+            ClosedAt = closedAt
+        };
     }
 }

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionReadModelQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PositionReadModelQueryHandlerTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class PositionReadModelQueryHandlerTests
+{
+    private readonly Mock<IPositionReadModel> _positionReadModelMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+
+    [Fact]
+    public async Task GetPosition_WithPair_ReturnsProjectedViewUsingCurrentExchangePrice()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = CreateProjection(pair, averagePrice: 50000m, quantity: 0.02m, cost: 1000m, fees: 1m);
+
+        _positionReadModelMock
+            .Setup(x => x.GetByPairAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(position);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
+
+        var handler = new GetPositionHandler(_positionReadModelMock.Object, _exchangePortMock.Object);
+
+        var result = await handler.HandleAsync(new GetPositionQuery { Pair = pair });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(position.Id);
+        result.Value.CurrentPrice.Value.Should().Be(55000m);
+        result.Value.CurrentValue.Amount.Should().Be(1100m);
+        result.Value.UnrealizedPnL.Amount.Should().Be(99m);
+        result.Value.CurrentMargin.Percentage.Should().BeApproximately(9.8901098901m, 0.0000000001m);
+        result.Value.EntryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetClosedPositions_ReadsClosedProjectionWithoutExchangeLookup()
+    {
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var closedAt = DateTimeOffset.Parse("2026-04-26T12:00:00Z");
+        var position = CreateProjection(pair, averagePrice: 1000m, quantity: 0.5m, cost: 500m, fees: 2m) with
+        {
+            IsClosed = true,
+            ClosedAt = closedAt
+        };
+
+        _positionReadModelMock
+            .Setup(x => x.GetClosedAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                pair,
+                1,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+
+        var handler = new GetClosedPositionsHandler(_positionReadModelMock.Object);
+
+        var result = await handler.HandleAsync(new GetClosedPositionsQuery
+        {
+            Pair = pair,
+            Limit = 1
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].Id.Should().Be(position.Id);
+        result.Value[0].IsClosed.Should().BeTrue();
+        result.Value[0].CurrentPrice.Should().Be(position.AveragePrice);
+        _exchangePortMock.Verify(
+            x => x.GetCurrentPriceAsync(It.IsAny<TradingPair>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static PositionReadModelEntry CreateProjection(
+        TradingPair pair,
+        decimal averagePrice,
+        decimal quantity,
+        decimal cost,
+        decimal fees)
+    {
+        return new PositionReadModelEntry
+        {
+            Id = PositionId.Create(),
+            Pair = pair,
+            AveragePrice = Price.Create(averagePrice),
+            TotalQuantity = Quantity.Create(quantity),
+            TotalCost = Money.Create(cost, pair.QuoteCurrency),
+            TotalFees = Money.Create(fees, pair.QuoteCurrency),
+            DCALevel = 0,
+            EntryCount = 1,
+            OpenedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z"),
+            SignalRule = "MomentumBreakout"
+        };
+    }
+}

--- a/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
+++ b/tests/IntelliTrader.Domain.Tests/Trading/Aggregates/PositionTests.cs
@@ -430,6 +430,36 @@ public class PositionTests
     }
 
     [Fact]
+    public void ApplyCloseFillDelta_WithMultipleEntries_RaisesPartialCloseEventWithExactRemainingState()
+    {
+        var position = Position.Open(
+            CreatePair(),
+            CreateOrderId("buy1"),
+            CreatePrice(50000m),
+            CreateQuantity(0.1m),
+            CreateFees(10m));
+        position.AddDCAEntry(
+            CreateOrderId("buy2"),
+            CreatePrice(25000m),
+            CreateQuantity(0.1m),
+            CreateFees(1m));
+        position.ClearDomainEvents();
+
+        position.ApplyCloseFillDelta(
+            CreateOrderId("sell1"),
+            CreatePrice(55000m),
+            CreateQuantity(0.1m),
+            CreateFees(2m));
+
+        var evt = position.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<PositionPartiallyClosed>().Subject;
+        evt.RemainingCost.Should().Be(position.TotalCost);
+        evt.RemainingFees.Should().Be(position.TotalFees);
+        evt.NewAveragePrice.Should().Be(position.AveragePrice);
+        evt.RemainingEntryCount.Should().Be(position.Entries.Count);
+    }
+
+    [Fact]
     public void Close_OnAlreadyClosedPosition_ThrowsInvalidOperationException()
     {
         // Arrange

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/PositionReadModelProjectionTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/PositionReadModelProjectionTests.cs
@@ -1,0 +1,222 @@
+using FluentAssertions;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Events;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+using IntelliTrader.Infrastructure.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class PositionReadModelProjectionTests
+{
+    [Fact]
+    public async Task DispatchManyAsync_WhenPositionIsOpenedAndDcaExecuted_ProjectsActivePositionAndPersistsIt()
+    {
+        var filePath = CreateReadModelPath();
+        using var readModel = new JsonPositionReadModel(filePath);
+        var handler = new PositionReadModelProjectionHandler(readModel);
+        var dispatcher = CreateDispatcher(handler);
+        var positionId = PositionId.Create();
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var openedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z");
+        var dcaAt = DateTimeOffset.Parse("2026-04-26T10:30:00Z");
+
+        var events = new IDomainEvent[]
+        {
+            new PositionOpened(
+                positionId,
+                pair,
+                OrderId.From("open-1"),
+                Price.Create(100m),
+                Quantity.Create(2m),
+                Money.Create(200m, "USDT"),
+                Money.Create(1m, "USDT"),
+                "MomentumBreakout",
+                occurredAt: openedAt),
+            new DCAExecuted(
+                positionId,
+                pair,
+                OrderId.From("dca-1"),
+                newDCALevel: 1,
+                Price.Create(80m),
+                Quantity.Create(1m),
+                Money.Create(80m, "USDT"),
+                Money.Create(0.5m, "USDT"),
+                Price.Create(93.33333333333333333333333333m),
+                Quantity.Create(3m),
+                Money.Create(280m, "USDT"),
+                occurredAt: dcaAt)
+        };
+
+        try
+        {
+            await dispatcher.DispatchManyAsync(events);
+
+            var projected = await readModel.GetByIdAsync(positionId);
+            projected.Should().NotBeNull();
+            projected!.Pair.Should().Be(pair);
+            projected.AveragePrice.Value.Should().Be(93.33333333333333333333333333m);
+            projected.TotalQuantity.Value.Should().Be(3m);
+            projected.TotalCost.Amount.Should().Be(280m);
+            projected.TotalFees.Amount.Should().Be(1.5m);
+            projected.DCALevel.Should().Be(1);
+            projected.EntryCount.Should().Be(2);
+            projected.OpenedAt.Should().Be(openedAt);
+            projected.IsClosed.Should().BeFalse();
+
+            (await readModel.GetByPairAsync(pair)).Should().BeEquivalentTo(projected);
+            (await readModel.GetActiveAsync("USDT")).Should().ContainSingle(p => p.Id == positionId);
+
+            using var reloadedReadModel = new JsonPositionReadModel(filePath);
+            var reloaded = await reloadedReadModel.GetByIdAsync(positionId);
+            reloaded.Should().NotBeNull();
+            reloaded!.TotalQuantity.Value.Should().Be(3m);
+            reloaded.TotalFees.Amount.Should().Be(1.5m);
+        }
+        finally
+        {
+            DeleteFileIfExists(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchManyAsync_WhenPositionIsPartiallyClosed_ProjectsExactRemainingAggregateState()
+    {
+        var filePath = CreateReadModelPath();
+        using var readModel = new JsonPositionReadModel(filePath);
+        var handler = new PositionReadModelProjectionHandler(readModel);
+        var dispatcher = CreateDispatcher(handler);
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var position = Position.Open(
+            pair,
+            OrderId.From("open-partial-1"),
+            Price.Create(50000m),
+            Quantity.Create(0.1m),
+            Money.Create(10m, "USDT"),
+            "MomentumBreakout");
+        var events = new List<IDomainEvent>(position.DomainEvents);
+
+        position.ClearDomainEvents();
+        position.AddDCAEntry(
+            OrderId.From("dca-partial-1"),
+            Price.Create(25000m),
+            Quantity.Create(0.1m),
+            Money.Create(1m, "USDT"));
+        events.AddRange(position.DomainEvents);
+
+        position.ClearDomainEvents();
+        position.ApplyCloseFillDelta(
+            OrderId.From("sell-partial-1"),
+            Price.Create(55000m),
+            Quantity.Create(0.1m),
+            Money.Create(2m, "USDT"));
+        events.AddRange(position.DomainEvents);
+
+        try
+        {
+            await dispatcher.DispatchManyAsync(events);
+
+            var projected = await readModel.GetByIdAsync(position.Id);
+            projected.Should().NotBeNull();
+            projected!.TotalQuantity.Should().Be(position.TotalQuantity);
+            projected.TotalCost.Should().Be(position.TotalCost);
+            projected.TotalFees.Should().Be(position.TotalFees);
+            projected.AveragePrice.Should().Be(position.AveragePrice);
+            projected.EntryCount.Should().Be(position.Entries.Count);
+            projected.IsClosed.Should().BeFalse();
+        }
+        finally
+        {
+            DeleteFileIfExists(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchManyAsync_WhenPositionIsClosed_ProjectsClosedPositionAndRemovesItFromActiveQueries()
+    {
+        var filePath = CreateReadModelPath();
+        using var readModel = new JsonPositionReadModel(filePath);
+        var handler = new PositionReadModelProjectionHandler(readModel);
+        var dispatcher = CreateDispatcher(handler);
+        var positionId = PositionId.Create();
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+        var openedAt = DateTimeOffset.Parse("2026-04-26T09:00:00Z");
+        var closedAt = DateTimeOffset.Parse("2026-04-26T12:00:00Z");
+
+        var events = new IDomainEvent[]
+        {
+            new PositionOpened(
+                positionId,
+                pair,
+                OrderId.From("open-2"),
+                Price.Create(1000m),
+                Quantity.Create(0.5m),
+                Money.Create(500m, "USDT"),
+                Money.Create(0.8m, "USDT"),
+                null,
+                occurredAt: openedAt),
+            new PositionClosed(
+                positionId,
+                pair,
+                OrderId.From("sell-2"),
+                Price.Create(1100m),
+                Quantity.Create(0.5m),
+                Money.Create(550m, "USDT"),
+                Money.Create(500m, "USDT"),
+                Money.Create(1.8m, "USDT"),
+                Margin.FromPercentage(9.6m),
+                dcaLevel: 0,
+                duration: TimeSpan.FromHours(3),
+                occurredAt: closedAt)
+        };
+
+        try
+        {
+            await dispatcher.DispatchManyAsync(events);
+
+            var projected = await readModel.GetByIdAsync(positionId);
+            projected.Should().NotBeNull();
+            projected!.IsClosed.Should().BeTrue();
+            projected.ClosedAt.Should().Be(closedAt);
+            projected.TotalFees.Amount.Should().Be(1.8m);
+
+            (await readModel.GetByPairAsync(pair)).Should().BeNull();
+            (await readModel.GetActiveAsync("USDT")).Should().BeEmpty();
+            (await readModel.GetClosedAsync(openedAt, closedAt.AddMinutes(1), pair, limit: 10))
+                .Should().ContainSingle(p => p.Id == positionId);
+        }
+        finally
+        {
+            DeleteFileIfExists(filePath);
+        }
+    }
+
+    private static InMemoryDomainEventDispatcher CreateDispatcher(PositionReadModelProjectionHandler handler)
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher(
+            Mock.Of<IServiceProvider>(),
+            NullLogger<InMemoryDomainEventDispatcher>.Instance);
+        dispatcher.RegisterHandler<PositionOpened>(handler);
+        dispatcher.RegisterHandler<DCAExecuted>(handler);
+        dispatcher.RegisterHandler<PositionPartiallyClosed>(handler);
+        dispatcher.RegisterHandler<PositionClosed>(handler);
+        return dispatcher;
+    }
+
+    private static string CreateReadModelPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"position_read_model_{Guid.NewGuid():N}.json");
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
@@ -70,6 +70,7 @@ public class InfrastructureTestFixture : IDisposable
         var outboxPath = CreateTempFilePath($"{prefix}_outbox");
         var inboxPath = CreateTempFilePath($"{prefix}_handler_inbox");
         var readModelPath = CreateTempFilePath($"{prefix}_order_read_model");
+        var positionReadModelPath = CreateTempFilePath($"{prefix}_position_read_model");
 
         builder.Register(_ => new JsonDomainEventOutbox(outboxPath, transactionCoordinator))
             .As<IDomainEventOutbox>()
@@ -84,6 +85,12 @@ public class InfrastructureTestFixture : IDisposable
         builder.Register(_ => new JsonOrderReadModel(readModelPath))
             .As<IOrderReadModel>()
             .As<IOrderReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ => new JsonPositionReadModel(positionReadModelPath))
+            .As<IPositionReadModel>()
+            .As<IPositionReadModelProjectionWriter>()
             .AsSelf()
             .SingleInstance();
     }


### PR DESCRIPTION
## Summary
- Adds a durable JSON-backed position read model projected from position domain events.
- Moves position query handlers to the read-side `IPositionReadModel` port instead of the write-side repository.
- Enriches `PositionPartiallyClosed` events with exact remaining state so partial-close projections stay consistent with the aggregate.

## Acceptance Criteria
- Given a position event, when it is dispatched, then it updates a persistent projection.
- Given position queries, when they are handled, then they read from the read model and not `IPositionRepository`.
- Given a restart, when the read model file exists, then queries reload projected state.

## Changes
- `IPositionReadModel` and `PositionReadModelEntry` define the application read-side port.
- `JsonPositionReadModel` persists active/closed position projections and handles open, DCA, partial-close, and close events.
- `PositionReadModelProjectionHandler` wires domain events into the projection writer.
- Position query handlers now map projected read-model entries and still resolve live prices through `IExchangePort` for active positions.
- `PositionPartiallyClosed` carries remaining cost, fees, average price, and entry count for exact projection after FIFO reductions.

## Testing
- Added/updated Application query handler tests for read-model-backed position queries.
- Added Infrastructure projection tests for open+DCA persistence, partial close exactness, and closed-position filtering.
- Added Domain test for partial-close event remaining-state snapshot.
- Verified with `dotnet test IntelliTrader.sln --no-restore`.

## Checklist
- [x] Tests pass
- [x] Coverage maintained
- [x] Linter clean
- [x] Documentation updated (not user-facing)
