### PR TITLE
feat(cqrs): add projected portfolio status query

### DIFF
--- a/IntelliTrader.Application/Ports/Driven/ITradingStateReadModel.cs
+++ b/IntelliTrader.Application/Ports/Driven/ITradingStateReadModel.cs
@@ -1,0 +1,28 @@
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Application.Ports.Driven;
+
+/// <summary>
+/// Read-side port for operational trading state.
+/// </summary>
+public interface ITradingStateReadModel
+{
+    Task<TradingStateReadModelEntry> GetAsync(
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record TradingStateReadModelEntry
+{
+    public static TradingStateReadModelEntry Running => new();
+
+    public bool IsTradingSuspended { get; init; }
+    public SuspensionReason? SuspensionReason { get; init; }
+    public bool IsForcedSuspension { get; init; }
+    public DateTimeOffset? SuspendedAt { get; init; }
+    public DateTimeOffset? ResumedAt { get; init; }
+    public DateTimeOffset? LastChangedAt { get; init; }
+    public int OpenPositionsAtSuspension { get; init; }
+    public int PendingOrdersAtSuspension { get; init; }
+    public string? ChangedBy { get; init; }
+    public string? Details { get; init; }
+}

--- a/IntelliTrader.Application/Trading/Handlers/PortfolioStatusQueryHandler.cs
+++ b/IntelliTrader.Application/Trading/Handlers/PortfolioStatusQueryHandler.cs
@@ -1,0 +1,251 @@
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using StatusOrderSide = IntelliTrader.Application.Trading.Queries.OrderSide;
+using StatusOrderStatus = IntelliTrader.Application.Trading.Queries.OrderStatus;
+
+namespace IntelliTrader.Application.Trading.Handlers;
+
+/// <summary>
+/// Query handler for portfolio status projected from read models.
+/// </summary>
+public sealed class GetPortfolioStatusHandler : IQueryHandler<GetPortfolioStatusQuery, GetPortfolioStatusResult>
+{
+    private readonly IPortfolioReadModel _portfolioReadModel;
+    private readonly IPositionReadModel _positionReadModel;
+    private readonly IOrderReadModel _orderReadModel;
+    private readonly ITradingStateReadModel _tradingStateReadModel;
+    private readonly IExchangePort _exchangePort;
+
+    public GetPortfolioStatusHandler(
+        IPortfolioReadModel portfolioReadModel,
+        IPositionReadModel positionReadModel,
+        IOrderReadModel orderReadModel,
+        ITradingStateReadModel tradingStateReadModel,
+        IExchangePort exchangePort)
+    {
+        _portfolioReadModel = portfolioReadModel ?? throw new ArgumentNullException(nameof(portfolioReadModel));
+        _positionReadModel = positionReadModel ?? throw new ArgumentNullException(nameof(positionReadModel));
+        _orderReadModel = orderReadModel ?? throw new ArgumentNullException(nameof(orderReadModel));
+        _tradingStateReadModel = tradingStateReadModel ?? throw new ArgumentNullException(nameof(tradingStateReadModel));
+        _exchangePort = exchangePort ?? throw new ArgumentNullException(nameof(exchangePort));
+    }
+
+    public async Task<Result<GetPortfolioStatusResult>> HandleAsync(
+        GetPortfolioStatusQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var portfolio = await _portfolioReadModel.GetDefaultAsync(cancellationToken).ConfigureAwait(false);
+        if (portfolio is null)
+        {
+            return Result<GetPortfolioStatusResult>.Failure(Error.NotFound("Portfolio", "default"));
+        }
+
+        var activePositions = await _positionReadModel.GetActiveAsync(
+            portfolio.Market,
+            cancellationToken).ConfigureAwait(false);
+
+        var priceResult = await LoadPricesAsync(activePositions, cancellationToken).ConfigureAwait(false);
+        if (priceResult.IsFailure)
+        {
+            return Result<GetPortfolioStatusResult>.Failure(priceResult.Error);
+        }
+
+        var tradingState = await _tradingStateReadModel.GetAsync(cancellationToken).ConfigureAwait(false);
+        var activeOrders = query.IncludeTrailingOrders
+            ? await _orderReadModel.GetActiveAsync(
+                pair: null,
+                side: null,
+                limit: int.MaxValue,
+                cancellationToken).ConfigureAwait(false)
+            : Array.Empty<OrderView>();
+        var trailingBuys = query.IncludeTrailingOrders ? MapActiveOrderPairs(activeOrders, DomainOrderSide.Buy) : null;
+        var trailingSells = query.IncludeTrailingOrders ? MapActiveOrderPairs(activeOrders, DomainOrderSide.Sell) : null;
+        var trailingSellPairs = trailingSells?.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                                ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var snapshots = activePositions
+            .Select(position => PositionStatusSnapshot.Create(
+                position,
+                priceResult.Value[position.Pair],
+                trailingSellPairs.Contains(position.Pair.Symbol)))
+            .ToList();
+
+        IReadOnlyList<OrderHistoryInfo>? orderHistory = null;
+        if (query.IncludeOrderHistory)
+        {
+            var limit = query.OrderHistoryLimit <= 0 ? 50 : query.OrderHistoryLimit;
+            var recentOrders = await _orderReadModel.GetRecentAsync(
+                pair: null,
+                status: null,
+                side: null,
+                limit,
+                cancellationToken).ConfigureAwait(false);
+            orderHistory = recentOrders.Select(MapOrderHistory).ToList();
+        }
+
+        var currentValue = snapshots.Sum(snapshot => snapshot.CurrentValue.Amount);
+        var unrealizedPnL = snapshots.Sum(snapshot => snapshot.UnrealizedPnL.Amount);
+        var costBasis = snapshots.Sum(snapshot => snapshot.CostBasis.Amount);
+
+        return Result<GetPortfolioStatusResult>.Success(new GetPortfolioStatusResult
+        {
+            Summary = new PortfolioSummary
+            {
+                TotalBalance = portfolio.TotalBalance.Amount,
+                AvailableBalance = portfolio.AvailableBalance.Amount,
+                ReservedBalance = portfolio.ReservedBalance.Amount,
+                CurrentValue = currentValue,
+                UnrealizedPnL = unrealizedPnL,
+                UnrealizedPnLPercent = costBasis == 0m ? 0m : unrealizedPnL / costBasis * 100m,
+                ActivePositionCount = portfolio.ActivePositionCount,
+                TrailingBuyCount = trailingBuys?.Count ?? 0,
+                TrailingSellCount = trailingSells?.Count ?? 0,
+                IsTradingSuspended = tradingState.IsTradingSuspended,
+                Market = portfolio.Market
+            },
+            Positions = query.IncludePositions
+                ? snapshots.Select(snapshot => snapshot.ToPositionInfo()).ToList()
+                : null,
+            TrailingBuys = trailingBuys,
+            TrailingSells = trailingSells,
+            OrderHistory = orderHistory
+        });
+    }
+
+    private async Task<Result<IReadOnlyDictionary<TradingPair, Price>>> LoadPricesAsync(
+        IReadOnlyCollection<PositionReadModelEntry> positions,
+        CancellationToken cancellationToken)
+    {
+        if (positions.Count == 0)
+        {
+            return Result<IReadOnlyDictionary<TradingPair, Price>>.Success(
+                new Dictionary<TradingPair, Price>());
+        }
+
+        var pairs = positions.Select(position => position.Pair).Distinct().ToList();
+        var priceResult = await _exchangePort.GetCurrentPricesAsync(pairs, cancellationToken).ConfigureAwait(false);
+        if (priceResult.IsFailure)
+        {
+            return Result<IReadOnlyDictionary<TradingPair, Price>>.Failure(priceResult.Error);
+        }
+
+        foreach (var pair in pairs)
+        {
+            if (!priceResult.Value.ContainsKey(pair))
+            {
+                return Result<IReadOnlyDictionary<TradingPair, Price>>.Failure(
+                    Error.ExchangeError($"Missing current price for {pair.Symbol}."));
+            }
+        }
+
+        return priceResult;
+    }
+
+    private static OrderHistoryInfo MapOrderHistory(OrderView order)
+    {
+        return new OrderHistoryInfo
+        {
+            OrderId = order.Id.Value,
+            Pair = order.Pair.Symbol,
+            Side = MapSide(order.Side),
+            Status = MapStatus(order.Status),
+            Amount = order.RequestedQuantity.Value,
+            AmountFilled = order.FilledQuantity.Value,
+            Price = order.SubmittedPrice.Value,
+            AveragePrice = order.AveragePrice.Value,
+            TotalCost = order.Cost.Amount,
+            Fees = order.Fees.Amount,
+            Timestamp = order.SubmittedAt,
+            Message = order.SignalRule
+        };
+    }
+
+    private static IReadOnlyList<string> MapActiveOrderPairs(
+        IReadOnlyList<OrderView> activeOrders,
+        DomainOrderSide side)
+    {
+        return activeOrders
+            .Where(order => order.Side == side)
+            .Select(order => order.Pair.Symbol)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(pair => pair, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static StatusOrderSide MapSide(DomainOrderSide side)
+    {
+        return side == DomainOrderSide.Sell ? StatusOrderSide.Sell : StatusOrderSide.Buy;
+    }
+
+    private static StatusOrderStatus MapStatus(OrderLifecycleStatus status)
+    {
+        return status switch
+        {
+            OrderLifecycleStatus.Filled => StatusOrderStatus.Filled,
+            OrderLifecycleStatus.PartiallyFilled => StatusOrderStatus.PartiallyFilled,
+            OrderLifecycleStatus.Canceled => StatusOrderStatus.Canceled,
+            OrderLifecycleStatus.Rejected => StatusOrderStatus.Rejected,
+            OrderLifecycleStatus.Submitted => StatusOrderStatus.Pending,
+            _ => StatusOrderStatus.Unknown
+        };
+    }
+
+    private sealed record PositionStatusSnapshot(
+        PositionReadModelEntry Position,
+        Price CurrentPrice,
+        Money CurrentValue,
+        Money UnrealizedPnL,
+        Money CostBasis,
+        Margin Margin,
+        bool HasTrailingSell)
+    {
+        public static PositionStatusSnapshot Create(
+            PositionReadModelEntry position,
+            Price currentPrice,
+            bool hasTrailingSell)
+        {
+            var currentValue = Money.Create(
+                currentPrice.Value * position.TotalQuantity.Value,
+                position.TotalCost.Currency);
+            var costBasis = position.TotalCost + position.TotalFees;
+            var unrealizedPnL = currentValue - costBasis;
+            var margin = costBasis.Amount == 0m
+                ? Margin.Zero
+                : Margin.Calculate(costBasis.Amount, currentValue.Amount);
+
+            return new PositionStatusSnapshot(
+                position,
+                currentPrice,
+                currentValue,
+                unrealizedPnL,
+                costBasis,
+                margin,
+                hasTrailingSell);
+        }
+
+        public PositionInfo ToPositionInfo()
+        {
+            return new PositionInfo
+            {
+                Pair = Position.Pair.Symbol,
+                Amount = Position.TotalQuantity.Value,
+                TotalCost = Position.TotalCost.Amount,
+                CurrentValue = CurrentValue.Amount,
+                AveragePrice = Position.AveragePrice.Value,
+                CurrentPrice = CurrentPrice.Value,
+                UnrealizedPnL = UnrealizedPnL.Amount,
+                Margin = Margin.Percentage,
+                DCALevel = Position.DCALevel,
+                Age = DateTimeOffset.UtcNow - Position.OpenedAt,
+                OpenedAt = Position.OpenedAt,
+                SignalRule = Position.SignalRule,
+                HasTrailingSell = HasTrailingSell
+            };
+        }
+    }
+}

--- a/IntelliTrader.Application/Trading/Queries/GetPortfolioStatusQuery.cs
+++ b/IntelliTrader.Application/Trading/Queries/GetPortfolioStatusQuery.cs
@@ -1,8 +1,7 @@
 namespace IntelliTrader.Application.Trading.Queries;
 
 /// <summary>
-/// Query to get the current portfolio status from the legacy trading service.
-/// This bridges the Application layer to the legacy service for read operations.
+/// Query to get the current portfolio status from projected read models.
 /// </summary>
 public sealed record GetPortfolioStatusQuery
 {

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/ITradingStateReadModelProjectionWriter.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/ITradingStateReadModelProjectionWriter.cs
@@ -1,0 +1,10 @@
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public interface ITradingStateReadModelProjectionWriter
+{
+    Task ProjectAsync(TradingSuspendedEvent domainEvent, CancellationToken cancellationToken = default);
+
+    Task ProjectAsync(TradingResumedEvent domainEvent, CancellationToken cancellationToken = default);
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonTradingStateReadModel.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/JsonTradingStateReadModel.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+/// <summary>
+/// Durable read-side projection for operational trading state.
+/// </summary>
+public sealed class JsonTradingStateReadModel :
+    ITradingStateReadModel,
+    ITradingStateReadModelProjectionWriter,
+    IDisposable
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private TradingStateReadModelDto _cache = new();
+    private bool _cacheLoaded;
+    private bool _disposed;
+
+    public JsonTradingStateReadModel(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+
+        _filePath = filePath;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<TradingStateReadModelEntry> GetAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+        return MapEntry(_cache);
+    }
+
+    public Task ProjectAsync(TradingSuspendedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(dto =>
+        {
+            dto.IsTradingSuspended = true;
+            dto.SuspensionReason = domainEvent.Reason.ToString();
+            dto.IsForcedSuspension = domainEvent.IsForced;
+            dto.SuspendedAt = domainEvent.OccurredAt;
+            dto.ResumedAt = null;
+            dto.LastChangedAt = domainEvent.OccurredAt;
+            dto.OpenPositionsAtSuspension = domainEvent.OpenPositions;
+            dto.PendingOrdersAtSuspension = domainEvent.PendingOrders;
+            dto.ChangedBy = domainEvent.SuspendedBy;
+            dto.Details = domainEvent.Details;
+        }, cancellationToken);
+    }
+
+    public Task ProjectAsync(TradingResumedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+
+        return MutateAsync(dto =>
+        {
+            dto.IsTradingSuspended = false;
+            dto.SuspensionReason = null;
+            dto.IsForcedSuspension = false;
+            dto.SuspendedAt = null;
+            dto.ResumedAt = domainEvent.OccurredAt;
+            dto.LastChangedAt = domainEvent.OccurredAt;
+            dto.OpenPositionsAtSuspension = 0;
+            dto.PendingOrdersAtSuspension = 0;
+            dto.ChangedBy = domainEvent.ResumedBy;
+            dto.Details = null;
+        }, cancellationToken);
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cacheLoaded = false;
+            await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task MutateAsync(
+        Action<TradingStateReadModelDto> mutate,
+        CancellationToken cancellationToken)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            mutate(_cache);
+            await PersistCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_cacheLoaded)
+            {
+                await LoadCacheUnlockedAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    private async Task LoadCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_filePath))
+        {
+            _cache = new TradingStateReadModelDto();
+            _cacheLoaded = true;
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            _cache = new TradingStateReadModelDto();
+            _cacheLoaded = true;
+            return;
+        }
+
+        _cache = JsonSerializer.Deserialize<TradingStateReadModelDto>(json, _jsonOptions)
+                 ?? new TradingStateReadModelDto();
+        _cacheLoaded = true;
+    }
+
+    private async Task PersistCacheUnlockedAsync(CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(_cache, _jsonOptions);
+        await File.WriteAllTextAsync(_filePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static TradingStateReadModelEntry MapEntry(TradingStateReadModelDto dto)
+    {
+        return new TradingStateReadModelEntry
+        {
+            IsTradingSuspended = dto.IsTradingSuspended,
+            SuspensionReason = ParseSuspensionReason(dto.SuspensionReason),
+            IsForcedSuspension = dto.IsForcedSuspension,
+            SuspendedAt = dto.SuspendedAt,
+            ResumedAt = dto.ResumedAt,
+            LastChangedAt = dto.LastChangedAt,
+            OpenPositionsAtSuspension = dto.OpenPositionsAtSuspension,
+            PendingOrdersAtSuspension = dto.PendingOrdersAtSuspension,
+            ChangedBy = dto.ChangedBy,
+            Details = dto.Details
+        };
+    }
+
+    private static SuspensionReason? ParseSuspensionReason(string? reason)
+    {
+        return Enum.TryParse<SuspensionReason>(reason, ignoreCase: true, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _fileLock.Dispose();
+        _disposed = true;
+    }
+
+    private sealed class TradingStateReadModelDto
+    {
+        public bool IsTradingSuspended { get; set; }
+        public string? SuspensionReason { get; set; }
+        public bool IsForcedSuspension { get; set; }
+        public DateTimeOffset? SuspendedAt { get; set; }
+        public DateTimeOffset? ResumedAt { get; set; }
+        public DateTimeOffset? LastChangedAt { get; set; }
+        public int OpenPositionsAtSuspension { get; set; }
+        public int PendingOrdersAtSuspension { get; set; }
+        public string? ChangedBy { get; set; }
+        public string? Details { get; set; }
+    }
+}

--- a/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/TradingStateReadModelProjectionHandler.cs
+++ b/IntelliTrader.Infrastructure/Adapters/Persistence/ReadModels/TradingStateReadModelProjectionHandler.cs
@@ -1,0 +1,26 @@
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Domain.Events;
+
+namespace IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+
+public sealed class TradingStateReadModelProjectionHandler :
+    IDomainEventHandler<TradingSuspendedEvent>,
+    IDomainEventHandler<TradingResumedEvent>
+{
+    private readonly ITradingStateReadModelProjectionWriter _projectionWriter;
+
+    public TradingStateReadModelProjectionHandler(ITradingStateReadModelProjectionWriter projectionWriter)
+    {
+        _projectionWriter = projectionWriter ?? throw new ArgumentNullException(nameof(projectionWriter));
+    }
+
+    public Task HandleAsync(TradingSuspendedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+
+    public Task HandleAsync(TradingResumedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        return _projectionWriter.ProjectAsync(domainEvent, cancellationToken);
+    }
+}

--- a/IntelliTrader.Infrastructure/AppModule.cs
+++ b/IntelliTrader.Infrastructure/AppModule.cs
@@ -132,6 +132,13 @@ public class AppModule : Module
             .SingleInstance();
 
         builder.Register(_ =>
+            new JsonTradingStateReadModel(CreateDataFilePath("trading-state-read-model.json")))
+            .As<ITradingStateReadModel>()
+            .As<ITradingStateReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ =>
             new JsonOrderRepository(CreateDataFilePath("orders.json"), _.Resolve<JsonTransactionCoordinator>()))
             .As<IOrderRepository>()
             .AsSelf()

--- a/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioStatusQueryHandlerTests.cs
+++ b/tests/IntelliTrader.Application.Tests/Trading/Handlers/PortfolioStatusQueryHandlerTests.cs
@@ -1,0 +1,295 @@
+using FluentAssertions;
+using IntelliTrader.Application.Common;
+using IntelliTrader.Application.Ports.Driven;
+using IntelliTrader.Application.Trading.Handlers;
+using IntelliTrader.Application.Trading.Queries;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.Trading.Orders;
+using IntelliTrader.Domain.Trading.ValueObjects;
+using Moq;
+using DomainOrderSide = IntelliTrader.Domain.Events.OrderSide;
+using DomainOrderType = IntelliTrader.Domain.Events.OrderType;
+using StatusOrderSide = IntelliTrader.Application.Trading.Queries.OrderSide;
+using StatusOrderStatus = IntelliTrader.Application.Trading.Queries.OrderStatus;
+
+namespace IntelliTrader.Application.Tests.Trading.Handlers;
+
+public sealed class PortfolioStatusQueryHandlerTests
+{
+    private readonly Mock<IPortfolioReadModel> _portfolioReadModelMock = new();
+    private readonly Mock<IPositionReadModel> _positionReadModelMock = new();
+    private readonly Mock<IOrderReadModel> _orderReadModelMock = new();
+    private readonly Mock<ITradingStateReadModel> _tradingStateReadModelMock = new();
+    private readonly Mock<IExchangePort> _exchangePortMock = new();
+
+    [Fact]
+    public async Task HandleAsync_WhenReadModelsHaveState_ReturnsAggregatedPortfolioStatus()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = CreatePortfolioEntry(
+            total: 10000m,
+            available: 8000m,
+            reserved: 2000m,
+            activePositions: 1);
+        var position = CreatePositionEntry(pair, price: 50000m, quantity: 0.04m, fees: 2m);
+        var order = CreateOrderView(pair);
+        var activeBuy = CreateOrderView(
+            TradingPair.Create("ETHUSDT", "USDT"),
+            DomainOrderSide.Buy,
+            OrderLifecycleStatus.Submitted,
+            "active-buy-1");
+        var activeSell = CreateOrderView(
+            pair,
+            DomainOrderSide.Sell,
+            OrderLifecycleStatus.Submitted,
+            "active-sell-1");
+
+        _portfolioReadModelMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { position });
+        _orderReadModelMock
+            .Setup(x => x.GetRecentAsync(
+                null,
+                null,
+                null,
+                25,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { order });
+        _orderReadModelMock
+            .Setup(x => x.GetActiveAsync(
+                null,
+                null,
+                int.MaxValue,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { activeBuy, activeSell });
+        _tradingStateReadModelMock
+            .Setup(x => x.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TradingStateReadModelEntry
+            {
+                IsTradingSuspended = true,
+                SuspensionReason = SuspensionReason.Manual,
+                IsForcedSuspension = true,
+                LastChangedAt = DateTimeOffset.Parse("2026-04-26T10:30:00Z")
+            });
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPricesAsync(
+                It.Is<IEnumerable<TradingPair>>(pairs => pairs.Single() == pair),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyDictionary<TradingPair, Price>>.Success(
+                new Dictionary<TradingPair, Price>
+                {
+                    [pair] = Price.Create(55000m)
+                }));
+
+        var handler = CreateHandler();
+
+        var result = await handler.HandleAsync(new GetPortfolioStatusQuery
+        {
+            IncludeOrderHistory = true,
+            OrderHistoryLimit = 25
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Summary.TotalBalance.Should().Be(10000m);
+        result.Value.Summary.AvailableBalance.Should().Be(8000m);
+        result.Value.Summary.ReservedBalance.Should().Be(2000m);
+        result.Value.Summary.CurrentValue.Should().Be(2200m);
+        result.Value.Summary.UnrealizedPnL.Should().Be(198m);
+        result.Value.Summary.UnrealizedPnLPercent.Should().BeApproximately(9.8901098901m, 0.0000000001m);
+        result.Value.Summary.ActivePositionCount.Should().Be(1);
+        result.Value.Summary.TrailingBuyCount.Should().Be(1);
+        result.Value.Summary.TrailingSellCount.Should().Be(1);
+        result.Value.Summary.IsTradingSuspended.Should().BeTrue();
+        result.Value.Summary.Market.Should().Be("USDT");
+        result.Value.Positions.Should().ContainSingle()
+            .Which.Should().Match<PositionInfo>(info =>
+                info.Pair == "BTCUSDT" &&
+                info.Amount == 0.04m &&
+                info.TotalCost == 2000m &&
+                info.CurrentValue == 2200m &&
+                info.UnrealizedPnL == 198m &&
+                info.DCALevel == 1 &&
+                info.HasTrailingSell);
+        result.Value.TrailingBuys.Should().BeEquivalentTo("ETHUSDT");
+        result.Value.TrailingSells.Should().BeEquivalentTo("BTCUSDT");
+        result.Value.OrderHistory.Should().ContainSingle()
+            .Which.Should().Match<OrderHistoryInfo>(info =>
+                info.OrderId == order.Id.Value &&
+                info.Pair == "BTCUSDT" &&
+                info.Side == StatusOrderSide.Buy &&
+                info.Status == StatusOrderStatus.Filled &&
+                info.AmountFilled == 0.04m);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOptionalSectionsAreDisabled_DoesNotLoadThem()
+    {
+        var portfolio = CreatePortfolioEntry(
+            total: 10000m,
+            available: 10000m,
+            reserved: 0m,
+            activePositions: 0);
+
+        _portfolioReadModelMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PositionReadModelEntry>());
+        _tradingStateReadModelMock
+            .Setup(x => x.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TradingStateReadModelEntry.Running);
+
+        var handler = CreateHandler();
+
+        var result = await handler.HandleAsync(new GetPortfolioStatusQuery
+        {
+            IncludePositions = false,
+            IncludeTrailingOrders = false,
+            IncludeOrderHistory = false
+        });
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Positions.Should().BeNull();
+        result.Value.TrailingBuys.Should().BeNull();
+        result.Value.TrailingSells.Should().BeNull();
+        result.Value.OrderHistory.Should().BeNull();
+        _orderReadModelMock.Verify(
+            x => x.GetRecentAsync(
+                It.IsAny<TradingPair?>(),
+                It.IsAny<OrderLifecycleStatus?>(),
+                It.IsAny<DomainOrderSide?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPortfolioIsMissing_ReturnsNotFound()
+    {
+        _portfolioReadModelMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PortfolioReadModelEntry?)null);
+
+        var handler = CreateHandler();
+
+        var result = await handler.HandleAsync(new GetPortfolioStatusQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPriceLookupFails_ReturnsFailure()
+    {
+        var pair = TradingPair.Create("BTCUSDT", "USDT");
+        var portfolio = CreatePortfolioEntry(
+            total: 10000m,
+            available: 8000m,
+            reserved: 2000m,
+            activePositions: 1);
+
+        _portfolioReadModelMock
+            .Setup(x => x.GetDefaultAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(portfolio);
+        _positionReadModelMock
+            .Setup(x => x.GetActiveAsync("USDT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { CreatePositionEntry(pair, price: 50000m, quantity: 0.04m, fees: 2m) });
+        _tradingStateReadModelMock
+            .Setup(x => x.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TradingStateReadModelEntry.Running);
+        _exchangePortMock
+            .Setup(x => x.GetCurrentPricesAsync(It.IsAny<IEnumerable<TradingPair>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyDictionary<TradingPair, Price>>.Failure(
+                Error.ExchangeError("price unavailable")));
+
+        var handler = CreateHandler();
+
+        var result = await handler.HandleAsync(new GetPortfolioStatusQuery());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Message.Should().Contain("price unavailable");
+    }
+
+    private GetPortfolioStatusHandler CreateHandler()
+    {
+        return new GetPortfolioStatusHandler(
+            _portfolioReadModelMock.Object,
+            _positionReadModelMock.Object,
+            _orderReadModelMock.Object,
+            _tradingStateReadModelMock.Object,
+            _exchangePortMock.Object);
+    }
+
+    private static PortfolioReadModelEntry CreatePortfolioEntry(
+        decimal total,
+        decimal available,
+        decimal reserved,
+        int activePositions)
+    {
+        return new PortfolioReadModelEntry
+        {
+            Id = PortfolioId.Create(),
+            Name = "Default",
+            Market = "USDT",
+            TotalBalance = Money.Create(total, "USDT"),
+            AvailableBalance = Money.Create(available, "USDT"),
+            ReservedBalance = Money.Create(reserved, "USDT"),
+            ActivePositionCount = activePositions,
+            MaxPositions = 5,
+            MinPositionCost = Money.Create(100m, "USDT"),
+            InvestedBalance = Money.Create(reserved, "USDT"),
+            CreatedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z"),
+            IsDefault = true
+        };
+    }
+
+    private static PositionReadModelEntry CreatePositionEntry(
+        TradingPair pair,
+        decimal price,
+        decimal quantity,
+        decimal fees)
+    {
+        return new PositionReadModelEntry
+        {
+            Id = PositionId.Create(),
+            Pair = pair,
+            AveragePrice = Price.Create(price),
+            TotalQuantity = Quantity.Create(quantity),
+            TotalCost = Money.Create(price * quantity, pair.QuoteCurrency),
+            TotalFees = Money.Create(fees, pair.QuoteCurrency),
+            DCALevel = 1,
+            EntryCount = 2,
+            OpenedAt = DateTimeOffset.Parse("2026-04-26T09:00:00Z"),
+            SignalRule = "RSI"
+        };
+    }
+
+    private static OrderView CreateOrderView(
+        TradingPair pair,
+        DomainOrderSide side = DomainOrderSide.Buy,
+        OrderLifecycleStatus status = OrderLifecycleStatus.Filled,
+        string orderId = "order-1")
+    {
+        return new OrderView
+        {
+            Id = OrderId.From(orderId),
+            Pair = pair,
+            Side = side,
+            Type = DomainOrderType.Market,
+            Status = status,
+            RequestedQuantity = Quantity.Create(0.04m),
+            FilledQuantity = Quantity.Create(0.04m),
+            SubmittedPrice = Price.Create(50000m),
+            AveragePrice = Price.Create(50000m),
+            Cost = Money.Create(2000m, pair.QuoteCurrency),
+            Fees = Money.Create(2m, pair.QuoteCurrency),
+            SubmittedAt = DateTimeOffset.Parse("2026-04-26T09:01:00Z"),
+            CanAffectPosition = true,
+            IsTerminal = true
+        };
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/TradingStateReadModelProjectionTests.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Adapters/Persistence/TradingStateReadModelProjectionTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using IntelliTrader.Domain.Events;
+using IntelliTrader.Domain.SharedKernel;
+using IntelliTrader.Infrastructure.Adapters.Persistence.ReadModels;
+using IntelliTrader.Infrastructure.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace IntelliTrader.Infrastructure.Tests.Adapters.Persistence;
+
+public sealed class TradingStateReadModelProjectionTests
+{
+    [Fact]
+    public async Task GetAsync_WhenProjectionIsEmpty_ReturnsRunningState()
+    {
+        var readModelPath = CreateReadModelPath();
+
+        try
+        {
+            using var readModel = new JsonTradingStateReadModel(readModelPath);
+
+            var state = await readModel.GetAsync();
+
+            state.IsTradingSuspended.Should().BeFalse();
+            state.SuspensionReason.Should().BeNull();
+            state.SuspendedAt.Should().BeNull();
+            state.ResumedAt.Should().BeNull();
+        }
+        finally
+        {
+            DeleteFileIfExists(readModelPath);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchManyAsync_WhenSuspendedAndResumed_ProjectsAndPersistsTradingState()
+    {
+        var readModelPath = CreateReadModelPath();
+        using var readModel = new JsonTradingStateReadModel(readModelPath);
+        var handler = new TradingStateReadModelProjectionHandler(readModel);
+        var dispatcher = CreateDispatcher(handler);
+        var suspendedAt = DateTimeOffset.Parse("2026-04-26T10:00:00Z");
+        var resumedAt = DateTimeOffset.Parse("2026-04-26T10:15:00Z");
+        var suspended = new TradingSuspendedEvent(
+            SuspensionReason.Manual,
+            "Manual (Forced)",
+            isForced: true,
+            openPositions: 2,
+            pendingOrders: 1,
+            occurredAt: suspendedAt);
+        var resumed = new TradingResumedEvent(
+            "Manual (Forced)",
+            wasForced: true,
+            suspensionDuration: TimeSpan.FromMinutes(15),
+            previousSuspensionReason: SuspensionReason.Manual,
+            occurredAt: resumedAt);
+
+        try
+        {
+            await dispatcher.DispatchManyAsync([suspended]);
+
+            var suspendedState = await readModel.GetAsync();
+            suspendedState.IsTradingSuspended.Should().BeTrue();
+            suspendedState.SuspensionReason.Should().Be(SuspensionReason.Manual);
+            suspendedState.IsForcedSuspension.Should().BeTrue();
+            suspendedState.SuspendedAt.Should().Be(suspendedAt);
+            suspendedState.OpenPositionsAtSuspension.Should().Be(2);
+            suspendedState.PendingOrdersAtSuspension.Should().Be(1);
+
+            await dispatcher.DispatchManyAsync([resumed]);
+
+            using var reloaded = new JsonTradingStateReadModel(readModelPath);
+            var resumedState = await reloaded.GetAsync();
+            resumedState.IsTradingSuspended.Should().BeFalse();
+            resumedState.SuspensionReason.Should().BeNull();
+            resumedState.IsForcedSuspension.Should().BeFalse();
+            resumedState.SuspendedAt.Should().BeNull();
+            resumedState.ResumedAt.Should().Be(resumedAt);
+            resumedState.LastChangedAt.Should().Be(resumedAt);
+        }
+        finally
+        {
+            DeleteFileIfExists(readModelPath);
+        }
+    }
+
+    private static InMemoryDomainEventDispatcher CreateDispatcher(TradingStateReadModelProjectionHandler handler)
+    {
+        var dispatcher = new InMemoryDomainEventDispatcher(
+            Mock.Of<IServiceProvider>(),
+            NullLogger<InMemoryDomainEventDispatcher>.Instance);
+        dispatcher.RegisterHandler<TradingSuspendedEvent>(handler);
+        dispatcher.RegisterHandler<TradingResumedEvent>(handler);
+        return dispatcher;
+    }
+
+    private static string CreateReadModelPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"trading_state_read_model_{Guid.NewGuid():N}.json");
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
+++ b/tests/IntelliTrader.Infrastructure.Tests/Integration/InfrastructureTestFixture.cs
@@ -73,6 +73,7 @@ public class InfrastructureTestFixture : IDisposable
         var readModelPath = CreateTempFilePath($"{prefix}_order_read_model");
         var portfolioReadModelPath = CreateTempFilePath($"{prefix}_portfolio_read_model");
         var positionReadModelPath = CreateTempFilePath($"{prefix}_position_read_model");
+        var tradingStateReadModelPath = CreateTempFilePath($"{prefix}_trading_state_read_model");
 
         builder.Register(_ => new JsonDomainEventOutbox(outboxPath, transactionCoordinator))
             .As<IDomainEventOutbox>()
@@ -99,6 +100,12 @@ public class InfrastructureTestFixture : IDisposable
         builder.Register(_ => new JsonPositionReadModel(positionReadModelPath))
             .As<IPositionReadModel>()
             .As<IPositionReadModelProjectionWriter>()
+            .AsSelf()
+            .SingleInstance();
+
+        builder.Register(_ => new JsonTradingStateReadModel(tradingStateReadModelPath))
+            .As<ITradingStateReadModel>()
+            .As<ITradingStateReadModelProjectionWriter>()
             .AsSelf()
             .SingleInstance();
     }


### PR DESCRIPTION
## Summary
- Adds a projected `GetPortfolioStatusQuery` handler backed by portfolio, position, order, and trading-state read models.
- Adds a durable trading-state read model projected from `TradingSuspendedEvent` and `TradingResumedEvent`.
- Uses active order projections for read-side trailing buy/sell pair summaries and keeps optional query sections lazy.

## Acceptance Criteria
- Given trading suspend/resume domain events, when they are dispatched, then they update and persist the trading-state projection.
- Given projected portfolio, position, order, and trading state, when portfolio status is queried, then the response is aggregated from read models without using the legacy trading adapter.
- Given optional portfolio status sections are disabled, when the query is handled, then positions, trailing orders, and order history are not loaded or returned.

## Changes
- Added `ITradingStateReadModel` and JSON projection/writer/handler for operational trading state.
- Added `GetPortfolioStatusHandler` to aggregate projected portfolio status and order history.
- Registered the trading-state read model in Autofac and isolated integration fixture wiring.
- Added Application and Infrastructure tests covering RED/GREEN behavior.

## Testing
- `dotnet test tests/IntelliTrader.Application.Tests/IntelliTrader.Application.Tests.csproj --no-restore`
- `dotnet test tests/IntelliTrader.Infrastructure.Tests/IntelliTrader.Infrastructure.Tests.csproj --no-restore`
- `dotnet test IntelliTrader.sln --no-restore`
- `git diff --cached --check`

## Checklist
- [x] Tests pass
- [x] Coverage maintained
- [x] Linter clean via `git diff --cached --check`
- [x] Documentation updated: not applicable, internal CQRS slice
