### PR TITLE
feat(cqrs): add projected portfolio read model

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/IPortfolioReadModel.cs
+++ b/IntelliTrader.Application/Ports/Driven/IPortfolioReadModel.cs
@@ -1,0 +1,47 @@
+using IntelliTrader.Domain.Trading.ValueObjects;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Read-side port for portfolio query models.
+/// </summary>
+public interface IPortfolioReadModel
+{
+    Task<PortfolioReadModelEntry?> GetByIdAsync(
+        PortfolioId id,
+        CancellationToken cancellationToken = default);
+
+    Task<PortfolioReadModelEntry?> GetByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default);
+
+    Task<PortfolioReadModelEntry?> GetDefaultAsync(
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record PortfolioReadModelEntry
+{
+    public required PortfolioId Id { get; init; }
+    public required string Name { get; init; }
+    public required string Market { get; init; }
+    public required Money TotalBalance { get; init; }
+    public required Money AvailableBalance { get; init; }
+    public required Money ReservedBalance { get; init; }
+    public required int ActivePositionCount { get; init; }
+    public required int MaxPositions { get; init; }
+    public required Money MinPositionCost { get; init; }
+    public required Money InvestedBalance { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? LastUpdatedAt { get; init; }
+    public bool IsDefault { get; init; }
+
+    public bool CanOpenNewPosition => ActivePositionCount < MaxPositions && AvailableBalance >= MinPositionCost;
+
+    public decimal AvailablePercentage => TotalBalance.IsZero
+        ? 0m
+        : AvailableBalance.Amount / TotalBalance.Amount * 100m;
+
+    public decimal ReservedPercentage => TotalBalance.IsZero
+        ? 0m
+        : ReservedBalance.Amount / TotalBalance.Amount * 100m;
+}

--- a/IntelliTrader.Application/Trading/Handlers/PortfolioQueryHandlers.cs
+++ b/IntelliTrader.Application/Trading/Handlers/PortfolioQueryHandlers.cs
@@ -1,7 +1,6 @@
 using IntelliTrader.Application.Common;
 using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.ValueObjects;
 
 namespace IntelliTrader.Application.Trading.Handlers;
@@ -11,11 +10,11 @@ namespace IntelliTrader.Application.Trading.Handlers;
 /// </summary>
 public sealed class GetPortfolioHandler : IQueryHandler<GetPortfolioQuery, PortfolioView>
 {
-    private readonly IPortfolioRepository _portfolioRepository;
+    private readonly IPortfolioReadModel _portfolioReadModel;
 
-    public GetPortfolioHandler(IPortfolioRepository portfolioRepository)
+    public GetPortfolioHandler(IPortfolioReadModel portfolioReadModel)
     {
-        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
+        _portfolioReadModel = portfolioReadModel ?? throw new ArgumentNullException(nameof(portfolioReadModel));
     }
 
     public async Task<Result<PortfolioView>> HandleAsync(
@@ -34,24 +33,24 @@ public sealed class GetPortfolioHandler : IQueryHandler<GetPortfolioQuery, Portf
         return Result<PortfolioView>.Success(Map(portfolio));
     }
 
-    private Task<Portfolio?> ResolvePortfolioAsync(
+    private Task<PortfolioReadModelEntry?> ResolvePortfolioAsync(
         GetPortfolioQuery query,
         CancellationToken cancellationToken)
     {
         if (query.PortfolioId is not null)
         {
-            return _portfolioRepository.GetByIdAsync(query.PortfolioId, cancellationToken);
+            return _portfolioReadModel.GetByIdAsync(query.PortfolioId, cancellationToken);
         }
 
         if (!string.IsNullOrWhiteSpace(query.Name))
         {
-            return _portfolioRepository.GetByNameAsync(query.Name, cancellationToken);
+            return _portfolioReadModel.GetByNameAsync(query.Name, cancellationToken);
         }
 
-        return _portfolioRepository.GetDefaultAsync(cancellationToken);
+        return _portfolioReadModel.GetDefaultAsync(cancellationToken);
     }
 
-    internal static PortfolioView Map(Portfolio portfolio)
+    internal static PortfolioView Map(PortfolioReadModelEntry portfolio)
     {
         ArgumentNullException.ThrowIfNull(portfolio);
 
@@ -60,17 +59,17 @@ public sealed class GetPortfolioHandler : IQueryHandler<GetPortfolioQuery, Portf
             Id = portfolio.Id,
             Name = portfolio.Name,
             Market = portfolio.Market,
-            TotalBalance = portfolio.Balance.Total,
-            AvailableBalance = portfolio.Balance.Available,
-            ReservedBalance = portfolio.Balance.Reserved,
+            TotalBalance = portfolio.TotalBalance,
+            AvailableBalance = portfolio.AvailableBalance,
+            ReservedBalance = portfolio.ReservedBalance,
             ActivePositionCount = portfolio.ActivePositionCount,
             MaxPositions = portfolio.MaxPositions,
             MinPositionCost = portfolio.MinPositionCost,
             CanOpenNewPosition = portfolio.CanOpenNewPosition,
-            AvailablePercentage = portfolio.Balance.AvailablePercentage,
-            ReservedPercentage = portfolio.Balance.ReservedPercentage,
+            AvailablePercentage = portfolio.AvailablePercentage,
+            ReservedPercentage = portfolio.ReservedPercentage,
             CreatedAt = portfolio.CreatedAt,
-            LastUpdatedAt = null
+            LastUpdatedAt = portfolio.LastUpdatedAt
         };
     }
 }
@@ -80,17 +79,17 @@ public sealed class GetPortfolioHandler : IQueryHandler<GetPortfolioQuery, Portf
 /// </summary>
 public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioStatisticsQuery, PortfolioStatistics>
 {
-    private readonly IPortfolioRepository _portfolioRepository;
-    private readonly IPositionRepository _positionRepository;
+    private readonly IPortfolioReadModel _portfolioReadModel;
+    private readonly IPositionReadModel _positionReadModel;
     private readonly IExchangePort _exchangePort;
 
     public GetPortfolioStatisticsHandler(
-        IPortfolioRepository portfolioRepository,
-        IPositionRepository positionRepository,
+        IPortfolioReadModel portfolioReadModel,
+        IPositionReadModel positionReadModel,
         IExchangePort exchangePort)
     {
-        _portfolioRepository = portfolioRepository ?? throw new ArgumentNullException(nameof(portfolioRepository));
-        _positionRepository = positionRepository ?? throw new ArgumentNullException(nameof(positionRepository));
+        _portfolioReadModel = portfolioReadModel ?? throw new ArgumentNullException(nameof(portfolioReadModel));
+        _positionReadModel = positionReadModel ?? throw new ArgumentNullException(nameof(positionReadModel));
         _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
     }
 
@@ -109,8 +108,8 @@ public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioSt
         }
 
         var portfolio = query.PortfolioId is not null
-            ? await _portfolioRepository.GetByIdAsync(query.PortfolioId, cancellationToken)
-            : await _portfolioRepository.GetDefaultAsync(cancellationToken);
+            ? await _portfolioReadModel.GetByIdAsync(query.PortfolioId, cancellationToken)
+            : await _portfolioReadModel.GetDefaultAsync(cancellationToken);
 
         if (portfolio is null)
         {
@@ -118,8 +117,13 @@ public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioSt
             return Result<PortfolioStatistics>.Failure(Error.NotFound("Portfolio", id));
         }
 
-        var activePositions = await _positionRepository.GetAllActiveAsync(cancellationToken);
-        var closedPositions = await _positionRepository.GetClosedPositionsAsync(from, to, cancellationToken);
+        var activePositions = await _positionReadModel.GetActiveAsync(portfolio.Market, cancellationToken);
+        var closedPositions = await _positionReadModel.GetClosedAsync(
+            from,
+            to,
+            pair: null,
+            limit: int.MaxValue,
+            cancellationToken);
         var activeSnapshots = new List<PositionSnapshot>(activePositions.Count);
 
         foreach (var position in activePositions)
@@ -142,15 +146,15 @@ public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioSt
             : Margin.Calculate(totalCostBasis, totalCurrentValue.Amount);
         var winningSnapshots = activeSnapshots.Where(snapshot => snapshot.Margin.IsProfit).ToList();
         var losingSnapshots = activeSnapshots.Where(snapshot => snapshot.Margin.IsLoss).ToList();
-        var totalTrades = activePositions.Sum(position => position.Entries.Count) + closedPositions.Count;
+        var totalTrades = activePositions.Sum(position => position.EntryCount) + closedPositions.Count;
         var averageHoldingPeriod = CalculateAverageHoldingPeriod(activePositions, closedPositions);
 
         return Result<PortfolioStatistics>.Success(new PortfolioStatistics
         {
             PortfolioId = portfolio.Id,
-            TotalBalance = portfolio.Balance.Total,
-            AvailableBalance = portfolio.Balance.Available,
-            InvestedBalance = portfolio.GetTotalInvestedCost(),
+            TotalBalance = portfolio.TotalBalance,
+            AvailableBalance = portfolio.AvailableBalance,
+            InvestedBalance = portfolio.InvestedBalance,
             ActivePositions = portfolio.ActivePositionCount,
             MaxPositions = portfolio.MaxPositions,
             PositionSlotsAvailable = Math.Max(0, portfolio.MaxPositions - portfolio.ActivePositionCount),
@@ -188,8 +192,8 @@ public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioSt
     }
 
     private static TimeSpan CalculateAverageHoldingPeriod(
-        IReadOnlyCollection<Position> activePositions,
-        IReadOnlyCollection<Position> closedPositions)
+        IReadOnlyCollection<PositionReadModelEntry> activePositions,
+        IReadOnlyCollection<PositionReadModelEntry> closedPositions)
     {
         var periods = activePositions
             .Select(position => DateTimeOffset.UtcNow - position.OpenedAt)
@@ -226,13 +230,22 @@ public sealed class GetPortfolioStatisticsHandler : IQueryHandler<GetPortfolioSt
         Money CostBasis,
         Margin Margin)
     {
-        public static PositionSnapshot Create(Position position, Price currentPrice)
+        public static PositionSnapshot Create(PositionReadModelEntry position, Price currentPrice)
         {
+            var currentValue = Money.Create(
+                currentPrice.Value * position.TotalQuantity.Value,
+                position.TotalCost.Currency);
+            var costBasis = position.TotalCost + position.TotalFees;
+            var unrealizedPnL = currentValue - costBasis;
+            var margin = costBasis.Amount == 0m
+                ? Margin.Zero
+                : Margin.Calculate(costBasis.Amount, currentValue.Amount);
+
             return new PositionSnapshot(
-                position.CalculateCurrentValue(currentPrice),
-                position.CalculateUnrealizedPnL(currentPrice),
-                position.TotalCost + position.TotalFees,
-                position.CalculateMargin(currentPrice));
+                currentValue,
+                unrealizedPnL,
+                costBasis,
+                margin);
         }
     }
 }

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/IPortfolioReadModelProjectionWriter.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/IPortfolioReadModelProjectionWriter.cs
@@ -1,0 +1,12 @@
+using IntelliTrader.Domain.Trading.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public interface IPortfolioReadModelProjectionWriter
+{
+    Task ProjectAsync(PositionAddedToPortfolio domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(PositionRemovedFromPortfolio domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(PortfolioBalanceChanged domainEvent, CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonPortfolioReadModel.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonPortfolioReadModel.cs
@@ -1,0 +1,394 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Events;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+/// <summary>
+/// Durable read-side projection for portfolio queries.
+/// </summary>
+public sealed class JsonPortfolioReadModel : IPortfolioReadModel, IPortfolioReadModelProjectionWriter, IDisposable
+{
+    private readonly string _filePath;
+    private readonly string? _legacyPortfolioFilePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private ConcurrentDictionary<string, PortfolioReadModelDto> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonPortfolioReadModel(string filePath, string? legacyPortfolioFilePath = null)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+
+        _filePath = filePath;
+        _legacyPortfolioFilePath = legacyPortfolioFilePath;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<PortfolioReadModelEntry?> GetByIdAsync(
+        PortfolioId id,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.TryGetValue(id.ToString(), out var dto) ? MapEntry(dto) : null;
+    }
+
+    public async Task<PortfolioReadModelEntry?> GetByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be null or empty.", nameof(name));
+
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.Values
+            .FirstOrDefault(dto => dto.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) is { } dto
+            ? MapEntry(dto)
+            : null;
+    }
+
+    public async Task<PortfolioReadModelEntry?> GetDefaultAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        return _cache.Values
+            .OrderByDescending(dto => dto.IsDefault)
+            .ThenBy(dto => dto.CreatedAt)
+            .Select(MapEntry)
+            .FirstOrDefault();
+    }
+
+    public Task ProjectAsync(PositionAddedToPortfolio domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var dto = GetOrCreate(cache, domainEvent.PortfolioId, domainEvent.Cost.Currency, domainEvent.OccurredAt);
+            dto.ActivePositions[domainEvent.PositionId.ToString()] = new ActivePositionReadModelDto
+            {
+                PositionId = domainEvent.PositionId.ToString(),
+                Pair = domainEvent.Pair.Symbol,
+                QuoteCurrency = domainEvent.Pair.QuoteCurrency
+            };
+            dto.PositionCosts[domainEvent.PositionId.ToString()] = domainEvent.Cost.Amount;
+            dto.ActivePositionCount = domainEvent.ActivePositionCount;
+            dto.ReservedBalance = Math.Max(dto.ReservedBalance, SumPositionCosts(dto));
+            dto.AvailableBalance = Math.Max(0m, dto.TotalBalance - dto.ReservedBalance);
+            dto.LastUpdatedAt = domainEvent.OccurredAt;
+
+            cache[dto.Id] = dto;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(PositionRemovedFromPortfolio domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var dto = GetOrCreate(cache, domainEvent.PortfolioId, domainEvent.Proceeds.Currency, domainEvent.OccurredAt);
+            dto.ActivePositions.Remove(domainEvent.PositionId.ToString());
+            dto.PositionCosts.Remove(domainEvent.PositionId.ToString());
+            dto.ActivePositionCount = domainEvent.ActivePositionCount;
+            dto.ReservedBalance = SumPositionCosts(dto);
+            dto.AvailableBalance = Math.Max(0m, dto.TotalBalance - dto.ReservedBalance);
+            dto.LastUpdatedAt = domainEvent.OccurredAt;
+
+            cache[dto.Id] = dto;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(PortfolioBalanceChanged domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(cache =>
+        {
+            var dto = GetOrCreate(cache, domainEvent.PortfolioId, domainEvent.NewTotal.Currency, domainEvent.OccurredAt);
+            dto.Market = domainEvent.NewTotal.Currency;
+            dto.TotalBalance = domainEvent.NewTotal.Amount;
+            dto.AvailableBalance = domainEvent.NewAvailable.Amount;
+            dto.ReservedBalance = Math.Max(0m, domainEvent.NewTotal.Amount - domainEvent.NewAvailable.Amount);
+            dto.LastUpdatedAt = domainEvent.OccurredAt;
+
+            cache[dto.Id] = dto;
+        }, cancellationToken);
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task MutateAsync(
+        Action<ConcurrentDictionary<string, PortfolioReadModelDto>> mutate,
+        CancellationToken cancellationToken)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            mutate(_cache);
+            await PersistCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        if (await TryLoadProjectionAsync(cancellationToken).ConfigureAwait(false))
+        {
+            _cacheLoaded = true;
+            return;
+        }
+
+        if (await TryBootstrapFromLegacyPortfoliosAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await PersistCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+            _cacheLoaded = true;
+            return;
+        }
+
+        _cache = new ConcurrentDictionary<string, PortfolioReadModelDto>(StringComparer.OrdinalIgnoreCase);
+        _cacheLoaded = true;
+    }
+
+    private async Task<bool> TryLoadProjectionAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return false;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<PortfolioReadModelDto>>(json, _jsonOptions)
+                   ?? new List<PortfolioReadModelDto>();
+        if (dtos.Count == 0)
+        {
+            return false;
+        }
+
+        _cache = new ConcurrentDictionary<string, PortfolioReadModelDto>(
+            dtos.ToDictionary(dto => dto.Id, StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+        return true;
+    }
+
+    private async Task<bool> TryBootstrapFromLegacyPortfoliosAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_legacyPortfolioFilePath) || !File.Exists(_legacyPortfolioFilePath))
+        {
+            return false;
+        }
+
+        var json = await File.ReadAllTextAsync(_legacyPortfolioFilePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        var portfolios = JsonSerializer.Deserialize<List<PortfolioDto>>(json, _jsonOptions)
+                         ?? new List<PortfolioDto>();
+        if (portfolios.Count == 0)
+        {
+            return false;
+        }
+
+        if (!portfolios.Any(portfolio => portfolio.IsDefault))
+        {
+            portfolios.OrderBy(portfolio => portfolio.CreatedAt).First().IsDefault = true;
+        }
+
+        _cache = new ConcurrentDictionary<string, PortfolioReadModelDto>(
+            portfolios.Select(MapLegacyPortfolioDto)
+                .ToDictionary(dto => dto.Id, StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+        return true;
+    }
+
+    private async Task PersistCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var dtos = _cache.Values
+            .OrderByDescending(dto => dto.IsDefault)
+            .ThenBy(dto => dto.CreatedAt)
+            .ToList();
+        var json = JsonSerializer.Serialize(dtos, _jsonOptions);
+        await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static PortfolioReadModelDto GetOrCreate(
+        ConcurrentDictionary<string, PortfolioReadModelDto> cache,
+        PortfolioId id,
+        string market,
+        DateTimeOffset occurredAt)
+    {
+        return cache.GetValueOrDefault(id.ToString()) ?? new PortfolioReadModelDto
+        {
+            Id = id.ToString(),
+            Name = cache.IsEmpty ? "Default" : id.ToString(),
+            Market = market,
+            MaxPositions = 1,
+            CreatedAt = occurredAt,
+            IsDefault = cache.IsEmpty
+        };
+    }
+
+    private static PortfolioReadModelEntry MapEntry(PortfolioReadModelDto dto)
+    {
+        var market = ResolveMarket(dto.Market);
+
+        return new PortfolioReadModelEntry
+        {
+            Id = PortfolioId.From(dto.Id),
+            Name = dto.Name,
+            Market = market,
+            TotalBalance = Money.Create(dto.TotalBalance, market),
+            AvailableBalance = Money.Create(dto.AvailableBalance, market),
+            ReservedBalance = Money.Create(dto.ReservedBalance, market),
+            ActivePositionCount = dto.ActivePositionCount,
+            MaxPositions = dto.MaxPositions <= 0 ? 1 : dto.MaxPositions,
+            MinPositionCost = Money.Create(dto.MinPositionCost, market),
+            InvestedBalance = Money.Create(dto.ReservedBalance, market),
+            CreatedAt = dto.CreatedAt,
+            LastUpdatedAt = dto.LastUpdatedAt,
+            IsDefault = dto.IsDefault
+        };
+    }
+
+    private static PortfolioReadModelDto MapLegacyPortfolioDto(PortfolioDto dto)
+    {
+        return new PortfolioReadModelDto
+        {
+            Id = dto.Id.ToString(),
+            Name = dto.Name,
+            Market = ResolveMarket(dto.Market),
+            TotalBalance = dto.Balance.Total,
+            AvailableBalance = dto.Balance.Available,
+            ReservedBalance = dto.Balance.Reserved,
+            ActivePositionCount = dto.ActivePositions.Count,
+            MaxPositions = dto.MaxPositions,
+            MinPositionCost = dto.MinPositionCost,
+            CreatedAt = dto.CreatedAt,
+            IsDefault = dto.IsDefault,
+            ActivePositions = dto.ActivePositions.ToDictionary(
+                active => active.PositionId.ToString(),
+                active => new ActivePositionReadModelDto
+                {
+                    PositionId = active.PositionId.ToString(),
+                    Pair = active.Pair.Symbol,
+                    QuoteCurrency = active.Pair.QuoteCurrency
+                },
+                StringComparer.OrdinalIgnoreCase),
+            PositionCosts = dto.PositionCosts.ToDictionary(
+                cost => cost.PositionId.ToString(),
+                cost => cost.Amount,
+                StringComparer.OrdinalIgnoreCase)
+        };
+    }
+
+    private static decimal SumPositionCosts(PortfolioReadModelDto dto)
+    {
+        return dto.PositionCosts.Values.Sum();
+    }
+
+    private static string ResolveMarket(string? market)
+    {
+        return string.IsNullOrWhiteSpace(market) ? "USDT" : market.ToUpperInvariant();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+
+    private sealed class PortfolioReadModelDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Market { get; set; } = "USDT";
+        public decimal TotalBalance { get; set; }
+        public decimal AvailableBalance { get; set; }
+        public decimal ReservedBalance { get; set; }
+        public int ActivePositionCount { get; set; }
+        public int MaxPositions { get; set; }
+        public decimal MinPositionCost { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset? LastUpdatedAt { get; set; }
+        public bool IsDefault { get; set; }
+        public Dictionary<string, ActivePositionReadModelDto> ActivePositions { get; set; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, decimal> PositionCosts { get; set; } =
+            new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private sealed class ActivePositionReadModelDto
+    {
+        public string PositionId { get; set; } = string.Empty;
+        public string Pair { get; set; } = string.Empty;
+        public string QuoteCurrency { get; set; } = string.Empty;
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/PortfolioReadModelProjectionHandler.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/PortfolioReadModelProjectionHandler.cs
@@ -1,0 +1,32 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Trading.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public sealed class PortfolioReadModelProjectionHandler :
+    IDomainEventHandler<PositionAddedToPortfolio>,
+    IDomainEventHandler<PositionRemovedFromPortfolio>,
+    IDomainEventHandler<PortfolioBalanceChanged>
+{
+    private readonly IPortfolioReadModelProjectionWriter _projectionWriter;
+
+    public PortfolioReadModelProjectionHandler(IPortfolioReadModelProjectionWriter projectionWriter)
+    {
+        _projectionWriter = projectionWriter ?? throw new ArgumentNullException(nameof(projectionWriter));
+    }
+
+    public Task HandleAsync(PositionAddedToPortfolio domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(PositionRemovedFromPortfolio domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(PortfolioBalanceChanged domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -123,6 +123,15 @@ public class AppModule : Module
             .SingleInstance();
 
         builder.Register(_ =>
+            new JsonPortfolioReadModel(
+                CreateDataFilePath("portfolio-read-model.json"),
+                CreateDataFilePath("portfolios.json")))
+            .As<IPortfolioReadModel>()
+            .As<IPortfolioReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
             new JsonOrderRepository(CreateDataFilePath("orders.json"), _.Resolve<JsonTransactionCoordinator>()))
             .As<IOrderRepository>()
             .AsSelf()

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioQueryHandlerTests.cs
@@ -1,9 +1,8 @@
-using IntelliTrader.Application.Common;
 using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
 using IntelliTrader.Application.Trading.Handlers;
 using IntelliTrader.Application.Trading.Queries;
-using IntelliTrader.Application.Ports.Driven;
-using IntelliTrader.Domain.Trading.Aggregates;
 using IntelliTrader.Domain.Trading.ValueObjects;
 using Moq;
 
@@ -11,24 +10,25 @@ namespace IntelliTrader.Application.Tests.Trading.Handlers;
 
 public sealed class PortfolioQueryHandlerTests
 {
-    private readonly Mock<IPortfolioRepository> _portfolioRepositoryMock = new();
-    private readonly Mock<IPositionRepository> _positionRepositoryMock = new();
+    private readonly Mock<IPortfolioReadModel> _portfolioReadModelMock = new();
+    private readonly Mock<IPositionReadModel> _positionReadModelMock = new();
     private readonly Mock<IExchangePort> _exchangePortMock = new();
 
     [Fact]
-    public async Task GetPortfolio_WithDefaultPortfolio_ReturnsMappedBalances()
+    public async Task GetPortfolio_WithDefaultPortfolio_ReturnsMappedReadModelBalances()
     {
-        var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var positionId = PositionId.Create();
-        var portfolio = Portfolio.Create("Default", "USDT", 10000m, 5, 100m);
-        portfolio.RecordPositionOpened(positionId, pair, Money.Create(1000m, "USDT"));
-        portfolio.ClearDomainEvents();
+        var portfolio = CreatePortfolioEntry(
+            total: 10000m,
+            available: 9000m,
+            reserved: 1000m,
+            activePositions: 1,
+            invested: 1000m);
 
-        _portfolioRepositoryMock
+        _portfolioReadModelMock
             .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(portfolio);
 
-        var handler = new GetPortfolioHandler(_portfolioRepositoryMock.Object);
+        var handler = new GetPortfolioHandler(_portfolioReadModelMock.Object);
 
         var result = await handler.HandleAsync(new GetPortfolioQuery());
 
@@ -42,17 +42,17 @@ public sealed class PortfolioQueryHandlerTests
         result.Value.CanOpenNewPosition.Should().BeTrue();
         result.Value.AvailablePercentage.Should().Be(90m);
         result.Value.ReservedPercentage.Should().Be(10m);
-        result.Value.LastUpdatedAt.Should().BeNull();
+        result.Value.LastUpdatedAt.Should().Be(portfolio.LastUpdatedAt);
     }
 
     [Fact]
     public async Task GetPortfolio_WithMissingNamedPortfolio_ReturnsNotFound()
     {
-        _portfolioRepositoryMock
+        _portfolioReadModelMock
             .Setup(x => x.GetByNameAsync("Missing", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Portfolio?)null);
+            .ReturnsAsync((PortfolioReadModelEntry?)null);
 
-        var handler = new GetPortfolioHandler(_portfolioRepositoryMock.Object);
+        var handler = new GetPortfolioHandler(_portfolioReadModelMock.Object);
 
         var result = await handler.HandleAsync(new GetPortfolioQuery { Name = "Missing" });
 
@@ -62,39 +62,38 @@ public sealed class PortfolioQueryHandlerTests
     }
 
     [Fact]
-    public async Task GetPortfolioStatistics_WithActivePositions_ReturnsCurrentPortfolioMetrics()
+    public async Task GetPortfolioStatistics_WithActivePositions_ReturnsCurrentPortfolioMetricsFromReadModels()
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
-        var position = Position.Open(
-            pair,
-            OrderId.From("order-btc-1"),
-            Price.Create(50000m),
-            Quantity.Create(0.02m),
-            Money.Create(1m, "USDT"));
-        portfolio.RecordPositionOpened(position.Id, pair, Money.Create(1000m, "USDT"));
-        portfolio.ClearDomainEvents();
-        position.ClearDomainEvents();
+        var portfolio = CreatePortfolioEntry(
+            total: 5000m,
+            available: 4000m,
+            reserved: 1000m,
+            activePositions: 1,
+            invested: 1000m);
+        var position = CreatePositionEntry(pair, price: 50000m, quantity: 0.02m, fees: 1m);
 
-        _portfolioRepositoryMock
+        _portfolioReadModelMock
             .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(portfolio);
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { position });
-        _positionRepositoryMock
-            .Setup(x => x.GetClosedPositionsAsync(
+        _positionReadModelMock
+            .Setup(x => x.GetClosedAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
+                null,
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<Position>());
+            .ReturnsAsync(Array.Empty<PositionReadModelEntry>());
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Success(Price.Create(55000m)));
 
         var handler = new GetPortfolioStatisticsHandler(
-            _portfolioRepositoryMock.Object,
-            _positionRepositoryMock.Object,
+            _portfolioReadModelMock.Object,
+            _positionReadModelMock.Object,
             _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
@@ -117,13 +116,13 @@ public sealed class PortfolioQueryHandlerTests
     [Fact]
     public async Task GetPortfolioStatistics_WhenPortfolioMissing_ReturnsNotFound()
     {
-        _portfolioRepositoryMock
+        _portfolioReadModelMock
             .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Portfolio?)null);
+            .ReturnsAsync((PortfolioReadModelEntry?)null);
 
         var handler = new GetPortfolioStatisticsHandler(
-            _portfolioRepositoryMock.Object,
-            _positionRepositoryMock.Object,
+            _portfolioReadModelMock.Object,
+            _positionReadModelMock.Object,
             _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
@@ -136,33 +135,77 @@ public sealed class PortfolioQueryHandlerTests
     public async Task GetPortfolioStatistics_WhenPriceLookupFails_ReturnsFailure()
     {
         var pair = TradingPair.Create("BTCUSDT", "USDT");
-        var portfolio = Portfolio.Create("Default", "USDT", 5000m, 5, 100m);
-        var position = Position.Open(
-            pair,
-            OrderId.From("order-btc-1"),
-            Price.Create(50000m),
-            Quantity.Create(0.02m),
-            Money.Create(1m, "USDT"));
-        position.ClearDomainEvents();
+        var portfolio = CreatePortfolioEntry(
+            total: 5000m,
+            available: 4000m,
+            reserved: 1000m,
+            activePositions: 1,
+            invested: 1000m);
+        var position = CreatePositionEntry(pair, price: 50000m, quantity: 0.02m, fees: 1m);
 
-        _portfolioRepositoryMock
+        _portfolioReadModelMock
             .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(portfolio);
-        _positionRepositoryMock
-            .Setup(x => x.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { position });
         _exchangePortMock
             .Setup(x => x.GetCurrentPriceAsync(pair, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<Price>.Failure(Error.ExchangeError("price unavailable")));
 
         var handler = new GetPortfolioStatisticsHandler(
-            _portfolioRepositoryMock.Object,
-            _positionRepositoryMock.Object,
+            _portfolioReadModelMock.Object,
+            _positionReadModelMock.Object,
             _exchangePortMock.Object);
 
         var result = await handler.HandleAsync(new GetPortfolioStatisticsQuery());
 
         result.IsFailure.Should().BeTrue();
         result.Error.Message.Should().Contain("price unavailable");
+    }
+
+    private static PortfolioReadModelEntry CreatePortfolioEntry(
+        decimal total,
+        decimal available,
+        decimal reserved,
+        int activePositions,
+        decimal invested)
+    {
+        return new PortfolioReadModelEntry
+        {
+            Id = PortfolioId.Create(),
+            Name = "Default",
+            Market = "USDT",
+            TotalBalance = Money.Create(total, "USDT"),
+            AvailableBalance = Money.Create(available, "USDT"),
+            ReservedBalance = Money.Create(reserved, "USDT"),
+            ActivePositionCount = activePositions,
+            MaxPositions = 5,
+            MinPositionCost = Money.Create(100m, "USDT"),
+            InvestedBalance = Money.Create(invested, "USDT"),
+            CreatedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z"),
+            LastUpdatedAt = DateTimeOffset.Parse("2026-04-26T10:30:00Z"),
+            IsDefault = true
+        };
+    }
+
+    private static PositionReadModelEntry CreatePositionEntry(
+        TradingPair pair,
+        decimal price,
+        decimal quantity,
+        decimal fees)
+    {
+        return new PositionReadModelEntry
+        {
+            Id = PositionId.Create(),
+            Pair = pair,
+            AveragePrice = Price.Create(price),
+            TotalQuantity = Quantity.Create(quantity),
+            TotalCost = Money.Create(price * quantity, pair.QuoteCurrency),
+            TotalFees = Money.Create(fees, pair.QuoteCurrency),
+            DCALevel = 0,
+            EntryCount = 1,
+            OpenedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z")
+        };
     }
 }

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/PortfolioReadModelProjectionTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/PortfolioReadModelProjectionTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Domain.Trading.Aggregates;
+using IntelliTrader.Domain.Trading.Events;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using IntelliTrader.Infrastructure.Adapters.Persistence.Json;
+using IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+using IntelliTrader.Infrastructure.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class PortfolioReadModelProjectionTests
+{
+    [Fact]
+    public async Task GetDefaultAsync_WhenProjectionIsEmpty_BootstrapsFromLegacyPortfolioJsonAndPersistsReadModel()
+    {
+        var portfolioPath = CreateReadModelPath("portfolios");
+        var readModelPath = CreateReadModelPath("portfolio_read_model");
+        using var repository = new JsonPortfolioRepository(portfolioPath);
+        var portfolio = Portfolio.Create("Default", "USDT", 10000m, 5, 100m);
+        portfolio.RecordPositionOpened(
+            PositionId.Create(),
+            TradingPair.Create("BTCUSDT", "USDT"),
+            Money.Create(1000m, "USDT"));
+        portfolio.ClearDomainEvents();
+        await repository.SaveAsync(portfolio);
+
+        try
+        {
+            using var readModel = new JsonPortfolioReadModel(readModelPath, portfolioPath);
+
+            var projected = await readModel.GetDefaultAsync();
+
+            projected.Should().NotBeNull();
+            projected!.Id.Should().Be(portfolio.Id);
+            projected.Name.Should().Be("Default");
+            projected.TotalBalance.Amount.Should().Be(10000m);
+            projected.AvailableBalance.Amount.Should().Be(9000m);
+            projected.ReservedBalance.Amount.Should().Be(1000m);
+            projected.ActivePositionCount.Should().Be(1);
+            projected.InvestedBalance.Amount.Should().Be(1000m);
+
+            using var reloaded = new JsonPortfolioReadModel(readModelPath);
+            var reloadedDefault = await reloaded.GetDefaultAsync();
+            reloadedDefault.Should().NotBeNull();
+            reloadedDefault!.ActivePositionCount.Should().Be(1);
+            reloadedDefault.InvestedBalance.Amount.Should().Be(1000m);
+        }
+        finally
+        {
+            DeleteFileIfExists(portfolioPath);
+            DeleteFileIfExists(readModelPath);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchManyAsync_WhenPortfolioEventsArePublished_ProjectsBalancesAndActiveCounts()
+    {
+        var portfolioPath = CreateReadModelPath("portfolios");
+        var readModelPath = CreateReadModelPath("portfolio_read_model");
+        using var repository = new JsonPortfolioRepository(portfolioPath);
+        var portfolio = Portfolio.Create("Default", "USDT", 10000m, 5, 100m);
+        await repository.SaveAsync(portfolio);
+        using var readModel = new JsonPortfolioReadModel(readModelPath, portfolioPath);
+        var handler = new PortfolioReadModelProjectionHandler(readModel);
+        var dispatcher = CreateDispatcher(handler);
+        var positionId = PositionId.Create();
+        var pair = TradingPair.Create("ETHUSDT", "USDT");
+
+        portfolio.RecordPositionOpened(positionId, pair, Money.Create(1000m, "USDT"));
+        var openedEvents = portfolio.DomainEvents.ToList();
+        portfolio.ClearDomainEvents();
+
+        portfolio.RecordPositionCostIncreased(positionId, pair, Money.Create(500m, "USDT"));
+        var dcaEvents = portfolio.DomainEvents.ToList();
+        portfolio.ClearDomainEvents();
+
+        portfolio.RecordPositionClosed(positionId, pair, Money.Create(1800m, "USDT"));
+        var closedEvents = portfolio.DomainEvents.ToList();
+
+        try
+        {
+            await dispatcher.DispatchManyAsync(openedEvents.Concat(dcaEvents).Concat(closedEvents));
+
+            var projected = await readModel.GetDefaultAsync();
+            projected.Should().NotBeNull();
+            projected!.TotalBalance.Amount.Should().Be(10300m);
+            projected.AvailableBalance.Amount.Should().Be(10300m);
+            projected.ReservedBalance.Amount.Should().Be(0m);
+            projected.ActivePositionCount.Should().Be(0);
+            projected.InvestedBalance.Amount.Should().Be(0m);
+            projected.LastUpdatedAt.Should().NotBeNull();
+        }
+        finally
+        {
+            DeleteFileIfExists(portfolioPath);
+            DeleteFileIfExists(readModelPath);
+        }
+    }
+
+    private static InMemoryDomainEventDispatcher CreateDispatcher(PortfolioReadModelProjectionHandler handler)
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher(
+            Mock.Of<IServiceProvider>(),
+            NullLogger<InMemoryDomainEventDispatcher>.Instance);
+        dispatcher.RegisterHandler<PositionAddedToPortfolio>(handler);
+        dispatcher.RegisterHandler<PositionRemovedFromPortfolio>(handler);
+        dispatcher.RegisterHandler<PortfolioBalanceChanged>(handler);
+        return dispatcher;
+    }
+
+    private static string CreateReadModelPath(string prefix)
+    {
+        return Path.Combine(Path.GetTempPath(), $"{prefix}_{Guid.NewGuid():N}.json");
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
@@ -65,11 +65,13 @@ public class InfrastructureTestFixture : IDisposable
     public void RegisterIsolatedEventPersistence(
         ContainerBuilder builder,
         JsonTransactionCoordinator transactionCoordinator,
-        string prefix)
+        string prefix,
+        string? portfolioBootstrapPath = null)
     {
         var outboxPath = CreateTempFilePath($"{prefix}_outbox");
         var inboxPath = CreateTempFilePath($"{prefix}_handler_inbox");
         var readModelPath = CreateTempFilePath($"{prefix}_order_read_model");
+        var portfolioReadModelPath = CreateTempFilePath($"{prefix}_portfolio_read_model");
         var positionReadModelPath = CreateTempFilePath($"{prefix}_position_read_model");
 
         builder.Register(_ => new JsonDomainEventOutbox(outboxPath, transactionCoordinator))
@@ -85,6 +87,12 @@ public class InfrastructureTestFixture : IDisposable
         builder.Register(_ => new JsonOrderReadModel(readModelPath))
             .As<IOrderReadModel>()
             .As<IOrderReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ => new JsonPortfolioReadModel(portfolioReadModelPath, portfolioBootstrapPath))
+            .As<IPortfolioReadModel>()
+            .As<IPortfolioReadModelProjectionWriter>()
             .AsSelf()
             .SingleInstance();
 

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OpenPositionCommandDispatchIntegrationTests.cs
@@ -38,7 +38,11 @@ public sealed class OpenPositionCommandDispatchIntegrationTests : IClassFixture<
         var builder = new ContainerBuilder();
         builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
         builder.RegisterInstance(transactionCoordinator).SingleInstance();
-        fixture.RegisterIsolatedEventPersistence(builder, transactionCoordinator, "open_position");
+        fixture.RegisterIsolatedEventPersistence(
+            builder,
+            transactionCoordinator,
+            "open_position",
+            portfoliosPath);
 
         // Test-specific concrete adapters.
         builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
@@ -294,7 +298,11 @@ public sealed class OpenPositionCommandDispatchIntegrationTests : IClassFixture<
         var builder = new ContainerBuilder();
         builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
         builder.RegisterInstance(transactionCoordinator).SingleInstance();
-        _fixture.RegisterIsolatedEventPersistence(builder, transactionCoordinator, "open_position_failure");
+        _fixture.RegisterIsolatedEventPersistence(
+            builder,
+            transactionCoordinator,
+            "open_position_failure",
+            portfoliosPath);
         builder.RegisterInstance(invalidPositionRepository)
             .As<IPositionRepository>()
             .AsSelf()

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderLifecycleCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/OrderLifecycleCommandDispatchIntegrationTests.cs
@@ -31,7 +31,11 @@ public sealed class OrderLifecycleCommandDispatchIntegrationTests : IClassFixtur
         var builder = new ContainerBuilder();
         builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
         builder.RegisterInstance(transactionCoordinator).SingleInstance();
-        fixture.RegisterIsolatedEventPersistence(builder, transactionCoordinator, "order_lifecycle");
+        fixture.RegisterIsolatedEventPersistence(
+            builder,
+            transactionCoordinator,
+            "order_lifecycle",
+            portfoliosPath);
 
         builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
             .As<IPositionRepository>()

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshOrderStatusCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshOrderStatusCommandDispatchIntegrationTests.cs
@@ -31,7 +31,11 @@ public sealed class RefreshOrderStatusCommandDispatchIntegrationTests : IClassFi
         var builder = new ContainerBuilder();
         builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
         builder.RegisterInstance(transactionCoordinator).SingleInstance();
-        fixture.RegisterIsolatedEventPersistence(builder, transactionCoordinator, "refresh_order_status");
+        fixture.RegisterIsolatedEventPersistence(
+            builder,
+            transactionCoordinator,
+            "refresh_order_status",
+            portfoliosPath);
 
         builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
             .As<IPositionRepository>()

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/RefreshSubmittedOrdersCommandDispatchIntegrationTests.cs
@@ -31,7 +31,11 @@ public sealed class RefreshSubmittedOrdersCommandDispatchIntegrationTests : ICla
         var builder = new ContainerBuilder();
         builder.RegisterModule(new IntelliTrader.Infrastructure.AppModule());
         builder.RegisterInstance(transactionCoordinator).SingleInstance();
-        fixture.RegisterIsolatedEventPersistence(builder, transactionCoordinator, "refresh_submitted");
+        fixture.RegisterIsolatedEventPersistence(
+            builder,
+            transactionCoordinator,
+            "refresh_submitted",
+            portfoliosPath);
 
         builder.Register(c => new JsonPositionRepository(positionsPath, transactionCoordinator))
             .As<IPositionRepository>()


### PR DESCRIPTION
## Summary
- Adds a durable portfolio read model projection fed by portfolio lifecycle domain events.
- Moves portfolio query handlers to read from read-side ports instead of write-side repositories.
- Bootstraps the projection from legacy `portfolios.json` so existing deployments can query after restart.

## Acceptance Criteria
- Given portfolio/position lifecycle events, when they are dispatched, then they update a persistent portfolio projection.
- Given portfolio query handlers, when handled, then they read from read models instead of write-side repositories.
- Given restart and an existing read model or legacy portfolio file, when queried, then projected state reloads.

## Changes
- Added `IPortfolioReadModel` and `PortfolioReadModelEntry` in the Application ports.
- Added JSON portfolio projection writer/read model and projection handler in Infrastructure.
- Updated portfolio query/statistics handlers to use portfolio and position read models.
- Updated integration fixtures so command-dispatch flows project portfolio state in isolated test data.

## Testing
- Added portfolio projection tests for legacy bootstrap, persistence reload, and event projection.
- Updated portfolio query handler tests to assert read-model behavior.
- Ran `dotnet test IntelliTrader.sln --no-restore`.

## Checklist
- [x] Tests pass
- [x] Coverage maintained
- [x] Linter clean via `git diff --cached --check`
- [x] Documentation updated: not applicable, internal architecture slice
